### PR TITLE
fix: add table of contents to all reference files

### DIFF
--- a/skills/ab-test-setup/references/sample-size-guide.md
+++ b/skills/ab-test-setup/references/sample-size-guide.md
@@ -2,6 +2,17 @@
 
 Reference for calculating sample sizes and test duration.
 
+## Contents
+- Sample Size Fundamentals (required inputs, what these mean)
+- Sample Size Quick Reference Tables
+- Duration Calculator (formula, examples, minimum duration rules, maximum duration guidelines)
+- Online Calculators
+- Adjusting for Multiple Variants
+- Common Sample Size Mistakes
+- When Sample Size Requirements Are Too High
+- Sequential Testing
+- Quick Decision Framework
+
 ## Sample Size Fundamentals
 
 ### Required Inputs

--- a/skills/ab-test-setup/references/test-templates.md
+++ b/skills/ab-test-setup/references/test-templates.md
@@ -2,6 +2,15 @@
 
 Templates for planning, documenting, and analyzing experiments.
 
+## Contents
+- Test Plan Template
+- Results Documentation Template
+- Test Repository Entry Template
+- Quick Test Brief Template
+- Stakeholder Update Template
+- Experiment Prioritization Scorecard
+- Hypothesis Bank Template
+
 ## Test Plan Template
 
 ```markdown

--- a/skills/analytics-tracking/references/event-library.md
+++ b/skills/analytics-tracking/references/event-library.md
@@ -2,6 +2,15 @@
 
 Comprehensive list of events to track by business type and context.
 
+## Contents
+- Marketing Site Events (navigation & engagement, CTA & form interactions, conversion events)
+- Product/App Events (onboarding, core usage, errors & support)
+- Monetization Events (pricing & checkout, subscription management)
+- E-commerce Events (browsing, cart, checkout, post-purchase)
+- B2B / SaaS Specific Events (team & collaboration, integration events, account events)
+- Event Properties (Parameters)
+- Funnel Event Sequences
+
 ## Marketing Site Events
 
 ### Navigation & Engagement

--- a/skills/analytics-tracking/references/ga4-implementation.md
+++ b/skills/analytics-tracking/references/ga4-implementation.md
@@ -2,6 +2,16 @@
 
 Detailed implementation guide for Google Analytics 4.
 
+## Contents
+- Configuration (data streams, enhanced measurement events, recommended events)
+- Custom Events (gtag.js implementation, Google Tag Manager)
+- Conversions Setup (creating conversions, conversion values)
+- Custom Dimensions and Metrics (when to use, setup steps, examples)
+- Audiences (creating audiences, audience examples)
+- Debugging (DebugView, real-time reports, common issues)
+- Data Quality (filters, cross-domain tracking, session settings)
+- Integration with Google Ads (linking, audience export)
+
 ## Configuration
 
 ### Data Streams

--- a/skills/analytics-tracking/references/gtm-implementation.md
+++ b/skills/analytics-tracking/references/gtm-implementation.md
@@ -2,6 +2,16 @@
 
 Detailed guide for implementing tracking via Google Tag Manager.
 
+## Contents
+- Container Structure (tags, triggers, variables)
+- Naming Conventions
+- Data Layer Patterns
+- Common Tag Configurations (GA4 configuration tag, GA4 event tag, Facebook pixel)
+- Preview and Debug
+- Workspaces and Versioning
+- Consent Management
+- Advanced Patterns (tag sequencing, exception handling, custom JavaScript variables)
+
 ## Container Structure
 
 ### Tags

--- a/skills/competitor-alternatives/references/content-architecture.md
+++ b/skills/competitor-alternatives/references/content-architecture.md
@@ -2,6 +2,14 @@
 
 How to structure and maintain competitor data for scalable comparison pages.
 
+## Contents
+- Centralized Competitor Data
+- Competitor Data Template
+- Your Product Data
+- Page Generation
+- Index Page Structure (alternatives index, vs comparisons index, index page best practices)
+- Footer Navigation
+
 ## Centralized Competitor Data
 
 Create a single source of truth for each competitor:

--- a/skills/competitor-alternatives/references/templates.md
+++ b/skills/competitor-alternatives/references/templates.md
@@ -2,6 +2,17 @@
 
 Ready-to-use templates for each section of competitor comparison pages.
 
+## Contents
+- TL;DR Summary
+- Paragraph Comparison (Not Just Tables)
+- Feature Comparison Section
+- Pricing Comparison Section
+- Service & Support Comparison
+- Who It's For Section
+- Migration Section
+- Social Proof Section
+- Comparison Table Best Practices (beyond checkmarks, organize by category, include ratings where useful)
+
 ## TL;DR Summary
 
 Start every page with a quick summary for scanners:

--- a/skills/copy-editing/references/plain-english-alternatives.md
+++ b/skills/copy-editing/references/plain-english-alternatives.md
@@ -6,6 +6,24 @@ Source: Plain English Campaign A-Z of Alternative Words (2001), Australian Gover
 
 ---
 
+## Contents
+- A
+- B
+- C
+- D
+- E
+- F
+- G-H
+- I
+- L-M
+- N-O
+- P
+- R
+- S
+- T-U
+- V-Z
+- Phrases to Remove Entirely
+
 ## A
 
 | Complex | Plain Alternative |

--- a/skills/copywriting/references/copy-frameworks.md
+++ b/skills/copywriting/references/copy-frameworks.md
@@ -2,6 +2,12 @@
 
 Headline formulas, page section types, and structural templates.
 
+## Contents
+- Headline Formulas (outcome-focused, problem-focused, audience-focused, differentiation-focused, proof-focused, additional formulas)
+- Landing Page Section Types (core sections, supporting sections)
+- Page Structure Templates (feature-heavy page, varied engaging page, compact landing page, enterprise/B2B landing page, product launch page)
+- Section Writing Tips (problem section, benefits section, how it works section, testimonial selection)
+
 ## Headline Formulas
 
 ### Outcome-Focused

--- a/skills/copywriting/references/natural-transitions.md
+++ b/skills/copywriting/references/natural-transitions.md
@@ -6,6 +6,26 @@ Adapted from: University of Manchester Academic Phrasebank (2023), Plain English
 
 ---
 
+## Contents
+- Previewing Content Structure
+- Introducing a New Topic
+- Referring Back
+- Moving Between Sections
+- Indicating Addition
+- Indicating Contrast
+- Indicating Similarity
+- Indicating Cause and Effect
+- Giving Examples
+- Emphasising Key Points
+- Providing Evidence (neutral attribution, expert quotes, supporting claims)
+- Summarising Sections
+- Concluding Content
+- Question-Based Transitions
+- List Introductions
+- Hedging Language
+- Best Practice Guidelines
+- Transitions to Avoid (AI Tells)
+
 ## Previewing Content Structure
 
 Use to orient readers and set expectations:

--- a/skills/email-sequence/references/copy-guidelines.md
+++ b/skills/email-sequence/references/copy-guidelines.md
@@ -1,5 +1,15 @@
 # Email Copy Guidelines
 
+## Contents
+- Structure
+- Formatting
+- Tone
+- Length
+- CTA Buttons vs. Links
+- Personalization (merge fields, dynamic content, triggered emails)
+- Segmentation Strategies (by behavior, by stage, by profile)
+- Testing and Optimization (what to test, how to test, metrics to track)
+
 ## Structure
 
 1. **Hook**: First line grabs attention

--- a/skills/email-sequence/references/email-types.md
+++ b/skills/email-sequence/references/email-types.md
@@ -2,6 +2,15 @@
 
 A comprehensive guide to lifecycle and campaign emails. Use this as an audit checklist and implementation reference.
 
+## Contents
+- Onboarding Emails (new users series, new customers series, key onboarding step reminder, new user invite)
+- Retention Emails (upgrade to paid, upgrade to higher plan, ask for review, offer support proactively, product usage report, NPS survey, referral program)
+- Billing Emails (switch to annual, failed payment recovery, cancellation survey, upcoming renewal reminder)
+- Usage Emails (daily/weekly/monthly summary, key event or milestone notifications)
+- Win-Back Emails (expired trials, cancelled customers)
+- Campaign Emails (monthly roundup/newsletter, seasonal promotions, product updates, industry news roundup, pricing update)
+- Email Audit Checklist (onboarding, retention, billing, usage, win-back, campaigns)
+
 ## Onboarding Emails
 
 ### New Users Series

--- a/skills/email-sequence/references/sequence-templates.md
+++ b/skills/email-sequence/references/sequence-templates.md
@@ -2,6 +2,12 @@
 
 Detailed templates for common email sequences.
 
+## Contents
+- Welcome Sequence (Post-Signup)
+- Lead Nurture Sequence (Pre-Sale)
+- Re-Engagement Sequence
+- Onboarding Sequence (Product Users)
+
 ## Welcome Sequence (Post-Signup)
 
 **Email 1: Welcome (Immediate)**

--- a/skills/free-tool-strategy/references/tool-types.md
+++ b/skills/free-tool-strategy/references/tool-types.md
@@ -2,6 +2,15 @@
 
 Detailed guide to each type of marketing tool you can build.
 
+## Contents
+- Calculators
+- Generators
+- Analyzers/Auditors
+- Testers/Validators
+- Libraries/Resources
+- Interactive Educational
+- Tool Concept Examples by Industry (SaaS product, agency/services, e-commerce, developer tools, finance)
+
 ## Calculators
 
 **Best for**: Decisions involving numbers, comparisons, estimates

--- a/skills/marketing-ideas/references/ideas-by-category.md
+++ b/skills/marketing-ideas/references/ideas-by-category.md
@@ -2,6 +2,25 @@
 
 Complete list of proven marketing approaches organized by category.
 
+## Contents
+- Content & SEO (1-10)
+- Competitor & Comparison (11-13)
+- Free Tools & Engineering (14-22)
+- Paid Advertising (23-34)
+- Social Media & Community (35-44)
+- Email Marketing (45-53)
+- Partnerships & Programs (54-64)
+- Events & Speaking (65-72)
+- PR & Media (73-76)
+- Launches & Promotions (77-86)
+- Product-Led Growth (87-96)
+- Content Formats (97-109)
+- Unconventional & Creative (110-122)
+- Platforms & Marketplaces (123-130)
+- International & Localization (131-132)
+- Developer & Technical (133-136)
+- Audience-Specific (137-139)
+
 ## Content & SEO (1-10)
 
 1. **Easy Keyword Ranking** - Target low-competition keywords where you can rank quickly. Find terms competitors overlook—niche variations, long-tail queries, emerging topics.

--- a/skills/onboarding-cro/references/experiments.md
+++ b/skills/onboarding-cro/references/experiments.md
@@ -2,6 +2,16 @@
 
 Comprehensive list of A/B tests and experiments for user onboarding and activation.
 
+## Contents
+- Flow Simplification Experiments (reduce friction, step sequencing, progress & motivation)
+- Guided Experience Experiments (product tours, CTA optimization, UI guidance)
+- Personalization Experiments (user segmentation, dynamic content)
+- Quick Wins & Engagement Experiments (time-to-value, motivation mechanics, support & help)
+- Email & Multi-Channel Experiments (onboarding emails, email content, feedback loops)
+- Re-engagement Experiments (stalled user recovery, return experience)
+- Technical & UX Experiments (performance, mobile onboarding, accessibility)
+- Metrics to Track
+
 ## Flow Simplification Experiments
 
 ### Reduce Friction

--- a/skills/page-cro/references/experiments.md
+++ b/skills/page-cro/references/experiments.md
@@ -2,6 +2,15 @@
 
 Comprehensive list of A/B tests and experiments organized by page type.
 
+## Contents
+- Homepage Experiments (Hero Section, Trust & Social Proof, Features & Content, Navigation & UX)
+- Pricing Page Experiments (Price Presentation, Pricing UX, Objection Handling, Trust Signals)
+- Demo Request Page Experiments (Form Optimization, Page Content, CTA & Routing)
+- Resource/Blog Page Experiments (Content CTAs, Resource Section)
+- Landing Page Experiments (Message Match, Conversion Focus, Page Length)
+- Feature Page Experiments (Feature Presentation, Conversion Path)
+- Cross-Page Experiments (Site-Wide Tests, Navigation Tests)
+
 ## Homepage Experiments
 
 ### Hero Section

--- a/skills/paid-ads/references/ad-copy-templates.md
+++ b/skills/paid-ads/references/ad-copy-templates.md
@@ -2,6 +2,13 @@
 
 Detailed formulas and templates for writing high-converting ad copy.
 
+## Contents
+- Primary Text Formulas (Problem-Agitate-Solve, Before-After-Bridge, Social Proof Lead, Feature-Benefit Bridge, Direct Response)
+- Headline Formulas (For Search Ads, For Social Ads)
+- CTA Variations (Soft CTAs, Hard CTAs, Urgency CTAs, Action-Oriented CTAs)
+- Platform-Specific Copy Guidelines (Google Search Ads, Meta Ads, LinkedIn Ads)
+- Copy Testing Priority
+
 ## Primary Text Formulas
 
 ### Problem-Agitate-Solve (PAS)

--- a/skills/paid-ads/references/audience-targeting.md
+++ b/skills/paid-ads/references/audience-targeting.md
@@ -2,6 +2,15 @@
 
 Detailed targeting strategies for each major ad platform.
 
+## Contents
+- Google Ads Audiences (Search Campaign Targeting, Display/YouTube Targeting)
+- Meta Audiences (Core Audiences, Custom Audiences, Lookalike Audiences)
+- LinkedIn Audiences (Job-Based Targeting, Company-Based Targeting, High-Performing Combinations)
+- Twitter/X Audiences
+- TikTok Audiences
+- Audience Size Guidelines
+- Exclusion Strategy
+
 ## Google Ads Audiences
 
 ### Search Campaign Targeting

--- a/skills/paid-ads/references/platform-setup-checklists.md
+++ b/skills/paid-ads/references/platform-setup-checklists.md
@@ -2,6 +2,14 @@
 
 Complete setup checklists for major ad platforms.
 
+## Contents
+- Google Ads Setup (Account Foundation, Conversion Tracking, Analytics Integration, Audience Setup, Campaign Readiness, Ad Extensions, Brand Protection)
+- Meta Ads Setup (Business Manager Foundation, Pixel & Tracking, Domain & Aggregated Events, Audience Setup, Catalog, Creative Assets, Compliance)
+- LinkedIn Ads Setup (Campaign Manager Foundation, Insight Tag & Tracking, Audience Setup, Lead Gen Forms, Document Ads, Creative Assets, Budget Considerations)
+- Twitter/X Ads Setup (Account Foundation, Tracking, Audience Setup, Creative)
+- TikTok Ads Setup (Account Foundation, Pixel & Tracking, Audience Setup, Creative)
+- Universal Pre-Launch Checklist
+
 ## Google Ads Setup
 
 ### Account Foundation

--- a/skills/paywall-upgrade-cro/references/experiments.md
+++ b/skills/paywall-upgrade-cro/references/experiments.md
@@ -2,6 +2,15 @@
 
 Comprehensive list of A/B tests and experiments for paywall optimization.
 
+## Contents
+- Trigger & Timing Experiments (When to Show, Trigger Type)
+- Paywall Design Experiments (Layout & Format, Value Presentation, Visual Elements)
+- Pricing Presentation Experiments (Price Display, Plan Options, Discounts & Offers)
+- Copy & Messaging Experiments (Headlines, CTAs, Objection Handling)
+- Trial & Conversion Experiments (Trial Structure, Trial Expiration, Upgrade Path)
+- Personalization Experiments (Usage-Based, Segment-Specific)
+- Frequency & UX Experiments (Frequency Capping, Dismiss Behavior)
+
 ## Trigger & Timing Experiments
 
 ### When to Show

--- a/skills/pricing-strategy/references/research-methods.md
+++ b/skills/pricing-strategy/references/research-methods.md
@@ -1,5 +1,11 @@
 # Pricing Research Methods
 
+## Contents
+- Van Westendorp Price Sensitivity Meter (The Four Questions, How to Analyze, Survey Tips, Sample Output)
+- MaxDiff Analysis (How It Works, Example Survey Question, Analyzing Results, Using MaxDiff for Packaging)
+- Willingness to Pay Surveys
+- Usage-Value Correlation Analysis
+
 ## Van Westendorp Price Sensitivity Meter
 
 The Van Westendorp survey identifies the acceptable price range for your product.

--- a/skills/pricing-strategy/references/tier-structure.md
+++ b/skills/pricing-strategy/references/tier-structure.md
@@ -1,5 +1,14 @@
 # Tier Structure and Packaging
 
+## Contents
+- How Many Tiers?
+- Good-Better-Best Framework
+- Tier Differentiation Strategies
+- Example Tier Structure
+- Packaging for Personas (Identifying Pricing Personas, Persona-Based Packaging)
+- Freemium vs. Free Trial (When to Use Freemium, When to Use Free Trial, Hybrid Approaches)
+- Enterprise Pricing (When to Add Custom Pricing, Enterprise Tier Elements, Enterprise Pricing Strategies)
+
 ## How Many Tiers?
 
 **2 tiers:** Simple, clear choice

--- a/skills/programmatic-seo/references/playbooks.md
+++ b/skills/programmatic-seo/references/playbooks.md
@@ -2,6 +2,21 @@
 
 Beyond mixing and matching data point permutations, these are the proven playbooks for programmatic SEO.
 
+## Contents
+- 1. Templates
+- 2. Curation
+- 3. Conversions
+- 4. Comparisons
+- 5. Examples
+- 6. Locations
+- 7. Personas
+- 8. Integrations
+- 9. Glossary
+- 10. Translations
+- 11. Directory
+- 12. Profiles
+- Choosing Your Playbook (Match to Your Assets, Combine Playbooks)
+
 ## 1. Templates
 
 **Pattern**: "[Type] template" or "free [type] template"

--- a/skills/referral-program/references/affiliate-programs.md
+++ b/skills/referral-program/references/affiliate-programs.md
@@ -2,6 +2,14 @@
 
 Detailed guidance for building and managing affiliate programs.
 
+## Contents
+- Commission Structures
+- Cookie Duration
+- Affiliate Recruitment
+- Affiliate Enablement
+- Tools & Platforms (Referral Program Tools, Affiliate Program Tools, Choosing a Tool)
+- Fraud Prevention (Common Referral Fraud, Prevention Measures)
+
 ## Commission Structures
 
 **Percentage of sale:**

--- a/skills/referral-program/references/program-examples.md
+++ b/skills/referral-program/references/program-examples.md
@@ -2,6 +2,15 @@
 
 Real-world examples of successful referral programs.
 
+## Contents
+- Dropbox (Classic)
+- Uber/Lyft
+- Morning Brew
+- Notion
+- Incentive Types Comparison
+- Incentive Sizing Framework
+- Viral Coefficient & Metrics (Key Metrics, Calculating Referral Program ROI)
+
 ## Dropbox (Classic)
 
 **Program:** Give 500MB storage, get 500MB storage

--- a/skills/schema-markup/references/schema-examples.md
+++ b/skills/schema-markup/references/schema-examples.md
@@ -2,6 +2,20 @@
 
 Complete JSON-LD examples for common schema types.
 
+## Contents
+- Organization
+- WebSite (with SearchAction)
+- Article / BlogPosting
+- Product
+- SoftwareApplication
+- FAQPage
+- HowTo
+- BreadcrumbList
+- LocalBusiness
+- Event
+- Multiple Schema Types
+- Implementation Example (Next.js)
+
 ## Organization
 
 For company/brand homepage or about page.

--- a/skills/seo-audit/references/aeo-geo-patterns.md
+++ b/skills/seo-audit/references/aeo-geo-patterns.md
@@ -4,6 +4,12 @@ Reusable content block patterns optimized for answer engines and AI citation.
 
 ---
 
+## Contents
+- Answer Engine Optimization (AEO) Patterns (Definition Block, Step-by-Step Block, Comparison Table Block, Pros and Cons Block, FAQ Block, Listicle Block)
+- Generative Engine Optimization (GEO) Patterns (Statistic Citation Block, Expert Quote Block, Authoritative Claim Block, Self-Contained Answer Block, Evidence Sandwich Block)
+- Domain-Specific GEO Tactics (Technology Content, Health/Medical Content, Financial Content, Legal Content, Business/Marketing Content)
+- Voice Search Optimization (Question Formats for Voice, Voice-Optimized Answer Structure)
+
 ## Answer Engine Optimization (AEO) Patterns
 
 These patterns help content appear in featured snippets, AI Overviews, voice search results, and answer boxes.

--- a/skills/seo-audit/references/ai-writing-detection.md
+++ b/skills/seo-audit/references/ai-writing-detection.md
@@ -6,6 +6,16 @@ Sources: Grammarly (2025), Microsoft 365 Life Hacks (2025), GPTHuman (2025), Wal
 
 ---
 
+## Contents
+- Em Dashes: The Primary AI Tell
+- Overused Verbs
+- Overused Adjectives
+- Overused Transitions and Connectors
+- Phrases That Signal AI Writing (Opening Phrases, Transitional Phrases, Concluding Phrases, Structural Patterns)
+- Filler Words and Empty Intensifiers
+- Academic-Specific AI Tells
+- How to Self-Check
+
 ## Em Dashes: The Primary AI Tell
 
 **The em dash (—) has become one of the most reliable markers of AI-generated content.**

--- a/skills/social-content/references/platforms.md
+++ b/skills/social-content/references/platforms.md
@@ -2,6 +2,13 @@
 
 Detailed strategies for each major social platform.
 
+## Contents
+- LinkedIn
+- Twitter/X
+- Instagram
+- TikTok
+- Facebook
+
 ## LinkedIn
 
 **Best for:** B2B, thought leadership, professional networking, recruiting

--- a/skills/social-content/references/post-templates.md
+++ b/skills/social-content/references/post-templates.md
@@ -2,6 +2,12 @@
 
 Ready-to-use templates for different platforms and content types.
 
+## Contents
+- LinkedIn Post Templates (The Story Post, The Contrarian Take, The List Post, The How-To)
+- Twitter/X Thread Templates (The Tutorial Thread, The Story Thread, The Breakdown Thread)
+- Instagram Templates (The Carousel Hook, The Reel Script)
+- Hook Formulas (Curiosity Hooks, Story Hooks, Value Hooks, Contrarian Hooks, Social Proof Hooks)
+
 ## LinkedIn Post Templates
 
 ### The Story Post

--- a/skills/social-content/references/reverse-engineering.md
+++ b/skills/social-content/references/reverse-engineering.md
@@ -2,6 +2,11 @@
 
 Instead of guessing what works, systematically analyze top-performing content in your niche and extract proven patterns.
 
+## Contents
+- The 6-Step Framework (Niche ID, Scrape, Analyze, Playbook, Layer Voice, Convert)
+- The Formula
+- Reverse Engineering Checklist
+
 ## The 6-Step Framework
 
 ### 1. NICHE ID — Find Top Creators


### PR DESCRIPTION
- Add `## Contents` table of contents to all 32 reference files
 - Per Anthropic's [Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#structure-longer-reference-files-with-table-of-contents), reference files over 100 lines should include a TOC
   so Claude can see the full scope when previewing with partial reads
 - Pure additions (312 lines), no existing content modified