### PR TITLE
docs: add `skillkit` as a CLI install option with multi-agent sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,30 +40,7 @@ Skills are markdown files that give AI agents specialized knowledge and workflow
 
 ## Installation
 
-### Option 1: SkillKit (Recommended)
-
-Use [skillkit](https://github.com/rohitg00/skillkit) - the universal skills loader for AI coding agents:
-
-```bash
-# Install all skills
-npx skillkit install coreyhaines31/marketingskills
-
-# Install specific skills
-npx skillkit install coreyhaines31/marketingskills --skill page-cro copywriting
-
-# List available skills without installing
-npx skillkit install coreyhaines31/marketingskills --list
-
-# Install to multiple agents at once
-npx skillkit install coreyhaines31/marketingskills --agent cursor --agent claude-code --agent windsurf
-```
-
-**Why SkillKit?**
-- **Multi-agent sync**: Install and sync skills across 17+ AI agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Goose, Amp, and more) with a single command
-- **Auto-detection**: Automatically detects which AI agent you're using
-- **Global or project-level**: Install skills globally (`--global`) or per-project
-
-### Option 2: add-skill
+### Option 1: add-skill
 
 Use [add-skill](https://github.com/vercel-labs/add-skill) to install skills directly:
 
@@ -80,7 +57,7 @@ npx add-skill coreyhaines31/marketingskills --list
 
 This automatically installs to your `.claude/skills/` directory.
 
-### Option 3: Claude Code Plugin
+### Option 2: Claude Code Plugin
 
 Install via Claude Code's built-in plugin system:
 
@@ -92,7 +69,7 @@ Install via Claude Code's built-in plugin system:
 /plugin install marketing-skills
 ```
 
-### Option 4: Clone and Copy
+### Option 3: Clone and Copy
 
 Clone the entire repo and copy the skills folder:
 
@@ -101,7 +78,7 @@ git clone https://github.com/coreyhaines31/marketingskills.git
 cp -r marketingskills/skills/* .claude/skills/
 ```
 
-### Option 5: Git Submodule
+### Option 4: Git Submodule
 
 Add as a submodule for easy updates:
 
@@ -111,11 +88,26 @@ git submodule add https://github.com/coreyhaines31/marketingskills.git .claude/m
 
 Then reference skills from `.claude/marketingskills/skills/`.
 
-### Option 6: Fork and Customize
+### Option 5: Fork and Customize
 
 1. Fork this repository
 2. Customize skills for your specific needs
 3. Clone your fork into your projects
+
+### Option 6: SkillKit
+
+Use [skillkit](https://github.com/rohitg00/skillkit) to install skills across multiple AI agents:
+
+```bash
+# Install all skills
+npx skillkit install coreyhaines31/marketingskills
+
+# Install specific skills
+npx skillkit install coreyhaines31/marketingskills --skill page-cro copywriting
+
+# List available skills without installing
+npx skillkit install coreyhaines31/marketingskills --list
+```
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to recommend using SkillKit as the primary method for installing skills, and reorganizes the order and naming of all installation options for clarity and consistency.

Installation instructions update:

* The recommended installation method is now SkillKit, with detailed usage examples and a "Why SkillKit?" section explaining its benefits.


Addresses https://github.com/coreyhaines31/marketingskills/issues/3