### PR TITLE
Add marketing tools registry for agent discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,34 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 - [ ] `SKILL.md` is under 500 lines
 - [ ] No sensitive data or credentials
 
+## Tool Integrations
+
+This repository includes a tools registry for agent-compatible marketing tools.
+
+- **Tool discovery**: Read `tools/REGISTRY.md` to see available tools and their capabilities
+- **Integration details**: See `tools/integrations/{tool}.md` for API endpoints, auth, and common operations
+- **MCP-enabled tools**: ga4, stripe, mailchimp, google-ads, resend, zapier
+
+### Registry Structure
+
+```
+tools/
+├── REGISTRY.md              # Index of all tools with capabilities
+└── integrations/            # Detailed integration guides
+    ├── ga4.md
+    ├── stripe.md
+    ├── rewardful.md
+    └── ...
+```
+
+### When to Use Tools
+
+Skills reference relevant tools for implementation. For example:
+- `referral-program` skill → rewardful, tolt, dub-co, mention-me guides
+- `analytics-tracking` skill → ga4, mixpanel, segment guides
+- `email-sequence` skill → customer-io, mailchimp, resend guides
+- `paid-ads` skill → google-ads, meta-ads, linkedin-ads guides
+
 ## Skill Categories
 
 See `README.md` for the current list of skills organized by category. When adding new skills, follow the naming patterns of existing skills in that category.

--- a/skills/analytics-tracking/SKILL.md
+++ b/skills/analytics-tracking/SKILL.md
@@ -285,6 +285,20 @@ dataLayer.push({
 
 ---
 
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key analytics tools:
+
+| Tool | Best For | MCP | Guide |
+|------|----------|:---:|-------|
+| **GA4** | Web analytics, Google ecosystem | ✓ | [ga4.md](../../tools/integrations/ga4.md) |
+| **Mixpanel** | Product analytics, event tracking | - | [mixpanel.md](../../tools/integrations/mixpanel.md) |
+| **Amplitude** | Product analytics, cohort analysis | - | [amplitude.md](../../tools/integrations/amplitude.md) |
+| **PostHog** | Open-source analytics, session replay | - | [posthog.md](../../tools/integrations/posthog.md) |
+| **Segment** | Customer data platform, routing | - | [segment.md](../../tools/integrations/segment.md) |
+
+---
+
 ## Related Skills
 
 - **ab-test-setup**: For experiment tracking

--- a/skills/email-sequence/SKILL.md
+++ b/skills/email-sequence/SKILL.md
@@ -283,6 +283,20 @@ What to measure and benchmarks
 
 ---
 
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key email tools:
+
+| Tool | Best For | MCP | Guide |
+|------|----------|:---:|-------|
+| **Customer.io** | Behavior-based automation | - | [customer-io.md](../../tools/integrations/customer-io.md) |
+| **Mailchimp** | SMB email marketing | ✓ | [mailchimp.md](../../tools/integrations/mailchimp.md) |
+| **Resend** | Developer-friendly transactional | ✓ | [resend.md](../../tools/integrations/resend.md) |
+| **SendGrid** | Transactional email at scale | - | [sendgrid.md](../../tools/integrations/sendgrid.md) |
+| **Kit** | Creator/newsletter focused | - | [kit.md](../../tools/integrations/kit.md) |
+
+---
+
 ## Related Skills
 
 - **onboarding-cro**: For in-app onboarding (email supports this)

--- a/skills/paid-ads/SKILL.md
+++ b/skills/paid-ads/SKILL.md
@@ -289,6 +289,21 @@ Before launching campaigns, ensure proper tracking and account setup.
 
 ---
 
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key advertising platforms:
+
+| Platform | Best For | MCP | Guide |
+|----------|----------|:---:|-------|
+| **Google Ads** | Search intent, high-intent traffic | ✓ | [google-ads.md](../../tools/integrations/google-ads.md) |
+| **Meta Ads** | Demand gen, visual products, B2C | - | [meta-ads.md](../../tools/integrations/meta-ads.md) |
+| **LinkedIn Ads** | B2B, job title targeting | - | [linkedin-ads.md](../../tools/integrations/linkedin-ads.md) |
+| **TikTok Ads** | Younger demographics, video | - | [tiktok-ads.md](../../tools/integrations/tiktok-ads.md) |
+
+For tracking, see also: [ga4.md](../../tools/integrations/ga4.md), [segment.md](../../tools/integrations/segment.md)
+
+---
+
 ## Related Skills
 
 - **copywriting**: For landing page copy that converts ad traffic

--- a/skills/referral-program/SKILL.md
+++ b/skills/referral-program/SKILL.md
@@ -231,6 +231,20 @@ They get [their reward] too.
 
 ---
 
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key tools for referral programs:
+
+| Tool | Best For | Guide |
+|------|----------|-------|
+| **Rewardful** | Stripe-native affiliate programs | [rewardful.md](../../tools/integrations/rewardful.md) |
+| **Tolt** | SaaS affiliate programs | [tolt.md](../../tools/integrations/tolt.md) |
+| **Mention Me** | Enterprise referral programs | [mention-me.md](../../tools/integrations/mention-me.md) |
+| **Dub.co** | Link tracking and attribution | [dub-co.md](../../tools/integrations/dub-co.md) |
+| **Stripe** | Payment processing (for commission tracking) | [stripe.md](../../tools/integrations/stripe.md) |
+
+---
+
 ## Related Skills
 
 - **launch-strategy**: For launching referral program effectively

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -1,0 +1,194 @@
+# Marketing Tools Registry
+
+Quick reference for AI agents to discover tool capabilities and integration methods.
+
+## How to Use This Registry
+
+1. **Find tools by category** - Browse sections below for tools in each domain
+2. **Check integration methods** - See what APIs, MCPs, CLIs, or SDKs are available
+3. **Read integration guides** - Detailed setup and common operations in `integrations/`
+
+---
+
+## Tool Index
+
+| Tool | Category | API | MCP | CLI | SDK | Guide |
+|------|----------|:---:|:---:|:---:|:---:|-------|
+| ga4 | Analytics | ✓ | ✓ | - | ✓ | [ga4.md](integrations/ga4.md) |
+| mixpanel | Analytics | ✓ | - | - | ✓ | [mixpanel.md](integrations/mixpanel.md) |
+| amplitude | Analytics | ✓ | - | - | ✓ | [amplitude.md](integrations/amplitude.md) |
+| posthog | Analytics | ✓ | - | ✓ | ✓ | [posthog.md](integrations/posthog.md) |
+| segment | Analytics | ✓ | - | - | ✓ | [segment.md](integrations/segment.md) |
+| adobe-analytics | Analytics | ✓ | - | - | ✓ | [adobe-analytics.md](integrations/adobe-analytics.md) |
+| google-search-console | SEO | ✓ | - | - | ✓ | [google-search-console.md](integrations/google-search-console.md) |
+| semrush | SEO | ✓ | - | - | - | [semrush.md](integrations/semrush.md) |
+| ahrefs | SEO | ✓ | - | - | - | [ahrefs.md](integrations/ahrefs.md) |
+| hubspot | CRM | ✓ | - | ✓ | ✓ | [hubspot.md](integrations/hubspot.md) |
+| salesforce | CRM | ✓ | - | ✓ | ✓ | [salesforce.md](integrations/salesforce.md) |
+| stripe | Payments | ✓ | ✓ | ✓ | ✓ | [stripe.md](integrations/stripe.md) |
+| rewardful | Referral | ✓ | - | - | - | [rewardful.md](integrations/rewardful.md) |
+| tolt | Referral | ✓ | - | - | - | [tolt.md](integrations/tolt.md) |
+| dub-co | Links | ✓ | - | - | ✓ | [dub-co.md](integrations/dub-co.md) |
+| mention-me | Referral | ✓ | - | - | - | [mention-me.md](integrations/mention-me.md) |
+| mailchimp | Email | ✓ | ✓ | - | ✓ | [mailchimp.md](integrations/mailchimp.md) |
+| customer-io | Email | ✓ | - | - | ✓ | [customer-io.md](integrations/customer-io.md) |
+| sendgrid | Email | ✓ | - | - | ✓ | [sendgrid.md](integrations/sendgrid.md) |
+| resend | Email | ✓ | ✓ | - | ✓ | [resend.md](integrations/resend.md) |
+| kit | Email | ✓ | - | - | ✓ | [kit.md](integrations/kit.md) |
+| google-ads | Ads | ✓ | ✓ | - | ✓ | [google-ads.md](integrations/google-ads.md) |
+| meta-ads | Ads | ✓ | - | - | ✓ | [meta-ads.md](integrations/meta-ads.md) |
+| linkedin-ads | Ads | ✓ | - | - | - | [linkedin-ads.md](integrations/linkedin-ads.md) |
+| tiktok-ads | Ads | ✓ | - | - | ✓ | [tiktok-ads.md](integrations/tiktok-ads.md) |
+| zapier | Automation | ✓ | ✓ | - | - | [zapier.md](integrations/zapier.md) |
+| shopify | Commerce | ✓ | - | ✓ | ✓ | [shopify.md](integrations/shopify.md) |
+| wordpress | CMS | ✓ | - | ✓ | ✓ | [wordpress.md](integrations/wordpress.md) |
+| webflow | CMS | ✓ | - | ✓ | ✓ | [webflow.md](integrations/webflow.md) |
+
+---
+
+## By Category
+
+### Analytics
+
+Track user behavior, measure conversions, and analyze marketing performance.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **ga4** | Web analytics, Google ecosystem | ✓ |
+| **mixpanel** | Product analytics, event tracking | - |
+| **amplitude** | Product analytics, cohort analysis | - |
+| **posthog** | Open-source analytics, session replay | - |
+| **segment** | Customer data platform, routing | - |
+| **adobe-analytics** | Enterprise analytics | - |
+
+**Agent recommendation**: Start with GA4 if using Google ecosystem. Use Mixpanel or Amplitude for deeper product analytics.
+
+### SEO
+
+Search engine optimization tools for keyword research, rank tracking, and site audits.
+
+| Tool | Best For | Notes |
+|------|----------|-------|
+| **google-search-console** | Free, authoritative search data | Direct from Google |
+| **semrush** | Competitive analysis, keyword research | Comprehensive |
+| **ahrefs** | Backlink analysis, content research | Best for links |
+
+**Agent recommendation**: Google Search Console is essential (free). Add Semrush or Ahrefs for competitive research.
+
+### CRM
+
+Customer relationship management and sales tools.
+
+| Tool | Best For | CLI Available |
+|------|----------|:-------------:|
+| **hubspot** | SMB, marketing + sales alignment | ✓ |
+| **salesforce** | Enterprise, complex sales processes | ✓ |
+
+**Agent recommendation**: HubSpot for startups/SMBs, Salesforce for enterprise.
+
+### Payments
+
+Payment processing and subscription management.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **stripe** | SaaS subscriptions, developer-friendly | ✓ |
+
+**Agent recommendation**: Stripe is the default for SaaS and developer-focused products.
+
+### Referral & Affiliate
+
+Tools for referral programs, affiliate tracking, and partner management.
+
+| Tool | Best For | Stripe Integration |
+|------|----------|:------------------:|
+| **rewardful** | Stripe-native affiliate programs | ✓ |
+| **tolt** | SaaS affiliate programs | ✓ |
+| **mention-me** | Enterprise referral programs | ✓ |
+| **dub-co** | Link tracking, attribution | - |
+
+**Agent recommendation**: Rewardful or Tolt for Stripe-based SaaS. Dub.co for link attribution.
+
+### Email
+
+Email marketing, transactional email, and automation platforms.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **mailchimp** | SMB email marketing | ✓ |
+| **customer-io** | Behavior-based messaging | - |
+| **sendgrid** | Transactional email at scale | - |
+| **resend** | Developer-friendly transactional | ✓ |
+| **kit** | Creator/newsletter focused | - |
+
+**Agent recommendation**: Resend for transactional (dev-friendly). Customer.io for advanced automation. Kit for creators.
+
+### Advertising
+
+Paid advertising platforms and campaign management.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **google-ads** | Search intent, high-intent traffic | ✓ |
+| **meta-ads** | Demand gen, visual products, B2C | - |
+| **linkedin-ads** | B2B, job title targeting | - |
+| **tiktok-ads** | Younger demographics, video | - |
+
+**Agent recommendation**: Google Ads for search intent. Meta for demand generation. LinkedIn for B2B.
+
+### Automation
+
+Workflow automation and integration platforms.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **zapier** | No-code integrations | ✓ |
+
+**Agent recommendation**: Zapier for connecting tools without code.
+
+### Commerce & CMS
+
+E-commerce platforms and content management systems.
+
+| Tool | Best For | CLI Available |
+|------|----------|:-------------:|
+| **shopify** | E-commerce, product sales | ✓ |
+| **wordpress** | Blogs, content sites | ✓ |
+| **webflow** | Design-focused marketing sites | ✓ |
+
+**Agent recommendation**: Shopify for e-commerce. Webflow for marketing sites. WordPress for blogs.
+
+---
+
+## MCP-Enabled Tools
+
+These tools have Model Context Protocol servers available, enabling direct agent interaction:
+
+- **ga4** - Google Analytics 4 data access
+- **stripe** - Payment and subscription management
+- **mailchimp** - Email campaign management
+- **google-ads** - Ad campaign management
+- **resend** - Transactional email sending
+- **zapier** - Workflow automation
+
+To use MCP tools, ensure the appropriate MCP server is configured in your environment.
+
+---
+
+## Quick Start by Use Case
+
+### Setting up analytics tracking
+1. Read [ga4.md](integrations/ga4.md) for web analytics
+2. Read [segment.md](integrations/segment.md) if routing to multiple tools
+
+### Launching a referral program
+1. Read [rewardful.md](integrations/rewardful.md) or [tolt.md](integrations/tolt.md) for Stripe-based programs
+2. Read [dub-co.md](integrations/dub-co.md) for link tracking
+
+### Setting up email automation
+1. Read [customer-io.md](integrations/customer-io.md) for behavior-based automation
+2. Read [resend.md](integrations/resend.md) for transactional email
+
+### Running paid ads
+1. Read [google-ads.md](integrations/google-ads.md) for search campaigns
+2. Read [meta-ads.md](integrations/meta-ads.md) for social campaigns

--- a/tools/integrations/adobe-analytics.md
+++ b/tools/integrations/adobe-analytics.md
@@ -1,0 +1,156 @@
+# Adobe Analytics
+
+Enterprise analytics platform for cross-channel measurement and attribution.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Reporting API 2.0, Data Insertion API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | AppMeasurement.js, Mobile SDKs, Launch |
+
+## Authentication
+
+- **Type**: OAuth 2.0 (Service Account JWT)
+- **Setup**: Create integration in Adobe Developer Console
+- **Header**: `Authorization: Bearer {access_token}`
+
+## Common Agent Operations
+
+### Get report suite info
+
+```bash
+GET https://analytics.adobe.io/api/{company_id}/reportsuites
+
+Authorization: Bearer {access_token}
+x-api-key: {client_id}
+```
+
+### Get dimensions
+
+```bash
+GET https://analytics.adobe.io/api/{company_id}/dimensions?rsid={report_suite_id}
+
+Authorization: Bearer {access_token}
+x-api-key: {client_id}
+```
+
+### Get metrics
+
+```bash
+GET https://analytics.adobe.io/api/{company_id}/metrics?rsid={report_suite_id}
+
+Authorization: Bearer {access_token}
+x-api-key: {client_id}
+```
+
+### Run report
+
+```bash
+POST https://analytics.adobe.io/api/{company_id}/reports
+
+{
+  "rsid": "{report_suite_id}",
+  "globalFilters": [{
+    "type": "dateRange",
+    "dateRange": "2024-01-01T00:00:00/2024-01-31T23:59:59"
+  }],
+  "metricContainer": {
+    "metrics": [
+      {"id": "metrics/visits"},
+      {"id": "metrics/pageviews"},
+      {"id": "metrics/orders"}
+    ]
+  },
+  "dimension": "variables/evar1"
+}
+```
+
+### Get segments
+
+```bash
+GET https://analytics.adobe.io/api/{company_id}/segments?rsid={report_suite_id}
+
+Authorization: Bearer {access_token}
+x-api-key: {client_id}
+```
+
+### Data Insertion (server-side)
+
+```bash
+POST https://{tracking_server}/b/ss/{report_suite_id}/0
+
+<?xml version="1.0" encoding="UTF-8"?>
+<request>
+  <visitorID>user_123</visitorID>
+  <events>event1</events>
+  <eVar1>campaign_name</eVar1>
+  <prop1>page_type</prop1>
+</request>
+```
+
+## AppMeasurement.js
+
+```javascript
+// Initialize
+var s = s_gi('report_suite_id');
+s.trackingServer = 'metrics.example.com';
+
+// Set variables
+s.pageName = 'Home Page';
+s.channel = 'Marketing';
+s.eVar1 = 'campaign_name';
+s.events = 'event1';
+
+// Track page view
+s.t();
+
+// Track link
+s.tl(this, 'o', 'Button Click');
+```
+
+## Key Concepts
+
+- **Report Suite** - Data container
+- **eVars** - Conversion variables (persistent)
+- **props** - Traffic variables (hit-level)
+- **Events** - Success metrics
+- **Segments** - User/visit filters
+- **Calculated Metrics** - Derived metrics
+
+## Common Dimensions
+
+- `variables/page` - Page name
+- `variables/evar1` - Custom conversion variable
+- `variables/prop1` - Custom traffic variable
+- `variables/marketingchannel` - Marketing channel
+- `variables/referringdomain` - Referring domain
+
+## Common Metrics
+
+- `metrics/visits` - Visits
+- `metrics/pageviews` - Page views
+- `metrics/uniquevisitors` - Unique visitors
+- `metrics/orders` - Orders
+- `metrics/revenue` - Revenue
+
+## When to Use
+
+- Enterprise-scale analytics
+- Cross-channel attribution
+- Integration with Adobe Experience Cloud
+- Advanced segmentation
+- Data warehouse exports
+
+## Rate Limits
+
+- 12 requests/second per company
+- 120 requests/minute
+
+## Relevant Skills
+
+- analytics-tracking
+- ab-test-setup
+- paid-ads

--- a/tools/integrations/ahrefs.md
+++ b/tools/integrations/ahrefs.md
@@ -1,0 +1,142 @@
+# Ahrefs
+
+SEO toolset for backlink analysis, keyword research, and competitive research.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for Site Explorer, Keywords Explorer |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | API-only |
+
+## Authentication
+
+- **Type**: API Token
+- **Header**: `Authorization: Bearer {api_token}`
+- **Get token**: Account Settings > API in Ahrefs dashboard
+
+## Common Agent Operations
+
+### Domain rating
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/domain-rating?target=example.com
+
+Authorization: Bearer {api_token}
+```
+
+### Backlinks overview
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/backlinks-stats?target=example.com&mode=domain
+
+Authorization: Bearer {api_token}
+```
+
+### Referring domains
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/refdomains?target=example.com&mode=domain&limit=100
+
+Authorization: Bearer {api_token}
+```
+
+### Backlinks list
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/backlinks?target=example.com&mode=domain&limit=100
+
+Authorization: Bearer {api_token}
+```
+
+### Organic keywords
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/organic-keywords?target=example.com&mode=domain&country=us&limit=100
+
+Authorization: Bearer {api_token}
+```
+
+### Top pages
+
+```bash
+GET https://api.ahrefs.com/v3/site-explorer/top-pages?target=example.com&mode=domain&country=us&limit=50
+
+Authorization: Bearer {api_token}
+```
+
+### Keyword overview
+
+```bash
+GET https://api.ahrefs.com/v3/keywords-explorer/overview?keywords=keyword1,keyword2&country=us
+
+Authorization: Bearer {api_token}
+```
+
+### Keyword suggestions
+
+```bash
+GET https://api.ahrefs.com/v3/keywords-explorer/matching-terms?keyword=seed+keyword&country=us&limit=100
+
+Authorization: Bearer {api_token}
+```
+
+### SERP overview
+
+```bash
+GET https://api.ahrefs.com/v3/keywords-explorer/serp-overview?keyword=target+keyword&country=us
+
+Authorization: Bearer {api_token}
+```
+
+## Key Metrics
+
+### Domain Metrics
+- `domain_rating` - Domain Rating (DR)
+- `ahrefs_rank` - Ahrefs Rank
+- `referring_domains` - Referring domains count
+- `backlinks` - Total backlinks
+- `organic_traffic` - Estimated organic traffic
+
+### Keyword Metrics
+- `volume` - Monthly search volume
+- `keyword_difficulty` - KD score (0-100)
+- `cpc` - Cost per click
+- `clicks` - Estimated monthly clicks
+- `global_volume` - Global search volume
+
+### Backlink Fields
+- `url_from` - Source URL
+- `url_to` - Target URL
+- `anchor` - Anchor text
+- `domain_rating_source` - Source DR
+- `first_seen` - First discovery date
+
+## Modes
+
+- `domain` - Entire domain
+- `subdomains` - Domain + subdomains
+- `prefix` - URL prefix
+- `exact` - Exact URL
+
+## When to Use
+
+- Backlink analysis
+- Link building research
+- Keyword research
+- Competitive analysis
+- Content gap analysis
+- Site audits
+
+## Rate Limits
+
+- Varies by plan
+- 500-5000 rows per request
+
+## Relevant Skills
+
+- seo-audit
+- content-strategy
+- competitor-alternatives

--- a/tools/integrations/amplitude.md
+++ b/tools/integrations/amplitude.md
@@ -1,0 +1,135 @@
+# Amplitude
+
+Product analytics platform for user behavior, retention, and experimentation.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | HTTP API for events, User Profile API, Export API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | JavaScript, iOS, Android, Python, etc. |
+
+## Authentication
+
+- **HTTP API**: API Key (public for events)
+- **Export/Dashboard API**: API Key + Secret Key
+
+## Common Agent Operations
+
+### Track event
+
+```bash
+POST https://api2.amplitude.com/2/httpapi
+
+{
+  "api_key": "{api_key}",
+  "events": [{
+    "user_id": "user_123",
+    "event_type": "signup_completed",
+    "event_properties": {
+      "plan": "pro"
+    },
+    "user_properties": {
+      "email": "user@example.com"
+    }
+  }]
+}
+```
+
+### Batch events
+
+```bash
+POST https://api2.amplitude.com/batch
+
+{
+  "api_key": "{api_key}",
+  "events": [
+    {"user_id": "user_1", "event_type": "pageview"},
+    {"user_id": "user_2", "event_type": "signup"}
+  ]
+}
+```
+
+### Get user activity
+
+```bash
+GET https://amplitude.com/api/2/useractivity?user={user_id}
+
+Authorization: Basic {base64(api_key:secret_key)}
+```
+
+### Export events
+
+```bash
+GET https://amplitude.com/api/2/export?start=20240101T00&end=20240131T23
+
+Authorization: Basic {base64(api_key:secret_key)}
+```
+
+### Get retention data
+
+```bash
+GET https://amplitude.com/api/2/retention?e={"event_type":"signup_completed"}&start=20240101&end=20240131
+
+Authorization: Basic {base64(api_key:secret_key)}
+```
+
+### Query with SQL (Snowflake)
+
+For Amplitude customers with SQL access:
+```sql
+SELECT event_type, COUNT(*) as count
+FROM events
+WHERE event_time > '2024-01-01'
+GROUP BY event_type
+```
+
+## JavaScript SDK
+
+```javascript
+// Initialize
+amplitude.init('API_KEY');
+
+// Identify user
+amplitude.setUserId('user_123');
+
+// Set user properties
+const identify = new amplitude.Identify();
+identify.set('plan', 'pro');
+amplitude.identify(identify);
+
+// Track event
+amplitude.track('Feature Used', {
+  feature_name: 'export'
+});
+```
+
+## Key Concepts
+
+- **Events** - User actions with properties
+- **User Properties** - Persistent user attributes
+- **Cohorts** - Behavioral segments
+- **Funnels** - Multi-step conversion analysis
+- **Retention** - User return patterns
+- **Journeys** - User path analysis
+
+## When to Use
+
+- Tracking product analytics
+- Analyzing user funnels
+- Cohort analysis and retention
+- Experimentation and A/B testing
+- User journey mapping
+
+## Rate Limits
+
+- HTTP API: 1000 events/second
+- Export API: 360 requests/hour
+
+## Relevant Skills
+
+- analytics-tracking
+- ab-test-setup
+- onboarding-cro

--- a/tools/integrations/customer-io.md
+++ b/tools/integrations/customer-io.md
@@ -1,0 +1,187 @@
+# Customer.io
+
+Behavior-based messaging platform for email, push, SMS, and in-app.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Track API, App API, Journeys API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | JavaScript, iOS, Android, Ruby, Python |
+
+## Authentication
+
+- **Track API**: Site ID + API Key (Basic auth)
+- **App API**: Bearer token
+- **Header**: `Authorization: Basic {base64(site_id:api_key)}`
+
+## Common Agent Operations
+
+### Identify customer
+
+```bash
+PUT https://track.customer.io/api/v1/customers/{customer_id}
+
+Authorization: Basic {base64(site_id:api_key)}
+
+{
+  "email": "user@example.com",
+  "created_at": 1705312800,
+  "first_name": "John",
+  "plan": "pro"
+}
+```
+
+### Track event
+
+```bash
+POST https://track.customer.io/api/v1/customers/{customer_id}/events
+
+Authorization: Basic {base64(site_id:api_key)}
+
+{
+  "name": "purchase",
+  "data": {
+    "product": "Pro Plan",
+    "amount": 99
+  }
+}
+```
+
+### Track anonymous event
+
+```bash
+POST https://track.customer.io/api/v1/events
+
+Authorization: Basic {base64(site_id:api_key)}
+
+{
+  "name": "page_viewed",
+  "data": {
+    "page": "/pricing"
+  },
+  "anonymous_id": "anon_123"
+}
+```
+
+### Delete customer
+
+```bash
+DELETE https://track.customer.io/api/v1/customers/{customer_id}
+
+Authorization: Basic {base64(site_id:api_key)}
+```
+
+### Get customer (App API)
+
+```bash
+GET https://api.customer.io/v1/customers/{customer_id}/attributes
+
+Authorization: Bearer {app_api_key}
+```
+
+### List campaigns
+
+```bash
+GET https://api.customer.io/v1/campaigns
+
+Authorization: Bearer {app_api_key}
+```
+
+### Get campaign metrics
+
+```bash
+GET https://api.customer.io/v1/campaigns/{campaign_id}/metrics
+
+Authorization: Bearer {app_api_key}
+```
+
+### Trigger broadcast
+
+```bash
+POST https://api.customer.io/v1/campaigns/{campaign_id}/triggers
+
+Authorization: Bearer {app_api_key}
+
+{
+  "emails": ["user@example.com"],
+  "data": {
+    "coupon_code": "SAVE20"
+  }
+}
+```
+
+### Send transactional email
+
+```bash
+POST https://api.customer.io/v1/send/email
+
+Authorization: Bearer {app_api_key}
+
+{
+  "transactional_message_id": "1",
+  "to": "user@example.com",
+  "identifiers": {
+    "id": "user_123"
+  },
+  "message_data": {
+    "order_id": "ORD-456"
+  }
+}
+```
+
+## JavaScript SDK
+
+```javascript
+// Initialize
+_cio.identify({
+  id: 'user_123',
+  email: 'user@example.com',
+  created_at: 1705312800,
+  plan: 'pro'
+});
+
+// Track event
+_cio.track('purchase', {
+  product: 'Pro Plan',
+  amount: 99
+});
+
+// Track page view
+_cio.page();
+```
+
+## Key Concepts
+
+- **People** - Customers and leads
+- **Segments** - Dynamic groups based on attributes/behavior
+- **Campaigns** - Automated message sequences
+- **Broadcasts** - One-time sends
+- **Transactional** - Triggered messages
+
+## Attribute Types
+
+- Standard: `email`, `created_at`, `unsubscribed`
+- Custom: Any key you define
+- Computed: Aggregations from events
+
+## When to Use
+
+- Behavior-based email automation
+- Multi-channel messaging (email, push, SMS)
+- Onboarding sequences
+- Re-engagement campaigns
+- Transactional messages
+
+## Rate Limits
+
+- Track API: 100 requests/second
+- App API: 10 requests/second
+
+## Relevant Skills
+
+- email-sequence
+- onboarding-cro
+- analytics-tracking

--- a/tools/integrations/dub-co.md
+++ b/tools/integrations/dub-co.md
@@ -1,0 +1,160 @@
+# Dub.co
+
+Link management and attribution platform for modern marketing teams.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for links, analytics, domains |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | TypeScript SDK available |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}`
+- **Get key**: Settings > API Keys in Dub dashboard
+
+## Common Agent Operations
+
+### Create short link
+
+```bash
+POST https://api.dub.co/links
+
+{
+  "url": "https://example.com/landing-page",
+  "domain": "link.example.com",
+  "key": "summer-sale",
+  "tags": ["campaign:summer", "channel:email"]
+}
+```
+
+### Get link by key
+
+```bash
+GET https://api.dub.co/links?domain=link.example.com&key=summer-sale
+```
+
+### List links
+
+```bash
+GET https://api.dub.co/links?domain=link.example.com&page=1
+```
+
+### Get link analytics
+
+```bash
+GET https://api.dub.co/analytics?domain=link.example.com&key=summer-sale&interval=30d
+```
+
+### Get clicks by location
+
+```bash
+GET https://api.dub.co/analytics/country?domain=link.example.com&key=summer-sale
+```
+
+### Get clicks by device
+
+```bash
+GET https://api.dub.co/analytics/device?domain=link.example.com&key=summer-sale
+```
+
+### Update link
+
+```bash
+PATCH https://api.dub.co/links/{link_id}
+
+{
+  "url": "https://example.com/new-landing-page",
+  "tags": ["campaign:summer", "channel:social"]
+}
+```
+
+### Delete link
+
+```bash
+DELETE https://api.dub.co/links/{link_id}
+```
+
+### Bulk create links
+
+```bash
+POST https://api.dub.co/links/bulk
+
+[
+  {"url": "https://example.com/page1", "key": "page1"},
+  {"url": "https://example.com/page2", "key": "page2"}
+]
+```
+
+## TypeScript SDK
+
+### Install
+
+```bash
+npm install dub
+```
+
+### Usage
+
+```typescript
+import { Dub } from "dub";
+
+const dub = new Dub({ token: "YOUR_API_KEY" });
+
+// Create link
+const link = await dub.links.create({
+  url: "https://example.com",
+  domain: "link.example.com"
+});
+
+// Get analytics
+const analytics = await dub.analytics.retrieve({
+  domain: "link.example.com",
+  key: "summer-sale"
+});
+```
+
+## Key Features
+
+- **Custom domains** - Use your own branded domains
+- **Link analytics** - Clicks, locations, devices, referrers
+- **Tags** - Organize links by campaign, channel, etc.
+- **QR codes** - Auto-generated for each link
+- **Password protection** - Secure sensitive links
+- **Expiration** - Time-limited links
+- **Geo-targeting** - Redirect based on location
+
+## Analytics Dimensions
+
+- `clicks` - Total click count
+- `country` - Clicks by country
+- `city` - Clicks by city
+- `device` - Clicks by device type
+- `browser` - Clicks by browser
+- `os` - Clicks by operating system
+- `referer` - Clicks by referrer
+
+## When to Use
+
+- Creating trackable marketing links
+- Building referral link systems
+- Tracking campaign attribution
+- A/B testing landing pages via links
+- Generating branded short URLs
+- Analyzing link performance
+
+## Rate Limits
+
+- Free: 1,000 links, 5 API requests/second
+- Pro: Unlimited links, 50 API requests/second
+- Enterprise: Custom limits
+
+## Relevant Skills
+
+- referral-program
+- analytics-tracking
+- paid-ads

--- a/tools/integrations/ga4.md
+++ b/tools/integrations/ga4.md
@@ -1,0 +1,126 @@
+# Google Analytics 4 (GA4)
+
+Web analytics platform for tracking user behavior, conversions, and marketing performance.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Data API for reports, Admin API for configuration |
+| MCP | ✓ | Available via Google Analytics MCP server |
+| CLI | - | Use gcloud for some operations |
+| SDK | ✓ | gtag.js, Google Analytics SDK for mobile |
+
+## Authentication
+
+- **Type**: OAuth 2.0 or Service Account
+- **Scopes**: `https://www.googleapis.com/auth/analytics.readonly` (read), `https://www.googleapis.com/auth/analytics.edit` (write)
+- **Setup**: Create credentials in Google Cloud Console
+
+## Common Agent Operations
+
+### Run a report (Data API)
+
+```bash
+POST https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runReport
+
+{
+  "dateRanges": [{"startDate": "30daysAgo", "endDate": "today"}],
+  "dimensions": [{"name": "sessionSource"}],
+  "metrics": [{"name": "sessions"}, {"name": "conversions"}]
+}
+```
+
+### Get real-time data
+
+```bash
+POST https://analyticsdata.googleapis.com/v1beta/properties/{property_id}:runRealtimeReport
+
+{
+  "dimensions": [{"name": "country"}],
+  "metrics": [{"name": "activeUsers"}]
+}
+```
+
+### List conversion events
+
+```bash
+GET https://analyticsadmin.googleapis.com/v1beta/properties/{property_id}/conversionEvents
+```
+
+### Create a conversion event
+
+```bash
+POST https://analyticsadmin.googleapis.com/v1beta/properties/{property_id}/conversionEvents
+
+{
+  "eventName": "purchase"
+}
+```
+
+## Client-Side Tracking
+
+### Send custom event (gtag.js)
+
+```javascript
+gtag('event', 'signup_completed', {
+  'method': 'email',
+  'plan': 'free'
+});
+```
+
+### Send event via Measurement Protocol
+
+```bash
+POST https://www.google-analytics.com/mp/collect?measurement_id={measurement_id}&api_secret={api_secret}
+
+{
+  "client_id": "client_123",
+  "events": [{
+    "name": "purchase",
+    "params": {
+      "value": 99.99,
+      "currency": "USD"
+    }
+  }]
+}
+```
+
+## Key Dimensions & Metrics
+
+### Common Dimensions
+- `sessionSource` - Traffic source
+- `sessionMedium` - Traffic medium
+- `sessionCampaignName` - Campaign name
+- `landingPage` - Entry page
+- `deviceCategory` - Device type
+- `country` - User country
+
+### Common Metrics
+- `sessions` - Total sessions
+- `activeUsers` - Active users
+- `newUsers` - New users
+- `conversions` - Conversion events
+- `engagementRate` - Engaged sessions rate
+- `averageSessionDuration` - Session duration
+
+## When to Use
+
+- Tracking website traffic and user behavior
+- Measuring marketing campaign performance
+- Setting up conversion tracking
+- Analyzing user journeys and funnels
+- Attribution modeling
+
+## Rate Limits
+
+- Data API: 10 requests per second per property
+- Admin API: Varies by endpoint
+- Measurement Protocol: 1M hits/day for free tier
+
+## Relevant Skills
+
+- analytics-tracking
+- ab-test-setup
+- seo-audit
+- page-cro

--- a/tools/integrations/google-ads.md
+++ b/tools/integrations/google-ads.md
@@ -1,0 +1,159 @@
+# Google Ads
+
+Pay-per-click advertising platform for search, display, and video campaigns.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Google Ads API for campaign management |
+| MCP | ✓ | Available via Google Ads MCP server |
+| CLI | - | Use gcloud or API scripts |
+| SDK | ✓ | Client libraries for multiple languages |
+
+## Authentication
+
+- **Type**: OAuth 2.0
+- **Scopes**: `https://www.googleapis.com/auth/adwords`
+- **Setup**: Create credentials in Google Cloud Console, link to Google Ads account
+- **Headers**: `developer-token`, `login-customer-id` (for MCC)
+
+## Common Agent Operations
+
+### Get account info
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/googleAds:searchStream
+
+{
+  "query": "SELECT customer.id, customer.descriptive_name FROM customer"
+}
+```
+
+### List campaigns
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/googleAds:searchStream
+
+{
+  "query": "SELECT campaign.id, campaign.name, campaign.status, campaign_budget.amount_micros FROM campaign ORDER BY campaign.id"
+}
+```
+
+### Get campaign performance
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/googleAds:searchStream
+
+{
+  "query": "SELECT campaign.name, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions FROM campaign WHERE segments.date DURING LAST_30_DAYS"
+}
+```
+
+### Get ad group performance
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/googleAds:searchStream
+
+{
+  "query": "SELECT ad_group.name, metrics.impressions, metrics.clicks, metrics.conversions FROM ad_group WHERE segments.date DURING LAST_7_DAYS"
+}
+```
+
+### Get keyword performance
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/googleAds:searchStream
+
+{
+  "query": "SELECT ad_group_criterion.keyword.text, metrics.impressions, metrics.clicks, metrics.average_cpc FROM keyword_view WHERE segments.date DURING LAST_30_DAYS ORDER BY metrics.clicks DESC LIMIT 50"
+}
+```
+
+### Pause campaign
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/campaigns:mutate
+
+{
+  "operations": [{
+    "update": {
+      "resourceName": "customers/{customer_id}/campaigns/{campaign_id}",
+      "status": "PAUSED"
+    },
+    "updateMask": "status"
+  }]
+}
+```
+
+### Update budget
+
+```bash
+POST https://googleads.googleapis.com/v14/customers/{customer_id}/campaignBudgets:mutate
+
+{
+  "operations": [{
+    "update": {
+      "resourceName": "customers/{customer_id}/campaignBudgets/{budget_id}",
+      "amountMicros": "50000000"
+    },
+    "updateMask": "amountMicros"
+  }]
+}
+```
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `metrics.impressions` | Ad impressions |
+| `metrics.clicks` | Clicks |
+| `metrics.cost_micros` | Cost in micros (divide by 1M) |
+| `metrics.conversions` | Conversions |
+| `metrics.conversions_value` | Conversion value |
+| `metrics.average_cpc` | Average cost per click |
+| `metrics.ctr` | Click-through rate |
+| `metrics.conversion_rate` | Conversion rate |
+
+## Campaign Types
+
+- `SEARCH` - Search network text ads
+- `DISPLAY` - Display network
+- `SHOPPING` - Product shopping ads
+- `VIDEO` - YouTube video ads
+- `PERFORMANCE_MAX` - AI-optimized across channels
+- `DEMAND_GEN` - Discovery/Demand Gen
+
+## GAQL (Google Ads Query Language)
+
+```sql
+SELECT
+  campaign.name,
+  metrics.clicks,
+  metrics.conversions
+FROM campaign
+WHERE
+  campaign.status = 'ENABLED'
+  AND segments.date DURING LAST_30_DAYS
+ORDER BY metrics.conversions DESC
+LIMIT 10
+```
+
+## When to Use
+
+- Managing search advertising campaigns
+- Analyzing campaign performance
+- Adjusting budgets and bids
+- Keyword research and management
+- Conversion tracking analysis
+
+## Rate Limits
+
+- 15,000 operations per day (basic)
+- Higher limits with developer token levels
+
+## Relevant Skills
+
+- paid-ads
+- analytics-tracking
+- page-cro

--- a/tools/integrations/google-search-console.md
+++ b/tools/integrations/google-search-console.md
@@ -1,0 +1,147 @@
+# Google Search Console
+
+Free tool for monitoring website search performance and indexing.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Search Analytics API, URL Inspection API |
+| MCP | - | Not available |
+| CLI | - | Use gcloud or API scripts |
+| SDK | ✓ | Google API client libraries |
+
+## Authentication
+
+- **Type**: OAuth 2.0 or Service Account
+- **Scopes**: `https://www.googleapis.com/auth/webmasters.readonly`
+- **Setup**: Create credentials in Google Cloud Console
+
+## Common Agent Operations
+
+### Get search analytics
+
+```bash
+POST https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query
+
+{
+  "startDate": "2024-01-01",
+  "endDate": "2024-01-31",
+  "dimensions": ["query"],
+  "rowLimit": 100
+}
+```
+
+### Get performance by page
+
+```bash
+POST https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query
+
+{
+  "startDate": "2024-01-01",
+  "endDate": "2024-01-31",
+  "dimensions": ["page"],
+  "rowLimit": 50
+}
+```
+
+### Get performance by country
+
+```bash
+POST https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/searchAnalytics/query
+
+{
+  "startDate": "2024-01-01",
+  "endDate": "2024-01-31",
+  "dimensions": ["country", "query"],
+  "rowLimit": 100
+}
+```
+
+### Inspect URL
+
+```bash
+POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect
+
+{
+  "inspectionUrl": "https://example.com/page",
+  "siteUrl": "https://example.com/"
+}
+```
+
+### List sitemaps
+
+```bash
+GET https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps
+
+Authorization: Bearer {access_token}
+```
+
+### Submit sitemap
+
+```bash
+PUT https://searchconsole.googleapis.com/webmasters/v3/sites/{site_url}/sitemaps/{sitemap_url}
+
+Authorization: Bearer {access_token}
+```
+
+### Request indexing
+
+```bash
+POST https://indexing.googleapis.com/v3/urlNotifications:publish
+
+{
+  "url": "https://example.com/new-page",
+  "type": "URL_UPDATED"
+}
+```
+
+## Dimensions
+
+- `query` - Search query
+- `page` - Page URL
+- `country` - Country code
+- `device` - Device type (MOBILE, DESKTOP, TABLET)
+- `date` - Date
+- `searchAppearance` - Search result type
+
+## Metrics
+
+- `clicks` - Clicks from search
+- `impressions` - Search impressions
+- `ctr` - Click-through rate
+- `position` - Average position
+
+## Filters
+
+```json
+{
+  "dimensionFilterGroups": [{
+    "filters": [{
+      "dimension": "query",
+      "operator": "contains",
+      "expression": "keyword"
+    }]
+  }]
+}
+```
+
+## When to Use
+
+- Analyzing search performance
+- Finding keyword opportunities
+- Monitoring indexing status
+- Submitting new pages for indexing
+- Identifying crawl issues
+- Tracking position changes
+
+## Rate Limits
+
+- 200 queries per minute
+- 1,200 requests per minute
+
+## Relevant Skills
+
+- seo-audit
+- programmatic-seo
+- analytics-tracking

--- a/tools/integrations/hubspot.md
+++ b/tools/integrations/hubspot.md
@@ -1,0 +1,178 @@
+# HubSpot
+
+CRM platform for marketing, sales, and customer service.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for CRM, Marketing, Sales |
+| MCP | - | Not available |
+| CLI | ✓ | `hs` CLI for local development |
+| SDK | ✓ | Official client libraries |
+
+## Authentication
+
+- **Type**: Private App Token or OAuth 2.0
+- **Header**: `Authorization: Bearer {access_token}`
+- **Get token**: Settings > Integrations > Private Apps
+
+## Common Agent Operations
+
+### Get contacts
+
+```bash
+GET https://api.hubapi.com/crm/v3/objects/contacts?limit=10
+
+Authorization: Bearer {access_token}
+```
+
+### Search contacts
+
+```bash
+POST https://api.hubapi.com/crm/v3/objects/contacts/search
+
+{
+  "filterGroups": [{
+    "filters": [{
+      "propertyName": "email",
+      "operator": "EQ",
+      "value": "user@example.com"
+    }]
+  }]
+}
+```
+
+### Create contact
+
+```bash
+POST https://api.hubapi.com/crm/v3/objects/contacts
+
+{
+  "properties": {
+    "email": "user@example.com",
+    "firstname": "John",
+    "lastname": "Doe",
+    "company": "Example Inc"
+  }
+}
+```
+
+### Update contact
+
+```bash
+PATCH https://api.hubapi.com/crm/v3/objects/contacts/{contact_id}
+
+{
+  "properties": {
+    "lifecyclestage": "customer"
+  }
+}
+```
+
+### Get deals
+
+```bash
+GET https://api.hubapi.com/crm/v3/objects/deals?limit=10&properties=dealname,amount,dealstage
+
+Authorization: Bearer {access_token}
+```
+
+### Create deal
+
+```bash
+POST https://api.hubapi.com/crm/v3/objects/deals
+
+{
+  "properties": {
+    "dealname": "New Deal",
+    "amount": "10000",
+    "dealstage": "appointmentscheduled",
+    "pipeline": "default"
+  }
+}
+```
+
+### Associate contact with deal
+
+```bash
+PUT https://api.hubapi.com/crm/v3/objects/deals/{deal_id}/associations/contacts/{contact_id}/deal_to_contact
+```
+
+### Get form submissions
+
+```bash
+GET https://api.hubapi.com/form-integrations/v1/submissions/forms/{form_guid}
+
+Authorization: Bearer {access_token}
+```
+
+### Get marketing emails
+
+```bash
+GET https://api.hubapi.com/marketing/v3/emails?limit=10
+
+Authorization: Bearer {access_token}
+```
+
+## CLI Commands
+
+```bash
+# Install
+npm install -g @hubspot/cli
+
+# Initialize project
+hs init
+
+# Upload files
+hs upload src dest
+
+# Watch for changes
+hs watch src dest
+
+# List portals
+hs accounts list
+```
+
+## Key Objects
+
+- **Contacts** - People in CRM
+- **Companies** - Organizations
+- **Deals** - Sales opportunities
+- **Tickets** - Support tickets
+- **Products** - Items for sale
+- **Line Items** - Deal line items
+
+## Common Properties
+
+### Contact Properties
+- `email` - Email address
+- `firstname`, `lastname` - Name
+- `lifecyclestage` - Funnel stage
+- `hs_lead_status` - Lead status
+
+### Deal Properties
+- `dealname` - Deal name
+- `amount` - Deal value
+- `dealstage` - Pipeline stage
+- `closedate` - Expected close
+
+## When to Use
+
+- Managing contacts and leads
+- Tracking sales deals
+- Marketing automation
+- Form submissions
+- Email campaigns
+- Customer service tickets
+
+## Rate Limits
+
+- 100 requests per 10 seconds
+- Higher limits on enterprise plans
+
+## Relevant Skills
+
+- email-sequence
+- analytics-tracking
+- referral-program

--- a/tools/integrations/kit.md
+++ b/tools/integrations/kit.md
@@ -1,0 +1,167 @@
+# Kit (formerly ConvertKit)
+
+Email marketing platform for creators and newsletter businesses.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for subscribers, forms, sequences |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | JavaScript, Ruby gems available |
+
+## Authentication
+
+- **Type**: API Key or API Secret
+- **Parameter**: `api_key={key}` or `api_secret={secret}` in query/body
+- **Get key**: Settings > Advanced in Kit dashboard
+
+## Common Agent Operations
+
+### List subscribers
+
+```bash
+GET https://api.convertkit.com/v3/subscribers?api_secret={api_secret}&page=1
+
+```
+
+### Get subscriber
+
+```bash
+GET https://api.convertkit.com/v3/subscribers/{subscriber_id}?api_secret={api_secret}
+```
+
+### Add subscriber to form
+
+```bash
+POST https://api.convertkit.com/v3/forms/{form_id}/subscribe
+
+{
+  "api_key": "{api_key}",
+  "email": "user@example.com",
+  "first_name": "John",
+  "fields": {
+    "company": "Example Inc"
+  }
+}
+```
+
+### Add subscriber to sequence
+
+```bash
+POST https://api.convertkit.com/v3/sequences/{sequence_id}/subscribe
+
+{
+  "api_key": "{api_key}",
+  "email": "user@example.com"
+}
+```
+
+### Tag subscriber
+
+```bash
+POST https://api.convertkit.com/v3/tags/{tag_id}/subscribe
+
+{
+  "api_key": "{api_key}",
+  "email": "user@example.com"
+}
+```
+
+### Remove tag from subscriber
+
+```bash
+DELETE https://api.convertkit.com/v3/subscribers/{subscriber_id}/tags/{tag_id}?api_secret={api_secret}
+```
+
+### Update subscriber
+
+```bash
+PUT https://api.convertkit.com/v3/subscribers/{subscriber_id}
+
+{
+  "api_secret": "{api_secret}",
+  "first_name": "Jane",
+  "fields": {
+    "plan": "pro"
+  }
+}
+```
+
+### Unsubscribe
+
+```bash
+PUT https://api.convertkit.com/v3/unsubscribe
+
+{
+  "api_secret": "{api_secret}",
+  "email": "user@example.com"
+}
+```
+
+### List forms
+
+```bash
+GET https://api.convertkit.com/v3/forms?api_key={api_key}
+```
+
+### List sequences
+
+```bash
+GET https://api.convertkit.com/v3/sequences?api_key={api_key}
+```
+
+### List tags
+
+```bash
+GET https://api.convertkit.com/v3/tags?api_key={api_key}
+```
+
+### Create broadcast
+
+```bash
+POST https://api.convertkit.com/v3/broadcasts
+
+{
+  "api_secret": "{api_secret}",
+  "subject": "Newsletter Subject",
+  "content": "<p>Email content here</p>",
+  "email_layout_template": "default"
+}
+```
+
+## Key Concepts
+
+- **Subscribers** - Email contacts
+- **Forms** - Signup forms
+- **Sequences** - Automated email series
+- **Tags** - Subscriber labels
+- **Broadcasts** - One-time sends
+- **Custom Fields** - Subscriber attributes
+
+## Subscriber States
+
+- `active` - Can receive emails
+- `unsubscribed` - Opted out
+- `bounced` - Email bounced
+- `complained` - Marked as spam
+- `inactive` - Cold subscriber
+
+## When to Use
+
+- Creator/newsletter businesses
+- Simple email automation
+- Form-based list building
+- Tagging and segmentation
+- Course email sequences
+
+## Rate Limits
+
+- 120 requests per minute
+- Batch endpoints available
+
+## Relevant Skills
+
+- email-sequence
+- content-strategy

--- a/tools/integrations/linkedin-ads.md
+++ b/tools/integrations/linkedin-ads.md
@@ -1,0 +1,164 @@
+# LinkedIn Ads
+
+B2B advertising platform with professional targeting.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Marketing API for campaigns, audiences, analytics |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | API-only (community libraries available) |
+
+## Authentication
+
+- **Type**: OAuth 2.0
+- **Header**: `Authorization: Bearer {access_token}`
+- **Scopes**: `r_ads`, `r_ads_reporting`, `rw_ads`
+
+## Common Agent Operations
+
+### Get ad accounts
+
+```bash
+GET https://api.linkedin.com/v2/adAccountsV2?q=search
+
+Authorization: Bearer {access_token}
+```
+
+### Get campaigns
+
+```bash
+GET https://api.linkedin.com/v2/adCampaignsV2?q=search&search.account.values[0]=urn:li:sponsoredAccount:{account_id}
+
+Authorization: Bearer {access_token}
+```
+
+### Get campaign analytics
+
+```bash
+GET https://api.linkedin.com/v2/adAnalyticsV2?q=analytics&pivot=CAMPAIGN&dateRange.start.year=2024&dateRange.start.month=1&dateRange.start.day=1&dateRange.end.year=2024&dateRange.end.month=1&dateRange.end.day=31&campaigns=urn:li:sponsoredCampaign:{campaign_id}&fields=impressions,clicks,costInLocalCurrency,conversions
+
+Authorization: Bearer {access_token}
+```
+
+### Create campaign
+
+```bash
+POST https://api.linkedin.com/v2/adCampaignsV2
+
+Authorization: Bearer {access_token}
+
+{
+  "account": "urn:li:sponsoredAccount:{account_id}",
+  "name": "Campaign Name",
+  "type": "SPONSORED_UPDATES",
+  "costType": "CPC",
+  "unitCost": {
+    "amount": "5.00",
+    "currencyCode": "USD"
+  },
+  "dailyBudget": {
+    "amount": "100.00",
+    "currencyCode": "USD"
+  },
+  "status": "PAUSED"
+}
+```
+
+### Update campaign status
+
+```bash
+POST https://api.linkedin.com/v2/adCampaignsV2/{campaign_id}
+
+Authorization: Bearer {access_token}
+
+{
+  "patch": {
+    "$set": {
+      "status": "ACTIVE"
+    }
+  }
+}
+```
+
+### Get creatives
+
+```bash
+GET https://api.linkedin.com/v2/adCreativesV2?q=search&search.campaign.values[0]=urn:li:sponsoredCampaign:{campaign_id}
+
+Authorization: Bearer {access_token}
+```
+
+### Get audience counts
+
+```bash
+POST https://api.linkedin.com/v2/audienceCountsV2
+
+{
+  "audienceCriteria": {
+    "include": {
+      "and": [{
+        "or": {
+          "urn:li:adTargetingFacet:titles": ["urn:li:title:123"]
+        }
+      }]
+    }
+  }
+}
+```
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `impressions` | Ad impressions |
+| `clicks` | Total clicks |
+| `costInLocalCurrency` | Spend |
+| `conversions` | Conversion count |
+| `leadGenerationMailContactInfoShares` | Lead form submissions |
+
+## Campaign Types
+
+- `SPONSORED_UPDATES` - Sponsored content
+- `TEXT_AD` - Text ads
+- `SPONSORED_INMAILS` - Message ads
+- `DYNAMIC` - Dynamic ads
+
+## Targeting Options
+
+### Job-Based
+- Job titles
+- Job functions
+- Seniority levels
+- Years of experience
+
+### Company-Based
+- Company names
+- Industries
+- Company size
+- Company followers
+
+### Professional
+- Skills
+- Groups
+- Schools
+- Degrees
+
+## When to Use
+
+- B2B advertising
+- Job title targeting
+- Account-based marketing
+- Lead generation campaigns
+
+## Rate Limits
+
+- 100 requests/day (basic)
+- 10,000 requests/day (Marketing Developer Platform)
+
+## Relevant Skills
+
+- paid-ads
+- analytics-tracking

--- a/tools/integrations/mailchimp.md
+++ b/tools/integrations/mailchimp.md
@@ -1,0 +1,150 @@
+# Mailchimp
+
+Email marketing platform for campaigns, automation, and audience management.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Marketing API for campaigns, audiences, automation |
+| MCP | ✓ | Available via Mailchimp MCP server |
+| CLI | - | Not available |
+| SDK | ✓ | Official SDKs for multiple languages |
+
+## Authentication
+
+- **Type**: API Key or OAuth 2.0
+- **Header**: `Authorization: Bearer {api_key}` or `Authorization: apikey {api_key}`
+- **Base URL**: `https://{dc}.api.mailchimp.com/3.0/` (dc = datacenter from API key)
+
+## Common Agent Operations
+
+### List audiences (lists)
+
+```bash
+GET https://{dc}.api.mailchimp.com/3.0/lists
+```
+
+### Get audience members
+
+```bash
+GET https://{dc}.api.mailchimp.com/3.0/lists/{list_id}/members?count=100
+```
+
+### Add subscriber
+
+```bash
+POST https://{dc}.api.mailchimp.com/3.0/lists/{list_id}/members
+
+{
+  "email_address": "user@example.com",
+  "status": "subscribed",
+  "merge_fields": {
+    "FNAME": "John",
+    "LNAME": "Doe"
+  }
+}
+```
+
+### Update subscriber
+
+```bash
+PATCH https://{dc}.api.mailchimp.com/3.0/lists/{list_id}/members/{subscriber_hash}
+
+{
+  "merge_fields": {
+    "FNAME": "Jane"
+  },
+  "tags": ["customer", "premium"]
+}
+```
+
+### Get campaigns
+
+```bash
+GET https://{dc}.api.mailchimp.com/3.0/campaigns?count=20
+```
+
+### Get campaign report
+
+```bash
+GET https://{dc}.api.mailchimp.com/3.0/reports/{campaign_id}
+```
+
+### Create campaign
+
+```bash
+POST https://{dc}.api.mailchimp.com/3.0/campaigns
+
+{
+  "type": "regular",
+  "recipients": {
+    "list_id": "{list_id}"
+  },
+  "settings": {
+    "subject_line": "Your Subject",
+    "from_name": "Your Name",
+    "reply_to": "reply@example.com"
+  }
+}
+```
+
+### Send campaign
+
+```bash
+POST https://{dc}.api.mailchimp.com/3.0/campaigns/{campaign_id}/actions/send
+```
+
+### List automations
+
+```bash
+GET https://{dc}.api.mailchimp.com/3.0/automations
+```
+
+## Key Metrics
+
+### Campaign Report Fields
+- `emails_sent` - Total sent
+- `opens` - Open count
+- `unique_opens` - Unique opens
+- `open_rate` - Open rate
+- `clicks` - Click count
+- `click_rate` - Click rate
+- `unsubscribes` - Unsubscribe count
+- `bounces` - Bounce count
+
+### Subscriber Hash
+
+Calculate subscriber hash for updates:
+```javascript
+const hash = md5(email.toLowerCase());
+```
+
+## Subscriber Statuses
+
+- `subscribed` - Active subscriber
+- `unsubscribed` - Unsubscribed
+- `cleaned` - Hard bounce
+- `pending` - Awaiting confirmation
+- `transactional` - Transactional only
+
+## When to Use
+
+- Managing email lists and subscribers
+- Creating and sending email campaigns
+- Setting up email automation
+- Analyzing campaign performance
+- Segmenting audiences
+- A/B testing emails
+
+## Rate Limits
+
+- 10 concurrent connections
+- 10 requests per second
+- Batch endpoints for bulk operations
+
+## Relevant Skills
+
+- email-sequence
+- analytics-tracking
+- referral-program

--- a/tools/integrations/mention-me.md
+++ b/tools/integrations/mention-me.md
@@ -1,0 +1,160 @@
+# Mention Me
+
+Enterprise referral marketing platform for customer advocacy.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for referrals, customers, rewards |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | JavaScript widget for embedding |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}`
+- **Environment**: Separate keys for sandbox and production
+
+## Common Agent Operations
+
+### Create referral offer
+
+```bash
+POST https://api.mention-me.com/api/v2/referrer-offer
+
+{
+  "email": "customer@example.com",
+  "firstname": "John",
+  "lastname": "Doe",
+  "order_number": "ORD-123",
+  "order_total": 99.99,
+  "order_currency": "USD"
+}
+```
+
+### Get referral link for customer
+
+```bash
+GET https://api.mention-me.com/api/v2/referrer/{customer_id}/share-links
+```
+
+### Record referee (referred customer)
+
+```bash
+POST https://api.mention-me.com/api/v2/referee
+
+{
+  "email": "referred@example.com",
+  "firstname": "Jane",
+  "referrer_code": "JOHN123",
+  "order_number": "ORD-456",
+  "order_total": 149.99
+}
+```
+
+### Get referral status
+
+```bash
+GET https://api.mention-me.com/api/v2/referral/{referral_id}
+```
+
+### List referrals for customer
+
+```bash
+GET https://api.mention-me.com/api/v2/referrer/{customer_id}/referrals
+```
+
+### Get reward balance
+
+```bash
+GET https://api.mention-me.com/api/v2/referrer/{customer_id}/rewards
+```
+
+### Redeem reward
+
+```bash
+POST https://api.mention-me.com/api/v2/referrer/{customer_id}/rewards/redeem
+
+{
+  "reward_id": "RWD-123",
+  "order_number": "ORD-789"
+}
+```
+
+## JavaScript Widget
+
+### Embed referral widget
+
+```html
+<div id="mmWrapper"></div>
+<script>
+  window.MentionMe = window.MentionMe || [];
+  MentionMe.push({
+    type: 'offer',
+    customer: {
+      email: 'customer@example.com',
+      firstname: 'John',
+      order_number: 'ORD-123'
+    }
+  });
+</script>
+<script src="https://tag.mention-me.com/client/{partner_code}.js" async></script>
+```
+
+### Name share widget
+
+```javascript
+MentionMe.push({
+  type: 'nameShare',
+  customer: {
+    email: 'customer@example.com'
+  }
+});
+```
+
+## Webhook Events
+
+| Event | When |
+|-------|------|
+| `referral.created` | New referral tracked |
+| `referral.converted` | Referral completed purchase |
+| `reward.earned` | Reward unlocked |
+| `reward.redeemed` | Reward used |
+
+## Key Features
+
+- **A/B testing** - Built-in experiment framework
+- **Fraud prevention** - Automatic fraud detection
+- **Multi-channel** - Share via link, email, social
+- **Name sharing** - Refer by name, not code
+- **Segmentation** - Different offers by segment
+- **Analytics** - Referral program reporting
+
+## Key Objects
+
+- **Referrer** - Customer who refers
+- **Referee** - Customer who is referred
+- **Referral** - Connection between referrer and referee
+- **Offer** - Referral program configuration
+- **Reward** - Incentive earned
+
+## When to Use
+
+- Enterprise referral programs
+- Multi-market referral campaigns
+- A/B testing referral offers
+- Fraud-resistant referral tracking
+- Name-based sharing programs
+
+## Rate Limits
+
+- 1000 requests per minute
+- Contact for higher limits
+
+## Relevant Skills
+
+- referral-program
+- pricing-strategy
+- analytics-tracking

--- a/tools/integrations/meta-ads.md
+++ b/tools/integrations/meta-ads.md
@@ -1,0 +1,147 @@
+# Meta Ads (Facebook/Instagram)
+
+Advertising platform for Facebook, Instagram, Messenger, and Audience Network.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Marketing API for campaigns, audiences, reporting |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | Official SDKs for Python, PHP, Node.js |
+
+## Authentication
+
+- **Type**: OAuth 2.0 Access Token
+- **Header**: Access token as query parameter
+- **Setup**: Create app in Meta Business Suite, generate System User token
+
+## Common Agent Operations
+
+### Get ad accounts
+
+```bash
+GET https://graph.facebook.com/v18.0/me/adaccounts?access_token={access_token}&fields=id,name,account_status
+```
+
+### Get campaigns
+
+```bash
+GET https://graph.facebook.com/v18.0/act_{ad_account_id}/campaigns?access_token={access_token}&fields=id,name,status,objective,daily_budget
+```
+
+### Get campaign insights
+
+```bash
+GET https://graph.facebook.com/v18.0/{campaign_id}/insights?access_token={access_token}&fields=impressions,clicks,spend,actions,cost_per_action_type&date_preset=last_30d
+```
+
+### Get ad sets
+
+```bash
+GET https://graph.facebook.com/v18.0/act_{ad_account_id}/adsets?access_token={access_token}&fields=id,name,status,targeting,daily_budget,bid_amount
+```
+
+### Get ads
+
+```bash
+GET https://graph.facebook.com/v18.0/{ad_set_id}/ads?access_token={access_token}&fields=id,name,status,creative
+```
+
+### Create campaign
+
+```bash
+POST https://graph.facebook.com/v18.0/act_{ad_account_id}/campaigns
+
+access_token={access_token}
+&name=Campaign Name
+&objective=CONVERSIONS
+&status=PAUSED
+&special_ad_categories=[]
+```
+
+### Update campaign status
+
+```bash
+POST https://graph.facebook.com/v18.0/{campaign_id}
+
+access_token={access_token}
+&status=ACTIVE
+```
+
+### Get custom audiences
+
+```bash
+GET https://graph.facebook.com/v18.0/act_{ad_account_id}/customaudiences?access_token={access_token}&fields=id,name,approximate_count
+```
+
+### Create lookalike audience
+
+```bash
+POST https://graph.facebook.com/v18.0/act_{ad_account_id}/customaudiences
+
+access_token={access_token}
+&name=Lookalike - Top Customers
+&subtype=LOOKALIKE
+&origin_audience_id={source_audience_id}
+&lookalike_spec={"type":"similarity","country":"US"}
+```
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `impressions` | Ad impressions |
+| `clicks` | All clicks |
+| `spend` | Amount spent |
+| `reach` | Unique people reached |
+| `frequency` | Avg impressions per person |
+| `cpm` | Cost per 1000 impressions |
+| `cpc` | Cost per click |
+| `actions` | Conversions array |
+| `cost_per_action_type` | CPA by action |
+
+## Campaign Objectives
+
+- `AWARENESS` - Brand awareness
+- `TRAFFIC` - Website traffic
+- `ENGAGEMENT` - Post engagement
+- `LEADS` - Lead generation
+- `APP_PROMOTION` - App installs
+- `SALES` - Conversions/catalog sales
+
+## Targeting Options
+
+```json
+{
+  "geo_locations": {
+    "countries": ["US"],
+    "cities": [{"key": "2420379"}]
+  },
+  "age_min": 25,
+  "age_max": 45,
+  "genders": [1, 2],
+  "interests": [{"id": "6003139266461", "name": "Marketing"}],
+  "behaviors": [{"id": "6002714895372"}]
+}
+```
+
+## When to Use
+
+- Creating/managing Facebook and Instagram ads
+- Audience targeting and lookalikes
+- Campaign performance analysis
+- Retargeting setup
+
+## Rate Limits
+
+- 200 calls/hour per ad account
+- 60 calls/hour for marketing API
+- Use batch requests for efficiency
+
+## Relevant Skills
+
+- paid-ads
+- analytics-tracking
+- page-cro

--- a/tools/integrations/mixpanel.md
+++ b/tools/integrations/mixpanel.md
@@ -1,0 +1,137 @@
+# Mixpanel
+
+Product analytics platform for tracking user behavior and retention.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Ingestion API, Query API, Data Export |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | JavaScript, iOS, Android, Python, etc. |
+
+## Authentication
+
+- **Ingestion**: Project token (public)
+- **Query API**: Service Account (username:secret as Basic auth)
+- **Export**: API Secret
+
+## Common Agent Operations
+
+### Track event (Ingestion API)
+
+```bash
+POST https://api.mixpanel.com/track
+
+{
+  "event": "signup_completed",
+  "properties": {
+    "token": "{project_token}",
+    "distinct_id": "user_123",
+    "plan": "pro",
+    "time": 1705312800
+  }
+}
+```
+
+### Set user profile
+
+```bash
+POST https://api.mixpanel.com/engage
+
+{
+  "$token": "{project_token}",
+  "$distinct_id": "user_123",
+  "$set": {
+    "$email": "user@example.com",
+    "$name": "John Doe",
+    "plan": "pro"
+  }
+}
+```
+
+### Query events (Query API)
+
+```bash
+POST https://mixpanel.com/api/2.0/insights
+
+{
+  "project_id": {project_id},
+  "bookmark_id": null,
+  "params": {
+    "events": [{"event": "signup_completed"}],
+    "time_range": {
+      "from_date": "2024-01-01",
+      "to_date": "2024-01-31"
+    }
+  }
+}
+```
+
+### Get funnel data
+
+```bash
+GET https://mixpanel.com/api/2.0/funnels?funnel_id={funnel_id}&from_date=2024-01-01&to_date=2024-01-31
+```
+
+### Export raw events
+
+```bash
+GET https://data.mixpanel.com/api/2.0/export?from_date=2024-01-01&to_date=2024-01-01
+```
+
+### Get retention data
+
+```bash
+GET https://mixpanel.com/api/2.0/retention?from_date=2024-01-01&to_date=2024-01-31&retention_type=birth&born_event=signup_completed
+```
+
+## JavaScript SDK
+
+```javascript
+// Initialize
+mixpanel.init('YOUR_TOKEN');
+
+// Identify user
+mixpanel.identify('user_123');
+
+// Set user properties
+mixpanel.people.set({
+  '$email': 'user@example.com',
+  'plan': 'pro'
+});
+
+// Track event
+mixpanel.track('Feature Used', {
+  'feature_name': 'export'
+});
+```
+
+## Key Concepts
+
+- **Events** - User actions (signup, purchase, etc.)
+- **Properties** - Attributes on events
+- **User Profiles** - Persistent user data
+- **Cohorts** - Saved user segments
+- **Funnels** - Conversion sequences
+- **Retention** - User return patterns
+
+## When to Use
+
+- Tracking product usage events
+- Analyzing conversion funnels
+- Measuring feature adoption
+- Retention analysis
+- User segmentation
+
+## Rate Limits
+
+- Ingestion: No hard limit (batch recommended)
+- Query API: Varies by plan
+
+## Relevant Skills
+
+- analytics-tracking
+- ab-test-setup
+- onboarding-cro

--- a/tools/integrations/posthog.md
+++ b/tools/integrations/posthog.md
@@ -1,0 +1,151 @@
+# PostHog
+
+Open-source product analytics with session replay and feature flags.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Capture API, Query API, Feature Flags API |
+| MCP | - | Not available |
+| CLI | ✓ | `posthog` CLI for local development |
+| SDK | ✓ | JavaScript, Python, Ruby, Go, etc. |
+
+## Authentication
+
+- **Type**: API Key (Personal or Project)
+- **Header**: `Authorization: Bearer {api_key}`
+- **For capture**: Project API Key in payload
+
+## Common Agent Operations
+
+### Capture event
+
+```bash
+POST https://app.posthog.com/capture/
+
+{
+  "api_key": "{project_api_key}",
+  "event": "signup_completed",
+  "distinct_id": "user_123",
+  "properties": {
+    "plan": "pro",
+    "$current_url": "https://example.com/signup"
+  }
+}
+```
+
+### Batch events
+
+```bash
+POST https://app.posthog.com/batch/
+
+{
+  "api_key": "{project_api_key}",
+  "batch": [
+    {"event": "pageview", "distinct_id": "user_1"},
+    {"event": "signup", "distinct_id": "user_2"}
+  ]
+}
+```
+
+### Get person by distinct_id
+
+```bash
+GET https://app.posthog.com/api/projects/{project_id}/persons/?distinct_id=user_123
+
+Authorization: Bearer {api_key}
+```
+
+### Query events (HogQL)
+
+```bash
+POST https://app.posthog.com/api/projects/{project_id}/query/
+
+{
+  "query": {
+    "kind": "HogQLQuery",
+    "query": "SELECT event, count() FROM events WHERE timestamp > now() - interval 7 day GROUP BY event ORDER BY count() DESC LIMIT 10"
+  }
+}
+```
+
+### Get feature flag value
+
+```bash
+POST https://app.posthog.com/decide?v=3
+
+{
+  "api_key": "{project_api_key}",
+  "distinct_id": "user_123"
+}
+```
+
+### Get insights
+
+```bash
+GET https://app.posthog.com/api/projects/{project_id}/insights/
+
+Authorization: Bearer {api_key}
+```
+
+### Get session recordings
+
+```bash
+GET https://app.posthog.com/api/projects/{project_id}/session_recordings/
+
+Authorization: Bearer {api_key}
+```
+
+## JavaScript SDK
+
+```javascript
+// Initialize
+posthog.init('PROJECT_API_KEY', {
+  api_host: 'https://app.posthog.com'
+});
+
+// Identify user
+posthog.identify('user_123', {
+  email: 'user@example.com',
+  plan: 'pro'
+});
+
+// Track event
+posthog.capture('signup_completed', {
+  method: 'email'
+});
+
+// Check feature flag
+if (posthog.isFeatureEnabled('new-pricing')) {
+  // Show new pricing
+}
+```
+
+## Key Features
+
+- **Event tracking** - Product analytics
+- **Session replay** - Watch user sessions
+- **Feature flags** - Control feature rollout
+- **A/B testing** - Built-in experiments
+- **HogQL** - SQL-like query language
+- **Self-hostable** - Run on your infrastructure
+
+## When to Use
+
+- Product analytics with privacy focus
+- Session replay for UX insights
+- Feature flag management
+- Self-hosted analytics needs
+- Open-source requirements
+
+## Rate Limits
+
+- Cloud: 10,000 events/second
+- Self-hosted: Unlimited
+
+## Relevant Skills
+
+- analytics-tracking
+- ab-test-setup
+- onboarding-cro

--- a/tools/integrations/resend.md
+++ b/tools/integrations/resend.md
@@ -1,0 +1,168 @@
+# Resend
+
+Developer-friendly transactional email service with modern API.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Simple REST API for sending emails |
+| MCP | ✓ | Available via Resend MCP server |
+| CLI | - | Not available |
+| SDK | ✓ | Official SDKs for Node.js, Python, Go, etc. |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}`
+- **Get key**: API Keys section in Resend dashboard
+
+## Common Agent Operations
+
+### Send email
+
+```bash
+POST https://api.resend.com/emails
+
+{
+  "from": "hello@example.com",
+  "to": ["user@example.com"],
+  "subject": "Welcome!",
+  "html": "<h1>Welcome to our app!</h1>"
+}
+```
+
+### Send with React template
+
+```bash
+POST https://api.resend.com/emails
+
+{
+  "from": "hello@example.com",
+  "to": ["user@example.com"],
+  "subject": "Welcome!",
+  "react": "WelcomeEmail",
+  "props": {
+    "name": "John"
+  }
+}
+```
+
+### Get email status
+
+```bash
+GET https://api.resend.com/emails/{email_id}
+```
+
+### List emails
+
+```bash
+GET https://api.resend.com/emails
+```
+
+### Send batch emails
+
+```bash
+POST https://api.resend.com/emails/batch
+
+[
+  {
+    "from": "hello@example.com",
+    "to": ["user1@example.com"],
+    "subject": "Welcome User 1"
+  },
+  {
+    "from": "hello@example.com",
+    "to": ["user2@example.com"],
+    "subject": "Welcome User 2"
+  }
+]
+```
+
+### List domains
+
+```bash
+GET https://api.resend.com/domains
+```
+
+### Verify domain
+
+```bash
+POST https://api.resend.com/domains/{domain_id}/verify
+```
+
+## Node.js SDK
+
+### Install
+
+```bash
+npm install resend
+```
+
+### Usage
+
+```typescript
+import { Resend } from 'resend';
+
+const resend = new Resend('re_xxx');
+
+await resend.emails.send({
+  from: 'hello@example.com',
+  to: 'user@example.com',
+  subject: 'Welcome!',
+  html: '<h1>Welcome!</h1>'
+});
+```
+
+### With React Email
+
+```typescript
+import { WelcomeEmail } from './emails/welcome';
+
+await resend.emails.send({
+  from: 'hello@example.com',
+  to: 'user@example.com',
+  subject: 'Welcome!',
+  react: WelcomeEmail({ name: 'John' })
+});
+```
+
+## Email Statuses
+
+- `queued` - Email queued for delivery
+- `sent` - Email sent to recipient server
+- `delivered` - Email delivered
+- `opened` - Email opened (if tracking enabled)
+- `clicked` - Link clicked (if tracking enabled)
+- `bounced` - Email bounced
+- `complained` - Marked as spam
+
+## Webhook Events
+
+| Event | When |
+|-------|------|
+| `email.sent` | Email sent |
+| `email.delivered` | Email delivered |
+| `email.opened` | Email opened |
+| `email.clicked` | Link clicked |
+| `email.bounced` | Email bounced |
+| `email.complained` | Spam complaint |
+
+## When to Use
+
+- Sending transactional emails
+- Welcome emails, password resets
+- Receipt and notification emails
+- Developer-friendly email integration
+- React-based email templates
+
+## Rate Limits
+
+- Free: 100 emails/day, 3,000/month
+- Pro: 100 emails/second
+- Higher limits on scale plans
+
+## Relevant Skills
+
+- email-sequence
+- onboarding-cro

--- a/tools/integrations/rewardful.md
+++ b/tools/integrations/rewardful.md
@@ -1,0 +1,147 @@
+# Rewardful
+
+Affiliate and referral tracking for Stripe-based SaaS businesses.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for affiliates, referrals, commissions |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | API-only, JavaScript snippet for tracking |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_secret}`
+- **Get key**: Settings > API in Rewardful dashboard
+
+## Common Agent Operations
+
+### List affiliates
+
+```bash
+GET https://api.getrewardful.com/v1/affiliates
+```
+
+### Get affiliate by ID
+
+```bash
+GET https://api.getrewardful.com/v1/affiliates/{affiliate_id}
+```
+
+### Search affiliate by email
+
+```bash
+GET https://api.getrewardful.com/v1/affiliates?email=affiliate@example.com
+```
+
+### Get referral by Stripe customer
+
+```bash
+GET https://api.getrewardful.com/v1/referrals?stripe_customer_id={customer_id}
+```
+
+### List referrals for affiliate
+
+```bash
+GET https://api.getrewardful.com/v1/referrals?affiliate_id={affiliate_id}
+```
+
+### Get commission details
+
+```bash
+GET https://api.getrewardful.com/v1/commissions/{commission_id}
+```
+
+### List commissions
+
+```bash
+GET https://api.getrewardful.com/v1/commissions?affiliate_id={affiliate_id}
+```
+
+### Create affiliate link
+
+```bash
+POST https://api.getrewardful.com/v1/affiliates/{affiliate_id}/links
+
+{
+  "token": "custom-link-token",
+  "url": "https://example.com/pricing"
+}
+```
+
+### Update affiliate
+
+```bash
+PUT https://api.getrewardful.com/v1/affiliates/{affiliate_id}
+
+{
+  "first_name": "John",
+  "last_name": "Doe",
+  "paypal_email": "john@example.com"
+}
+```
+
+## JavaScript Tracking
+
+### Install snippet
+
+```html
+<script>
+(function(w,r){w._rwq=r;w[r]=w[r]||function(){(w[r].q=w[r].q||[]).push(arguments)}})(window,'rewardful');
+</script>
+<script async src='https://r.wdfl.co/rw.js' data-rewardful='YOUR_API_KEY'></script>
+```
+
+### Track conversion manually
+
+```javascript
+rewardful('convert', { email: 'customer@example.com' });
+```
+
+## Webhook Events
+
+| Event | When |
+|-------|------|
+| `affiliate.created` | New affiliate signs up |
+| `affiliate.approved` | Affiliate approved |
+| `referral.created` | New referral tracked |
+| `referral.converted` | Referral becomes customer |
+| `commission.created` | Commission generated |
+| `commission.paid` | Commission paid out |
+
+## Key Objects
+
+- **Affiliate** - Partner promoting your product
+- **Referral** - Tracked visit/lead from affiliate
+- **Commission** - Earned payment for affiliate
+- **Campaign** - Program with specific terms
+- **Link** - Tracking URL for affiliate
+
+## Integration with Stripe
+
+Rewardful automatically:
+1. Tracks referral cookie when user visits via affiliate link
+2. Associates Stripe customer with referral on checkout
+3. Creates commissions when subscriptions are paid
+4. Handles recurring commissions for subscriptions
+
+## When to Use
+
+- Setting up affiliate/referral programs for SaaS
+- Tracking referral attribution from Stripe payments
+- Managing affiliate relationships
+- Processing affiliate payouts
+- Analyzing referral program performance
+
+## Rate Limits
+
+- 120 requests per minute
+- Contact support for higher limits
+
+## Relevant Skills
+
+- referral-program
+- pricing-strategy

--- a/tools/integrations/salesforce.md
+++ b/tools/integrations/salesforce.md
@@ -1,0 +1,150 @@
+# Salesforce
+
+Enterprise CRM platform for sales, service, and marketing.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API, SOAP API, Bulk API |
+| MCP | - | Not available |
+| CLI | ✓ | Salesforce CLI (`sf`) |
+| SDK | ✓ | JSforce, simple-salesforce, etc. |
+
+## Authentication
+
+- **Type**: OAuth 2.0 (Web Server Flow or JWT Bearer)
+- **Header**: `Authorization: Bearer {access_token}`
+- **Instance URL**: Use instance_url from auth response
+
+## Common Agent Operations
+
+### Query records (SOQL)
+
+```bash
+GET https://{instance}.salesforce.com/services/data/v59.0/query?q=SELECT+Id,Name,Email+FROM+Contact+LIMIT+10
+
+Authorization: Bearer {access_token}
+```
+
+### Get record by ID
+
+```bash
+GET https://{instance}.salesforce.com/services/data/v59.0/sobjects/Contact/{record_id}
+
+Authorization: Bearer {access_token}
+```
+
+### Create record
+
+```bash
+POST https://{instance}.salesforce.com/services/data/v59.0/sobjects/Contact
+
+{
+  "FirstName": "John",
+  "LastName": "Doe",
+  "Email": "john@example.com",
+  "AccountId": "{account_id}"
+}
+```
+
+### Update record
+
+```bash
+PATCH https://{instance}.salesforce.com/services/data/v59.0/sobjects/Contact/{record_id}
+
+{
+  "Title": "Senior Developer"
+}
+```
+
+### Search records (SOSL)
+
+```bash
+GET https://{instance}.salesforce.com/services/data/v59.0/search?q=FIND+{searchTerm}+IN+ALL+FIELDS+RETURNING+Contact(Id,Name,Email)
+
+Authorization: Bearer {access_token}
+```
+
+### Get opportunities
+
+```bash
+GET https://{instance}.salesforce.com/services/data/v59.0/query?q=SELECT+Id,Name,Amount,StageName,CloseDate+FROM+Opportunity+WHERE+IsClosed=false
+
+Authorization: Bearer {access_token}
+```
+
+### Describe object
+
+```bash
+GET https://{instance}.salesforce.com/services/data/v59.0/sobjects/Contact/describe
+
+Authorization: Bearer {access_token}
+```
+
+## CLI Commands
+
+```bash
+# Authenticate
+sf org login web
+
+# Query records
+sf data query --query "SELECT Id, Name FROM Account LIMIT 10"
+
+# Create record
+sf data create record --sobject Account --values "Name='New Account'"
+
+# Deploy metadata
+sf project deploy start
+
+# Run Apex
+sf apex run --file script.apex
+```
+
+## SOQL Examples
+
+```sql
+-- Get contacts with accounts
+SELECT Id, Name, Email, Account.Name
+FROM Contact
+WHERE Account.Industry = 'Technology'
+
+-- Get opportunities by stage
+SELECT StageName, COUNT(Id)
+FROM Opportunity
+GROUP BY StageName
+
+-- Get recent leads
+SELECT Id, Name, Company, Status
+FROM Lead
+WHERE CreatedDate = LAST_N_DAYS:30
+ORDER BY CreatedDate DESC
+```
+
+## Key Objects
+
+- **Lead** - Potential customer
+- **Contact** - Person at account
+- **Account** - Company/organization
+- **Opportunity** - Sales deal
+- **Case** - Support ticket
+- **Campaign** - Marketing campaign
+
+## When to Use
+
+- Enterprise CRM operations
+- Complex sales processes
+- Multi-object relationships
+- Custom object management
+- Marketing campaign tracking
+
+## Rate Limits
+
+- 15,000 API calls per 24 hours (Enterprise)
+- Higher limits available
+
+## Relevant Skills
+
+- email-sequence
+- analytics-tracking
+- paid-ads

--- a/tools/integrations/segment.md
+++ b/tools/integrations/segment.md
@@ -1,0 +1,159 @@
+# Segment
+
+Customer data platform for collecting, routing, and activating user data.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Tracking API, Profile API, Config API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | analytics.js, iOS, Android, server libraries |
+
+## Authentication
+
+- **Tracking**: Write Key (per source)
+- **API**: Access Token (OAuth 2.0)
+- **Header**: `Authorization: Bearer {access_token}`
+
+## Common Agent Operations
+
+### Track event
+
+```bash
+POST https://api.segment.io/v1/track
+
+Authorization: Basic {base64(write_key:)}
+
+{
+  "userId": "user_123",
+  "event": "signup_completed",
+  "properties": {
+    "plan": "pro",
+    "method": "email"
+  }
+}
+```
+
+### Identify user
+
+```bash
+POST https://api.segment.io/v1/identify
+
+Authorization: Basic {base64(write_key:)}
+
+{
+  "userId": "user_123",
+  "traits": {
+    "email": "user@example.com",
+    "name": "John Doe",
+    "plan": "pro"
+  }
+}
+```
+
+### Track page view
+
+```bash
+POST https://api.segment.io/v1/page
+
+Authorization: Basic {base64(write_key:)}
+
+{
+  "userId": "user_123",
+  "name": "Pricing",
+  "properties": {
+    "title": "Pricing - Example",
+    "url": "https://example.com/pricing"
+  }
+}
+```
+
+### Batch events
+
+```bash
+POST https://api.segment.io/v1/batch
+
+Authorization: Basic {base64(write_key:)}
+
+{
+  "batch": [
+    {"type": "identify", "userId": "user_1", "traits": {"plan": "free"}},
+    {"type": "track", "userId": "user_1", "event": "signup"}
+  ]
+}
+```
+
+### Get user profile (Profile API)
+
+```bash
+GET https://profiles.segment.com/v1/spaces/{space_id}/collections/users/profiles/user_id:{user_id}/traits
+
+Authorization: Basic {base64(access_token:)}
+```
+
+### Get user events
+
+```bash
+GET https://profiles.segment.com/v1/spaces/{space_id}/collections/users/profiles/user_id:{user_id}/events
+
+Authorization: Basic {base64(access_token:)}
+```
+
+## JavaScript SDK
+
+```javascript
+// Initialize
+analytics.load('WRITE_KEY');
+
+// Identify user
+analytics.identify('user_123', {
+  email: 'user@example.com',
+  plan: 'pro'
+});
+
+// Track event
+analytics.track('Feature Used', {
+  feature_name: 'export'
+});
+
+// Page view
+analytics.page('Pricing');
+```
+
+## Key Concepts
+
+- **Sources** - Where data comes from (website, app, server)
+- **Destinations** - Where data goes (analytics, CRM, ads)
+- **Tracking Plan** - Schema for events and properties
+- **Protocols** - Data governance and validation
+- **Personas** - Unified user profiles
+- **Audiences** - Computed user segments
+
+## Common Destinations
+
+- Analytics: GA4, Mixpanel, Amplitude
+- CRM: HubSpot, Salesforce
+- Email: Customer.io, Mailchimp
+- Ads: Google Ads, Meta
+- Data Warehouse: BigQuery, Snowflake
+
+## When to Use
+
+- Centralizing event tracking
+- Routing data to multiple tools
+- Maintaining consistent tracking
+- Building unified user profiles
+- Syncing audiences across platforms
+
+## Rate Limits
+
+- 500 requests/second per source
+- Batch up to 500KB or 32KB per event
+
+## Relevant Skills
+
+- analytics-tracking
+- email-sequence
+- paid-ads

--- a/tools/integrations/semrush.md
+++ b/tools/integrations/semrush.md
@@ -1,0 +1,121 @@
+# SEMrush
+
+SEO and competitive analysis platform for keyword research and site audits.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Analytics API, Projects API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | API-only |
+
+## Authentication
+
+- **Type**: API Key
+- **Parameter**: `key={api_key}` in query string
+- **Get key**: My Profile > API in SEMrush dashboard
+
+## Common Agent Operations
+
+### Domain overview
+
+```bash
+GET https://api.semrush.com/?type=domain_ranks&key={api_key}&export_columns=Db,Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain=example.com
+```
+
+### Organic keywords
+
+```bash
+GET https://api.semrush.com/?type=domain_organic&key={api_key}&export_columns=Ph,Po,Pp,Pd,Nq,Cp,Ur,Tr,Tc,Co,Nr&domain=example.com&database=us&display_limit=100
+```
+
+### Keyword overview
+
+```bash
+GET https://api.semrush.com/?type=phrase_all&key={api_key}&export_columns=Ph,Nq,Cp,Co,Nr&phrase=keyword&database=us
+```
+
+### Related keywords
+
+```bash
+GET https://api.semrush.com/?type=phrase_related&key={api_key}&export_columns=Ph,Nq,Cp,Co,Nr,Td&phrase=keyword&database=us&display_limit=50
+```
+
+### Keyword difficulty
+
+```bash
+GET https://api.semrush.com/?type=phrase_kdi&key={api_key}&export_columns=Ph,Kd&phrase=keyword&database=us
+```
+
+### Backlinks overview
+
+```bash
+GET https://api.semrush.com/?type=backlinks_overview&key={api_key}&target=example.com&target_type=root_domain
+```
+
+### Backlinks list
+
+```bash
+GET https://api.semrush.com/?type=backlinks&key={api_key}&target=example.com&target_type=root_domain&export_columns=source_url,source_title,target_url,anchor&display_limit=100
+```
+
+### Competitors
+
+```bash
+GET https://api.semrush.com/?type=domain_organic_organic&key={api_key}&export_columns=Dn,Cr,Np,Or,Ot,Oc,Ad&domain=example.com&database=us&display_limit=20
+```
+
+## Response Format
+
+Responses are CSV by default. Add `&export_escape=1` for proper escaping.
+
+## Export Columns
+
+### Domain Report
+- `Db` - Database
+- `Dn` - Domain
+- `Rk` - Rank
+- `Or` - Organic keywords
+- `Ot` - Organic traffic
+- `Oc` - Organic cost
+
+### Keyword Report
+- `Ph` - Phrase/keyword
+- `Nq` - Search volume
+- `Cp` - CPC
+- `Co` - Competition
+- `Kd` - Keyword difficulty
+- `Nr` - Number of results
+
+### Backlinks
+- `source_url` - Linking page
+- `target_url` - Target page
+- `anchor` - Anchor text
+- `source_title` - Page title
+
+## Databases
+
+Use country code: `us`, `uk`, `de`, `fr`, `ca`, `au`, etc.
+
+## When to Use
+
+- Keyword research
+- Competitive analysis
+- Backlink analysis
+- Site audits
+- Rank tracking
+- Content gap analysis
+
+## Rate Limits
+
+- Varies by plan (10-30K units/day)
+- Each API call costs units
+
+## Relevant Skills
+
+- seo-audit
+- programmatic-seo
+- content-strategy
+- competitor-alternatives

--- a/tools/integrations/sendgrid.md
+++ b/tools/integrations/sendgrid.md
@@ -1,0 +1,161 @@
+# SendGrid
+
+Email delivery platform for transactional and marketing emails.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Mail Send API, Marketing API |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | Official libraries for most languages |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}`
+- **Get key**: Settings > API Keys in SendGrid dashboard
+
+## Common Agent Operations
+
+### Send email
+
+```bash
+POST https://api.sendgrid.com/v3/mail/send
+
+Authorization: Bearer {api_key}
+
+{
+  "personalizations": [{
+    "to": [{"email": "user@example.com"}]
+  }],
+  "from": {"email": "hello@example.com"},
+  "subject": "Welcome!",
+  "content": [{
+    "type": "text/html",
+    "value": "<h1>Welcome!</h1>"
+  }]
+}
+```
+
+### Send with template
+
+```bash
+POST https://api.sendgrid.com/v3/mail/send
+
+{
+  "personalizations": [{
+    "to": [{"email": "user@example.com"}],
+    "dynamic_template_data": {
+      "name": "John",
+      "order_id": "12345"
+    }
+  }],
+  "from": {"email": "hello@example.com"},
+  "template_id": "d-xxx"
+}
+```
+
+### Add contact to list
+
+```bash
+PUT https://api.sendgrid.com/v3/marketing/contacts
+
+{
+  "list_ids": ["list-id"],
+  "contacts": [{
+    "email": "user@example.com",
+    "first_name": "John",
+    "last_name": "Doe"
+  }]
+}
+```
+
+### Search contacts
+
+```bash
+POST https://api.sendgrid.com/v3/marketing/contacts/search
+
+{
+  "query": "email LIKE 'user@%'"
+}
+```
+
+### Get email statistics
+
+```bash
+GET https://api.sendgrid.com/v3/stats?start_date=2024-01-01&end_date=2024-01-31
+
+Authorization: Bearer {api_key}
+```
+
+### Get bounces
+
+```bash
+GET https://api.sendgrid.com/v3/suppression/bounces
+
+Authorization: Bearer {api_key}
+```
+
+### Get spam reports
+
+```bash
+GET https://api.sendgrid.com/v3/suppression/spam_reports
+
+Authorization: Bearer {api_key}
+```
+
+### Validate email
+
+```bash
+POST https://api.sendgrid.com/v3/validations/email
+
+{
+  "email": "user@example.com"
+}
+```
+
+## Webhook Events
+
+| Event | Description |
+|-------|-------------|
+| `processed` | Email accepted |
+| `delivered` | Email delivered |
+| `open` | Email opened |
+| `click` | Link clicked |
+| `bounce` | Hard/soft bounce |
+| `dropped` | Email dropped |
+| `spamreport` | Marked as spam |
+| `unsubscribe` | Unsubscribed |
+
+## Node.js SDK
+
+```javascript
+const sgMail = require('@sendgrid/mail');
+sgMail.setApiKey('SG.xxx');
+
+await sgMail.send({
+  to: 'user@example.com',
+  from: 'hello@example.com',
+  subject: 'Welcome!',
+  html: '<h1>Welcome!</h1>'
+});
+```
+
+## When to Use
+
+- Transactional email at scale
+- Marketing email campaigns
+- Email validation
+- Deliverability management
+
+## Rate Limits
+
+- Free: 100 emails/day
+- Paid: Varies by plan (up to millions/month)
+
+## Relevant Skills
+
+- email-sequence
+- analytics-tracking

--- a/tools/integrations/shopify.md
+++ b/tools/integrations/shopify.md
@@ -1,0 +1,176 @@
+# Shopify
+
+E-commerce platform for online stores and retail.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST Admin API, Storefront API, GraphQL |
+| MCP | - | Not available |
+| CLI | ✓ | Shopify CLI for themes and apps |
+| SDK | ✓ | Official libraries for multiple languages |
+
+## Authentication
+
+- **Type**: Access Token (Custom App or OAuth)
+- **Header**: `X-Shopify-Access-Token: {access_token}`
+- **Base URL**: `https://{shop}.myshopify.com/admin/api/2024-01/`
+
+## Common Agent Operations
+
+### Get shop info
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/shop.json
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### List products
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/products.json?limit=50
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### Get product
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/products/{product_id}.json
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### Create product
+
+```bash
+POST https://{shop}.myshopify.com/admin/api/2024-01/products.json
+
+X-Shopify-Access-Token: {access_token}
+
+{
+  "product": {
+    "title": "Product Name",
+    "body_html": "<p>Description</p>",
+    "vendor": "Brand",
+    "product_type": "Category",
+    "variants": [{
+      "price": "99.00",
+      "sku": "SKU-001"
+    }]
+  }
+}
+```
+
+### List orders
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/orders.json?status=any&limit=50
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### Get order
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/orders/{order_id}.json
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### List customers
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/customers.json?limit=50
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### Search customers
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/customers/search.json?query=email:user@example.com
+
+X-Shopify-Access-Token: {access_token}
+```
+
+### Get analytics
+
+```bash
+GET https://{shop}.myshopify.com/admin/api/2024-01/reports.json
+
+X-Shopify-Access-Token: {access_token}
+```
+
+## GraphQL API
+
+```graphql
+{
+  products(first: 10) {
+    edges {
+      node {
+        id
+        title
+        totalInventory
+        priceRangeV2 {
+          minVariantPrice {
+            amount
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## CLI Commands
+
+```bash
+# Login
+shopify login --store={shop}
+
+# Create theme
+shopify theme init
+
+# Push theme
+shopify theme push
+
+# Preview theme
+shopify theme dev
+
+# Create app
+shopify app create node
+```
+
+## Webhook Topics
+
+| Topic | When |
+|-------|------|
+| `orders/create` | New order |
+| `orders/paid` | Order paid |
+| `orders/fulfilled` | Order shipped |
+| `customers/create` | New customer |
+| `products/update` | Product changed |
+| `checkouts/create` | Checkout started |
+
+## When to Use
+
+- E-commerce store management
+- Product catalog operations
+- Order processing
+- Customer data management
+- Inventory tracking
+
+## Rate Limits
+
+- REST: 2 requests/second
+- GraphQL: 50 points/second
+- Bulk operations available
+
+## Relevant Skills
+
+- analytics-tracking
+- email-sequence
+- referral-program

--- a/tools/integrations/stripe.md
+++ b/tools/integrations/stripe.md
@@ -1,0 +1,148 @@
+# Stripe
+
+Payment processing, subscriptions, and billing for internet businesses.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Comprehensive REST API |
+| MCP | ✓ | Available via Stripe MCP server |
+| CLI | ✓ | `stripe` CLI for testing and webhooks |
+| SDK | ✓ | Official SDKs for most languages |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer sk_live_xxx` or `sk_test_xxx`
+- **Keys**: Secret key (server), Publishable key (client)
+
+## Common Agent Operations
+
+### List customers
+
+```bash
+GET https://api.stripe.com/v1/customers?limit=10
+```
+
+### Get customer by email
+
+```bash
+GET https://api.stripe.com/v1/customers?email=user@example.com
+```
+
+### Get subscription
+
+```bash
+GET https://api.stripe.com/v1/subscriptions/{subscription_id}
+```
+
+### List subscriptions for customer
+
+```bash
+GET https://api.stripe.com/v1/subscriptions?customer={customer_id}
+```
+
+### Create checkout session
+
+```bash
+POST https://api.stripe.com/v1/checkout/sessions
+
+customer={customer_id}
+&line_items[0][price]={price_id}
+&line_items[0][quantity]=1
+&mode=subscription
+&success_url=https://example.com/success
+&cancel_url=https://example.com/cancel
+```
+
+### Create customer portal session
+
+```bash
+POST https://api.stripe.com/v1/billing_portal/sessions
+
+customer={customer_id}
+&return_url=https://example.com/account
+```
+
+### List recent invoices
+
+```bash
+GET https://api.stripe.com/v1/invoices?customer={customer_id}&limit=10
+```
+
+### Get payment intent
+
+```bash
+GET https://api.stripe.com/v1/payment_intents/{payment_intent_id}
+```
+
+## Webhook Events
+
+Key events to handle:
+
+| Event | When | Action |
+|-------|------|--------|
+| `checkout.session.completed` | Successful checkout | Provision access |
+| `customer.subscription.created` | New subscription | Update user record |
+| `customer.subscription.updated` | Plan change | Update entitlements |
+| `customer.subscription.deleted` | Cancellation | Revoke access |
+| `invoice.payment_failed` | Payment failed | Notify user, retry |
+| `invoice.paid` | Invoice paid | Confirm payment |
+
+### Verify webhook signature
+
+```javascript
+const event = stripe.webhooks.constructEvent(
+  payload,
+  sig,
+  webhookSecret
+);
+```
+
+## CLI Commands
+
+```bash
+# Listen to webhooks locally
+stripe listen --forward-to localhost:3000/webhooks
+
+# Trigger test events
+stripe trigger checkout.session.completed
+
+# List recent events
+stripe events list --limit 10
+
+# Get resource
+stripe customers retrieve cus_xxx
+```
+
+## Key Objects
+
+- **Customer** - User billing profile
+- **Subscription** - Recurring billing
+- **Price** - Pricing configuration
+- **Product** - What you sell
+- **Invoice** - Billing document
+- **PaymentIntent** - One-time payment
+- **Checkout Session** - Hosted payment page
+
+## When to Use
+
+- Processing payments
+- Managing subscriptions
+- Creating checkout flows
+- Handling billing portal
+- Querying customer data
+- Revenue analytics
+
+## Rate Limits
+
+- 100 read requests per second
+- 100 write requests per second
+- Higher limits available on request
+
+## Relevant Skills
+
+- pricing-strategy
+- referral-program (Stripe-integrated affiliate tools)
+- analytics-tracking (revenue tracking)

--- a/tools/integrations/tiktok-ads.md
+++ b/tools/integrations/tiktok-ads.md
@@ -1,0 +1,161 @@
+# TikTok Ads
+
+Advertising platform for TikTok's short-form video audience.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Marketing API for campaigns, audiences, reporting |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | ✓ | Python SDK available |
+
+## Authentication
+
+- **Type**: Access Token
+- **Header**: `Access-Token: {access_token}`
+- **Setup**: Create app in TikTok for Business, get access token
+
+## Common Agent Operations
+
+### Get advertiser info
+
+```bash
+GET https://business-api.tiktok.com/open_api/v1.3/advertiser/info/?advertiser_ids=["{advertiser_id}"]
+
+Access-Token: {access_token}
+```
+
+### Get campaigns
+
+```bash
+GET https://business-api.tiktok.com/open_api/v1.3/campaign/get/?advertiser_id={advertiser_id}&page=1&page_size=20
+
+Access-Token: {access_token}
+```
+
+### Get campaign report
+
+```bash
+POST https://business-api.tiktok.com/open_api/v1.3/report/integrated/get/
+
+Access-Token: {access_token}
+
+{
+  "advertiser_id": "{advertiser_id}",
+  "report_type": "BASIC",
+  "dimensions": ["campaign_id"],
+  "metrics": ["spend", "impressions", "clicks", "conversion"],
+  "data_level": "AUCTION_CAMPAIGN",
+  "start_date": "2024-01-01",
+  "end_date": "2024-01-31"
+}
+```
+
+### Create campaign
+
+```bash
+POST https://business-api.tiktok.com/open_api/v1.3/campaign/create/
+
+Access-Token: {access_token}
+
+{
+  "advertiser_id": "{advertiser_id}",
+  "campaign_name": "Campaign Name",
+  "objective_type": "CONVERSIONS",
+  "budget_mode": "BUDGET_MODE_DAY",
+  "budget": 100
+}
+```
+
+### Update campaign status
+
+```bash
+POST https://business-api.tiktok.com/open_api/v1.3/campaign/status/update/
+
+Access-Token: {access_token}
+
+{
+  "advertiser_id": "{advertiser_id}",
+  "campaign_ids": ["{campaign_id}"],
+  "opt_status": "ENABLE"
+}
+```
+
+### Get ad groups
+
+```bash
+GET https://business-api.tiktok.com/open_api/v1.3/adgroup/get/?advertiser_id={advertiser_id}&campaign_ids=["{campaign_id}"]
+
+Access-Token: {access_token}
+```
+
+### Get audiences
+
+```bash
+GET https://business-api.tiktok.com/open_api/v1.3/dmp/custom_audience/list/?advertiser_id={advertiser_id}
+
+Access-Token: {access_token}
+```
+
+## Key Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `spend` | Amount spent |
+| `impressions` | Ad impressions |
+| `clicks` | Clicks |
+| `ctr` | Click-through rate |
+| `cpc` | Cost per click |
+| `cpm` | Cost per 1000 impressions |
+| `conversion` | Conversions |
+| `cost_per_conversion` | CPA |
+| `video_play_actions` | Video views |
+| `video_watched_6s` | 6s views |
+
+## Campaign Objectives
+
+- `REACH` - Brand awareness
+- `TRAFFIC` - Website traffic
+- `VIDEO_VIEWS` - Video views
+- `LEAD_GENERATION` - Lead forms
+- `CONVERSIONS` - Website conversions
+- `APP_PROMOTION` - App installs
+
+## Targeting Options
+
+### Demographics
+- Age ranges
+- Gender
+- Languages
+- Locations
+
+### Interests & Behavior
+- Interest categories
+- Video interactions
+- Creator interactions
+- Hashtag interactions
+
+### Custom Audiences
+- Customer file uploads
+- Website visitors (pixel)
+- App activity
+- Engagement audiences
+
+## When to Use
+
+- Reaching younger demographics (18-34)
+- Video-first advertising
+- Viral/creative campaigns
+- App promotion
+
+## Rate Limits
+
+- 10 requests/second
+- 100,000 requests/day
+
+## Relevant Skills
+
+- paid-ads
+- analytics-tracking

--- a/tools/integrations/tolt.md
+++ b/tools/integrations/tolt.md
@@ -1,0 +1,144 @@
+# Tolt
+
+Affiliate program management for SaaS, with Stripe and Paddle integration.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for affiliates, referrals, payouts |
+| MCP | - | Not available |
+| CLI | - | Not available |
+| SDK | - | JavaScript snippet for tracking |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}`
+- **Get key**: Settings > API in Tolt dashboard
+
+## Common Agent Operations
+
+### List affiliates
+
+```bash
+GET https://api.tolt.io/v1/affiliates
+```
+
+### Get affiliate
+
+```bash
+GET https://api.tolt.io/v1/affiliates/{affiliate_id}
+```
+
+### Create affiliate
+
+```bash
+POST https://api.tolt.io/v1/affiliates
+
+{
+  "email": "affiliate@example.com",
+  "name": "John Doe"
+}
+```
+
+### List referrals
+
+```bash
+GET https://api.tolt.io/v1/referrals?affiliate_id={affiliate_id}
+```
+
+### Get referral by customer
+
+```bash
+GET https://api.tolt.io/v1/referrals?customer_id={stripe_customer_id}
+```
+
+### List commissions
+
+```bash
+GET https://api.tolt.io/v1/commissions?affiliate_id={affiliate_id}
+```
+
+### Get payout history
+
+```bash
+GET https://api.tolt.io/v1/payouts?affiliate_id={affiliate_id}
+```
+
+### Update affiliate
+
+```bash
+PATCH https://api.tolt.io/v1/affiliates/{affiliate_id}
+
+{
+  "commission_rate": 30,
+  "payout_method": "paypal",
+  "paypal_email": "affiliate@paypal.com"
+}
+```
+
+## JavaScript Tracking
+
+### Install snippet
+
+```html
+<script src="https://cdn.tolt.io/tolt.js" data-tolt="YOUR_PUBLIC_KEY"></script>
+```
+
+### Track signup
+
+```javascript
+window.tolt.signup(stripeCustomerId);
+```
+
+### Identify existing customer
+
+```javascript
+window.tolt.identify(stripeCustomerId);
+```
+
+## Webhook Events
+
+| Event | When |
+|-------|------|
+| `affiliate.created` | New affiliate registered |
+| `affiliate.approved` | Affiliate approved |
+| `referral.created` | New referral tracked |
+| `referral.converted` | Referral converted to customer |
+| `commission.created` | Commission earned |
+| `payout.completed` | Payout sent |
+
+## Key Features
+
+- **Stripe native** - Automatic commission tracking
+- **Paddle support** - Works with Paddle billing
+- **Affiliate dashboard** - White-labeled portal
+- **Payout automation** - PayPal and Wise payouts
+- **Custom commission tiers** - Different rates per affiliate
+
+## Key Objects
+
+- **Affiliate** - Partner in your program
+- **Referral** - Tracked conversion
+- **Commission** - Earned affiliate payment
+- **Payout** - Processed payment to affiliate
+- **Program** - Campaign configuration
+
+## When to Use
+
+- Setting up SaaS affiliate programs
+- Managing affiliate relationships
+- Tracking Stripe or Paddle-based referrals
+- Processing affiliate payouts
+- Building affiliate dashboards
+
+## Rate Limits
+
+- 100 requests per minute
+- Higher limits on enterprise plans
+
+## Relevant Skills
+
+- referral-program
+- pricing-strategy

--- a/tools/integrations/webflow.md
+++ b/tools/integrations/webflow.md
@@ -1,0 +1,198 @@
+# Webflow
+
+Visual web design and CMS platform for marketing sites.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for sites, CMS, forms |
+| MCP | - | Not available |
+| CLI | ✓ | Webflow CLI for devlink and apps |
+| SDK | ✓ | Official SDK for Node.js |
+
+## Authentication
+
+- **Type**: API Token (Site token or OAuth)
+- **Header**: `Authorization: Bearer {api_token}`
+- **Get token**: Site Settings > Integrations > API Access
+
+## Common Agent Operations
+
+### List sites
+
+```bash
+GET https://api.webflow.com/v2/sites
+
+Authorization: Bearer {api_token}
+```
+
+### Get site
+
+```bash
+GET https://api.webflow.com/v2/sites/{site_id}
+
+Authorization: Bearer {api_token}
+```
+
+### List collections
+
+```bash
+GET https://api.webflow.com/v2/sites/{site_id}/collections
+
+Authorization: Bearer {api_token}
+```
+
+### List collection items
+
+```bash
+GET https://api.webflow.com/v2/collections/{collection_id}/items
+
+Authorization: Bearer {api_token}
+```
+
+### Get collection item
+
+```bash
+GET https://api.webflow.com/v2/collections/{collection_id}/items/{item_id}
+
+Authorization: Bearer {api_token}
+```
+
+### Create collection item
+
+```bash
+POST https://api.webflow.com/v2/collections/{collection_id}/items
+
+Authorization: Bearer {api_token}
+
+{
+  "fieldData": {
+    "name": "Item Name",
+    "slug": "item-name",
+    "custom-field": "value"
+  }
+}
+```
+
+### Update collection item
+
+```bash
+PATCH https://api.webflow.com/v2/collections/{collection_id}/items/{item_id}
+
+Authorization: Bearer {api_token}
+
+{
+  "fieldData": {
+    "custom-field": "new value"
+  }
+}
+```
+
+### Publish collection items
+
+```bash
+POST https://api.webflow.com/v2/collections/{collection_id}/items/publish
+
+Authorization: Bearer {api_token}
+
+{
+  "itemIds": ["item_id_1", "item_id_2"]
+}
+```
+
+### List form submissions
+
+```bash
+GET https://api.webflow.com/v2/sites/{site_id}/forms/{form_id}/submissions
+
+Authorization: Bearer {api_token}
+```
+
+### Publish site
+
+```bash
+POST https://api.webflow.com/v2/sites/{site_id}/publish
+
+Authorization: Bearer {api_token}
+
+{
+  "publishToWebflowSubdomain": true,
+  "publishToCustomDomains": true
+}
+```
+
+## Node.js SDK
+
+```javascript
+const Webflow = require('webflow-api');
+
+const webflow = new Webflow({ token: 'api_token' });
+
+// List sites
+const sites = await webflow.sites.list();
+
+// Get collection items
+const items = await webflow.collections.items.listItems(collectionId);
+
+// Create item
+const item = await webflow.collections.items.createItem(collectionId, {
+  fieldData: {
+    name: 'New Item',
+    slug: 'new-item'
+  }
+});
+```
+
+## CLI Commands
+
+```bash
+# Install
+npm install -g @webflow/webflow-cli
+
+# Login
+webflow login
+
+# Initialize devlink
+webflow devlink init
+
+# Sync components
+webflow devlink sync
+```
+
+## CMS Structure
+
+- **Collections** - Content types (like blog posts, team members)
+- **Items** - Individual entries in a collection
+- **Fields** - Data fields on items
+
+## Common Field Types
+
+- `PlainText` - Simple text
+- `RichText` - Formatted content
+- `Image` - Image upload
+- `Link` - URL or page reference
+- `Reference` - Link to another collection
+- `Multi-Reference` - Multiple collection links
+- `Switch` - Boolean toggle
+- `Number` - Numeric value
+- `Date` - Date/time
+
+## When to Use
+
+- Marketing site CMS management
+- Blog/content publishing
+- Form submission handling
+- Automated content updates
+- Programmatic SEO pages
+
+## Rate Limits
+
+- 60 requests/minute (general)
+- 10 requests/minute (publishing)
+
+## Relevant Skills
+
+- programmatic-seo
+- content-strategy
+- page-cro

--- a/tools/integrations/wordpress.md
+++ b/tools/integrations/wordpress.md
@@ -1,0 +1,175 @@
+# WordPress
+
+Content management system for blogs and websites.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API (WP REST API) |
+| MCP | - | Not available |
+| CLI | ✓ | WP-CLI for server-side management |
+| SDK | ✓ | Various client libraries |
+
+## Authentication
+
+- **Type**: Application Password, JWT, or OAuth
+- **Header**: `Authorization: Basic {base64(username:app_password)}`
+- **Setup**: Users > Your Profile > Application Passwords
+
+## Common Agent Operations
+
+### List posts
+
+```bash
+GET https://example.com/wp-json/wp/v2/posts?per_page=10
+
+Authorization: Basic {base64(username:app_password)}
+```
+
+### Get post
+
+```bash
+GET https://example.com/wp-json/wp/v2/posts/{post_id}
+
+Authorization: Basic {base64(username:app_password)}
+```
+
+### Create post
+
+```bash
+POST https://example.com/wp-json/wp/v2/posts
+
+Authorization: Basic {base64(username:app_password)}
+
+{
+  "title": "Post Title",
+  "content": "<p>Post content here</p>",
+  "status": "draft",
+  "categories": [1],
+  "tags": [5, 6]
+}
+```
+
+### Update post
+
+```bash
+PUT https://example.com/wp-json/wp/v2/posts/{post_id}
+
+Authorization: Basic {base64(username:app_password)}
+
+{
+  "title": "Updated Title",
+  "status": "publish"
+}
+```
+
+### List pages
+
+```bash
+GET https://example.com/wp-json/wp/v2/pages?per_page=20
+
+Authorization: Basic {base64(username:app_password)}
+```
+
+### List categories
+
+```bash
+GET https://example.com/wp-json/wp/v2/categories
+```
+
+### Create category
+
+```bash
+POST https://example.com/wp-json/wp/v2/categories
+
+{
+  "name": "Category Name",
+  "slug": "category-name"
+}
+```
+
+### Upload media
+
+```bash
+POST https://example.com/wp-json/wp/v2/media
+
+Authorization: Basic {base64(username:app_password)}
+Content-Disposition: attachment; filename="image.jpg"
+Content-Type: image/jpeg
+
+[binary image data]
+```
+
+### List users
+
+```bash
+GET https://example.com/wp-json/wp/v2/users
+
+Authorization: Basic {base64(username:app_password)}
+```
+
+## WP-CLI Commands
+
+```bash
+# List posts
+wp post list --post_type=post --post_status=publish
+
+# Create post
+wp post create --post_title="Title" --post_content="Content" --post_status=publish
+
+# Update post
+wp post update 123 --post_title="New Title"
+
+# Export database
+wp db export backup.sql
+
+# Search/replace in database
+wp search-replace 'old-domain.com' 'new-domain.com'
+
+# Install plugin
+wp plugin install yoast-seo --activate
+
+# Update plugins
+wp plugin update --all
+```
+
+## Post Statuses
+
+- `publish` - Live on site
+- `draft` - Not published
+- `pending` - Awaiting review
+- `private` - Private post
+- `future` - Scheduled
+- `trash` - In trash
+
+## Common Endpoints
+
+| Endpoint | Resource |
+|----------|----------|
+| `/wp/v2/posts` | Blog posts |
+| `/wp/v2/pages` | Pages |
+| `/wp/v2/media` | Images/files |
+| `/wp/v2/categories` | Categories |
+| `/wp/v2/tags` | Tags |
+| `/wp/v2/users` | Users |
+| `/wp/v2/comments` | Comments |
+
+## When to Use
+
+- Blog content management
+- Page updates
+- Media management
+- Site configuration
+- Plugin/theme management
+
+## Rate Limits
+
+- No default limits
+- Server/host dependent
+
+## Relevant Skills
+
+- content-strategy
+- seo-audit
+- programmatic-seo

--- a/tools/integrations/zapier.md
+++ b/tools/integrations/zapier.md
@@ -1,0 +1,150 @@
+# Zapier
+
+Workflow automation platform connecting apps without code.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for Zaps, tasks, and webhooks |
+| MCP | ✓ | Available via Zapier MCP server |
+| CLI | - | Not available |
+| SDK | - | API and webhooks only |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `X-API-Key: {api_key}`
+- **Get key**: Settings > API in Zapier account
+
+## Common Agent Operations
+
+### List Zaps
+
+```bash
+GET https://api.zapier.com/v1/zaps
+```
+
+### Get Zap details
+
+```bash
+GET https://api.zapier.com/v1/zaps/{zap_id}
+```
+
+### Turn Zap on/off
+
+```bash
+POST https://api.zapier.com/v1/zaps/{zap_id}/on
+POST https://api.zapier.com/v1/zaps/{zap_id}/off
+```
+
+### Get task history
+
+```bash
+GET https://api.zapier.com/v1/zaps/{zap_id}/tasks
+```
+
+### Get profile info
+
+```bash
+GET https://api.zapier.com/v1/profiles/me
+```
+
+## Webhooks (Triggers)
+
+### Catch Hook (receive data)
+
+Create a "Webhooks by Zapier" trigger to receive data:
+
+```bash
+POST https://hooks.zapier.com/hooks/catch/{webhook_id}/
+
+{
+  "event": "user.created",
+  "user_id": "123",
+  "email": "user@example.com"
+}
+```
+
+### Send data to Zapier
+
+Most common: trigger a Zap from your app:
+
+```bash
+POST https://hooks.zapier.com/hooks/catch/{account_id}/{hook_id}/
+
+{
+  "name": "John Doe",
+  "email": "john@example.com",
+  "plan": "pro"
+}
+```
+
+## Common Marketing Automations
+
+### Lead capture to CRM
+```
+Typeform → Zapier → HubSpot
+```
+
+### New customer notifications
+```
+Stripe (new customer) → Zapier → Slack
+```
+
+### Email sequence triggers
+```
+Form submission → Zapier → Customer.io
+```
+
+### Social proof automation
+```
+New review → Zapier → Twitter/Slack
+```
+
+### Referral tracking
+```
+New referral → Zapier → Spreadsheet + Slack
+```
+
+## Webhook Payload Structure
+
+When sending to Zapier, structure data as flat JSON:
+
+```json
+{
+  "customer_name": "John Doe",
+  "customer_email": "john@example.com",
+  "plan_name": "Pro",
+  "plan_price": 99,
+  "signup_date": "2024-01-15"
+}
+```
+
+## Key Concepts
+
+- **Zap** - Automated workflow
+- **Trigger** - Event that starts a Zap
+- **Action** - Task performed by Zap
+- **Task** - Single action execution
+- **Filter** - Conditional logic
+- **Path** - Branching logic
+
+## When to Use
+
+- Connecting marketing tools without code
+- Automating lead routing
+- Syncing data between platforms
+- Triggering notifications
+- Building marketing workflows
+
+## Rate Limits
+
+- 100 requests per minute
+- Task limits by plan tier
+
+## Relevant Skills
+
+- email-sequence
+- analytics-tracking
+- referral-program


### PR DESCRIPTION
## Summary

- Create centralized `tools/` directory with registry and integration guides
- Add `tools/REGISTRY.md` as index of all tools with capabilities (API, MCP, CLI, SDK)
- Add 29 integration guides covering analytics, SEO, CRM, payments, referral, email, ads, automation, and commerce platforms
- Update `AGENTS.md` with tool discovery section
- Add tool integration tables to relevant skills (referral-program, analytics-tracking, email-sequence, paid-ads)

## Tools Registry Structure

```
tools/
├── REGISTRY.md              # Index of all tools with capabilities
└── integrations/            # 29 detailed integration guides
    ├── ga4.md
    ├── stripe.md
    ├── rewardful.md
    └── ...
```

## Integration Guides Added

| Category | Tools |
|----------|-------|
| Analytics | ga4, mixpanel, amplitude, posthog, segment, adobe-analytics |
| SEO | google-search-console, semrush, ahrefs |
| CRM | hubspot, salesforce |
| Payments | stripe |
| Referral | rewardful, tolt, dub-co, mention-me |
| Email | mailchimp, customer-io, sendgrid, resend, kit |
| Ads | google-ads, meta-ads, linkedin-ads, tiktok-ads |
| Automation | zapier |
| Commerce/CMS | shopify, wordpress, webflow |

## Test plan

- [ ] Verify `tools/REGISTRY.md` renders correctly and all links work
- [ ] Check that integration guides follow consistent format
- [ ] Confirm links from skills to tools work
- [ ] Verify AGENTS.md explains tool discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)