### PR TITLE
feat: add tagline-generator skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "25 marketing skills for technical marketers and founders: CRO, copywriting, SEO, paid ads, pricing strategy, referral programs, and more",
+      "description": "26 marketing skills for technical marketers and founders: CRO, copywriting, SEO, paid ads, pricing strategy, referral programs, and more",
       "source": "./",
       "strict": false,
       "skills": [
@@ -40,7 +40,8 @@
         "./skills/schema-markup",
         "./skills/seo-audit",
         "./skills/signup-flow-cro",
-        "./skills/social-content"
+        "./skills/social-content",
+        "./skills/tagline-generator"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Skills are markdown files that give AI agents specialized knowledge and workflow
 | [seo-audit](skills/seo-audit/) | When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO... |
 | [signup-flow-cro](skills/signup-flow-cro/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
 | [social-content](skills/social-content/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
+| [tagline-generator](skills/tagline-generator/) | When the user needs a brand tagline, slogan, or catchy phrase for their product. Also use when the user... |
 <!-- SKILLS:END -->
 
 ## Installation
@@ -156,6 +157,7 @@ You can also invoke skills directly:
 - `copy-editing` - Edit and polish existing copy
 - `email-sequence` - Automated email flows
 - `social-content` - Social media content
+- `tagline-generator` - Brand taglines and slogans
 
 ### SEO & Discovery
 - `seo-audit` - Technical and on-page SEO

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -249,3 +249,4 @@ For headlines and CTAs, provide 2-3 options:
 - **email-sequence**: For email copywriting
 - **popup-cro**: For popup and modal copy
 - **ab-test-setup**: To test copy variations
+- **tagline-generator**: If the page needs a brand tagline or slogan to accompany headlines

--- a/skills/launch-strategy/SKILL.md
+++ b/skills/launch-strategy/SKILL.md
@@ -195,8 +195,8 @@ Product Hunt can be powerful for reaching early adopters, but it's not magic—i
 ### How to Launch Successfully
 
 **Before launch day:**
-1. Build relationships with influential supporters, content hubs, and communities
-2. Optimize your listing: compelling tagline, polished visuals, short demo video
+1. Build relationships with influential supporters, content hubs, and communities.
+2. Optimize your listing: compelling tagline **(use tagline-generator if you don't have one)**, polished visuals, short demo video
 3. Study successful launches to identify what worked
 4. Engage in relevant communities—provide value before pitching
 5. Prepare your team for all-day engagement

--- a/skills/product-marketing-context/SKILL.md
+++ b/skills/product-marketing-context/SKILL.md
@@ -58,6 +58,7 @@ For each section:
 - Product category (what "shelf" you sit on—how customers search for you)
 - Product type (SaaS, marketplace, e-commerce, service, etc.)
 - Business model and pricing
+- Brand Tagline (optional)
 
 ### 2. Target Audience
 - Target company type (industry, size, stage)
@@ -140,6 +141,7 @@ After gathering information, create `.claude/product-marketing-context.md` with 
 **Product category:**
 **Product type:**
 **Business model:**
+**Brand Tagline:**
 
 ## Target Audience
 **Target companies:**

--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -275,3 +275,4 @@ Instead of guessing, analyze what's working for top creators in your niche:
 - **launch-strategy**: For coordinating social with launches
 - **email-sequence**: For nurturing social audience via email
 - **marketing-psychology**: For understanding what drives engagement
+- **tagline-generator**: For optimizing profile bios and creating situational slogans for trending content

--- a/skills/tagline-generator/SKILL.md
+++ b/skills/tagline-generator/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: tagline-generator
+version: 1.0.0
+description: When the user needs a brand tagline, slogan, or catchy phrase for their product. Use for permanent brand identity, situational campaigns (festivals/trends), or platform-specific bios (Twitter/LinkedIn). Distinguishes between "North Star" branding and campaign-specific "morphing."
+---
+
+# Tagline Generator
+
+You are a senior brand strategist and copywriter. Your goal is to generate taglines that are memorable, align with the product's core identity, and adapt to specific marketing contexts.
+
+## Initial Assessment
+
+**Check for product marketing context first:**
+If `.claude/product-marketing-context.md` exists, read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+**Check for existing tagline:**
+If the context file contains a "Brand Tagline," ask the user:
+- "Should I enhance your existing tagline or create campaign variations?"
+- "Is this for a situational campaign (like a festival or trend) or replacing the permanent brand tagline?"
+
+---
+
+Before providing recommendations, identify the **Tagline Intent**:
+1. **The "North Star" (Permanent)**: A foundational brand tagline for long-term use (e.g., "Think Different").
+2. **The "Campaign Morph" (Situational)**: Adapting the brand essence for a specific event, holiday, or trend (e.g., Five Star's "Eat Five Star, Do Nothing" → Valentine's Day variant).
+3. **The "Platform-Specific"**: Short, punchy taglines optimized for social bios or Product Hunt taglines.
+
+---
+
+## Tagline Taxonomy
+
+Analyze which psychological function the tagline should serve:
+
+### 1. Descriptive / Literal
+Focuses on clarity and *what* the product does. Best for new categories or abstract names.
+* *Example*: "The CRM for Freelancers"
+* *Formula*: [Product] for [Audience]
+
+### 2. Visionary / Belief
+Focuses on the *why* or a shared worldview. High emotional resonance.
+* *Example*: "Belong Anywhere" (Airbnb)
+* *Formula*: [Shared Aspiration or Action]
+
+### 3. Outcome / Transformation
+Focuses on the "Aha!" moment or the pain removed.
+* *Example*: "Shave Time. Shave Money." (Dollar Shave Club)
+* *Formula*: [Desired Outcome] without [Pain Point]
+
+---
+
+## The "Morphing" Framework (Situational Taglines)
+
+When adapting a tagline for a specific trend or event (The "Five Star" Logic), follow these steps:
+
+1.  **Isolate the Core**: Identify the untouchable "truth" of the brand (e.g., "Do nothing").
+2.  **Identify the Catalyst**: Define the situational event (e.g., Valentine's Day, a competitor launch, a viral trend).
+3.  **The Pivot**: Bridge the core truth to the catalyst with a witty or relevant setup.
+    * *Core*: "Eat Five Star, Do Nothing"
+    * *Catalyst*: Valentine's Day
+    * *Pivot*: "No date? No problem. Eat Five Star, Do Nothing."
+
+---
+
+## Output Format
+
+Provide 3-5 options categorized by style:
+
+### Option A: The "North Star"
+A permanent, high-level branding option.
+* **Copy**: "[Tagline]"
+* **Rationale**: Why this fits the brand's long-term vision.
+
+### Option B: The "Short & Punchy"
+Optimized for social bios or Product Hunt listings.
+* **Copy**: "[Tagline]"
+* **Rationale**: Why this works for quick scanning.
+
+### Option C: The "Situational Morph"
+If a specific event was mentioned, provide a contextual adaptation.
+* **Copy**: "[Tagline]"
+* **Rationale**: How this bridges the brand's core truth to the current moment.
+
+---
+
+## Implementation & The Mesh
+
+* **If choosing a "North Star" tagline**: You must suggest updating `.claude/product-marketing-context.md` so other skills (like `launch-strategy` and `social-content`) can use it.
+* **If choosing a "Campaign Morph"**: Direct the user to the `social-content` or `email-sequence` skill to deploy the campaign.
+
+---
+
+## Task-Specific Questions
+
+1. Do you have an existing "North Star" tagline we are building upon?
+2. Is this for a specific campaign, holiday, or trend (e.g., "The Five Star approach")?
+3. Where will this primarily live? (Logo, Website Hero, Twitter Bio, Product Hunt)
+4. What is the one specific emotion you want a visitor to feel? (Relief, Power, Joy, Security)
+
+---
+
+## Related Skills
+
+* **product-marketing-context**: For foundational product data.
+* **copywriting**: To turn a tagline into a full page headline.
+* **launch-strategy**: To use the tagline for a Product Hunt launch.
+* **social-content**: To use the tagline for social media bio optimization.
+* **marketing-psychology**: To align the tagline with specific mental models.


### PR DESCRIPTION
## New Skill
**Skill name:** `skills/tagline-generator`

## Summary
This PR adds the `tagline-generator` skill, designed to help users create permanent "North Star" brand taglines and situational "Campaign Morphs" (e.g., adapting a brand message for holidays or trends). 

Beyond the new skill, this PR fully integrates the tool into the existing "Marketing Mesh" by:
- Adding "Brand Tagline" support to `product-marketing-context`.
- Adding direct links to the generator from `launch-strategy` (for Product Hunt listings), `social-content` (for bios), and `copywriting` (for page slogans).

## Checklist
- [x] `name` matches directory name exactly
- [x] `name` follows naming rules (lowercase, hyphens, no `--`)
- [x] `description` is 1-1024 chars with trigger phrases
- [x] `SKILL.md` is under 500 lines
- [x] No sensitive data or credentials
- [x] Tested logic for "situational morphing" based on brand core truths