### PR TITLE
Rename Questions to Ask -> Task-Specific Questions

### DIFF
--- a/skills/ab-test-setup/SKILL.md
+++ b/skills/ab-test-setup/SKILL.md
@@ -492,9 +492,8 @@ Next steps based on results
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's your current conversion rate?
 2. How much traffic does this page get?
 3. What change are you considering and why?

--- a/skills/analytics-tracking/SKILL.md
+++ b/skills/analytics-tracking/SKILL.md
@@ -523,9 +523,8 @@ Specific validation steps
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What tools are you using (GA4, Mixpanel, etc.)?
 2. What key actions do you want to track?
 3. What decisions will this data inform?

--- a/skills/competitor-alternatives/SKILL.md
+++ b/skills/competitor-alternatives/SKILL.md
@@ -733,15 +733,12 @@ Recommended pages to create:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
-1. Who are your top 3-5 competitors?
-2. What's your core differentiator?
-3. What are common reasons people switch to you?
-4. Do you have customer quotes about switching?
-5. What's your pricing vs. competitors?
-6. Do you offer migration support?
+1. What are common reasons people switch to you?
+2. Do you have customer quotes about switching?
+3. What's your pricing vs. competitors?
+4. Do you offer migration support?
 
 ---
 

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -336,7 +336,7 @@ Visual or structured representation of how content interconnects.
 
 ---
 
-## Questions to Ask the User
+## Task-Specific Questions
 
 1. What patterns emerge from your last 10 customer conversations?
 2. What questions keep coming up in sales calls?

--- a/skills/copy-editing/SKILL.md
+++ b/skills/copy-editing/SKILL.md
@@ -411,15 +411,12 @@ This iterative process ensures each edit doesn't create new problems while respe
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's the goal of this copy? (Awareness, conversion, retention)
-2. Who's the target audience?
-3. What action should readers take?
-4. What's the brand voice? (Casual, professional, playful, authoritative)
-5. Are there specific concerns or known issues?
-6. What proof/evidence do you have available?
+2. What action should readers take?
+3. Are there specific concerns or known issues?
+4. What proof/evidence do you have available?
 
 ---
 

--- a/skills/email-sequence/SKILL.md
+++ b/skills/email-sequence/SKILL.md
@@ -908,15 +908,13 @@ What to measure and benchmarks
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What triggers entry to this sequence?
 2. What's the primary goal/conversion action?
-3. Who is the audience?
-4. What do they already know about you?
-5. What other emails are they receiving?
-6. What's your current email performance?
+3. What do they already know about you?
+4. What other emails are they receiving?
+5. What's your current email performance?
 
 ---
 

--- a/skills/form-cro/SKILL.md
+++ b/skills/form-cro/SKILL.md
@@ -408,9 +408,8 @@ Ideas to A/B test with expected outcomes
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's your current form completion rate?
 2. Do you have field-level analytics?
 3. What happens with the data after submission?

--- a/skills/free-tool-strategy/SKILL.md
+++ b/skills/free-tool-strategy/SKILL.md
@@ -558,15 +558,12 @@ Detailed launch and ongoing strategy
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
-1. What's your core product/service?
-2. What problems does your audience commonly face?
-3. What existing tools do they use for workarounds?
-4. How do you currently generate leads?
-5. What technical resources are available?
-6. What's the timeline and budget?
+1. What existing tools do they use for workarounds?
+2. How do you currently generate leads?
+3. What technical resources are available?
+4. What's the timeline and budget?
 
 ---
 

--- a/skills/launch-strategy/SKILL.md
+++ b/skills/launch-strategy/SKILL.md
@@ -330,9 +330,8 @@ Even small changelog updates remind customers your product is evolving. This bui
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What are you launching? (New product, major feature, minor update)
 2. What's your current audience size and engagement?
 3. What owned channels do you have? (Email list size, blog traffic, community)

--- a/skills/marketing-ideas/SKILL.md
+++ b/skills/marketing-ideas/SKILL.md
@@ -534,14 +534,12 @@ When suggesting ideas, consider:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
-1. What's your product and who's your target customer?
-2. What's your current stage and main growth goal?
-3. What's your marketing budget and team size?
-4. What have you already tried that worked or didn't?
-5. What are your competitors doing that you admire or want to counter?
+1. What's your current stage and main growth goal?
+2. What's your marketing budget and team size?
+3. What have you already tried that worked or didn't?
+4. What competitor tactics do you admire or want to counter?
 
 ---
 

--- a/skills/marketing-psychology/SKILL.md
+++ b/skills/marketing-psychology/SKILL.md
@@ -434,9 +434,8 @@ When facing a marketing challenge, consider:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What specific behavior are you trying to influence?
 2. What does your customer believe before encountering your marketing?
 3. Where in the journey (awareness → consideration → decision) is this?

--- a/skills/onboarding-cro/SKILL.md
+++ b/skills/onboarding-cro/SKILL.md
@@ -417,9 +417,8 @@ For each issue:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What action most correlates with retention?
 2. What happens immediately after signup?
 3. Where do users currently drop off?

--- a/skills/page-cro/SKILL.md
+++ b/skills/page-cro/SKILL.md
@@ -316,9 +316,8 @@ Content-to-conversion. Focus on:
 
 ---
 
-## Questions to Ask the User
+## Task-Specific Questions
 
-If you need more context, ask:
 
 1. What's your current conversion rate and goal?
 2. Where is traffic coming from?

--- a/skills/paid-ads/SKILL.md
+++ b/skills/paid-ads/SKILL.md
@@ -534,9 +534,8 @@ Always exclude:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What platform(s) are you currently running or want to start with?
 2. What's your monthly ad budget?
 3. What does a successful conversion look like (and what's it worth)?

--- a/skills/paywall-upgrade-cro/SKILL.md
+++ b/skills/paywall-upgrade-cro/SKILL.md
@@ -553,9 +553,8 @@ What to measure and expected benchmarks
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's your current free → paid conversion rate?
 2. What triggers upgrade prompts today?
 3. What features are behind the paywall?

--- a/skills/popup-cro/SKILL.md
+++ b/skills/popup-cro/SKILL.md
@@ -432,9 +432,8 @@ Ideas to A/B test with expected outcomes
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's the primary goal for this popup?
 2. What's your current popup performance (if any)?
 3. What traffic sources are you optimizing for?

--- a/skills/pricing-strategy/SKILL.md
+++ b/skills/pricing-strategy/SKILL.md
@@ -692,9 +692,8 @@ Add "Contact Sales" when:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What pricing research have you done (surveys, competitor analysis)?
 2. What's your current ARPU and conversion rate?
 3. What's your primary value metric (what do customers pay for value)?

--- a/skills/programmatic-seo/SKILL.md
+++ b/skills/programmatic-seo/SKILL.md
@@ -609,9 +609,8 @@ Specific pre-launch checks for this implementation
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What keyword patterns are you targeting?
 2. What data do you have (or can acquire)?
 3. How many pages are you planning to create?

--- a/skills/referral-program/SKILL.md
+++ b/skills/referral-program/SKILL.md
@@ -584,9 +584,8 @@ Typical findings:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What type of program are you building (referral, affiliate, or both)?
 2. What's your customer LTV and current CAC?
 3. Do you have an existing program, or starting from scratch?

--- a/skills/schema-markup/SKILL.md
+++ b/skills/schema-markup/SKILL.md
@@ -581,9 +581,8 @@ Where to add the code and how
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What type of page is this?
 2. What rich results are you hoping to achieve?
 3. What data is available to populate the schema?

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -368,9 +368,8 @@ Same format as above
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What pages/keywords matter most?
 2. Do you have Search Console access?
 3. Any recent changes or migrations?

--- a/skills/signup-flow-cro/SKILL.md
+++ b/skills/signup-flow-cro/SKILL.md
@@ -339,9 +339,8 @@ Organized by:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What's your current signup completion rate?
 2. Do you have field-level analytics on drop-off?
 3. What data is absolutely required before they can use the product?

--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -790,9 +790,8 @@ The formula:
 
 ---
 
-## Questions to Ask
+## Task-Specific Questions
 
-If you need more context:
 1. What platform(s) are you focusing on?
 2. What's your current posting frequency?
 3. Do you have existing content to repurpose?


### PR DESCRIPTION
## Summary

Since product-marketing-context now captures foundational info, renamed and cleaned up the question sections in all skills.

## Changes

- Renamed "Questions to Ask" → "Task-Specific Questions" in all 23 skills
- Removed redundant questions covered by product-marketing-context:
  - competitor-alternatives: removed competitors, differentiator
  - copy-editing: removed audience, brand voice
  - email-sequence: removed audience
  - free-tool-strategy: removed product, audience problems
  - marketing-ideas: removed product, target customer
- Removed "If you need more context:" intro line (redundant with section name)

Generated with [Claude Code](https://claude.com/claude-code)