### PR TITLE
Add SkillKit as installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ Then reference skills from `.claude/marketingskills/skills/`.
 2. Customize skills for your specific needs
 3. Clone your fork into your projects
 
+### Option 6: SkillKit (Multi-Agent)
+
+Use [SkillKit](https://github.com/rohitg00/skillkit) to install skills across multiple AI agents (Claude Code, Cursor, Copilot, etc.):
+
+```bash
+# Install all skills
+npx skillkit install coreyhaines31/marketingskills
+
+# Install specific skills
+npx skillkit install coreyhaines31/marketingskills --skill page-cro copywriting
+
+# List available skills
+npx skillkit install coreyhaines31/marketingskills --list
+```
+
 ## Usage
 
 Once installed, just ask Claude Code to help with marketing tasks:


### PR DESCRIPTION
## Summary

Add SkillKit as Option 6 for installing skills across multiple AI agents.

## Changes

- Add Option 6: SkillKit (Multi-Agent) to README installation section
- SkillKit supports installing skills to Claude Code, Cursor, Copilot, and 13+ other agents

## References

- Closes #3
- Supersedes #4 (cleaner implementation without outdated changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)