### PR TITLE
seo-audit: Add warning about web_fetch unable to detect JS-rendered schema markup

### DIFF
--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -34,6 +34,19 @@ Before auditing, understand:
 
 ## Audit Framework
 
+### ⚠️ Important: Schema Markup Detection Limitation
+
+**`web_fetch` and `curl` cannot reliably detect structured data / schema markup.**
+
+Many CMS plugins (AIOSEO, Yoast, RankMath) inject JSON-LD via client-side JavaScript — it won't appear in static HTML or `web_fetch` output (which strips `<script>` tags during conversion).
+
+**To accurately check for schema markup, use one of these methods:**
+1. **Browser tool** — render the page and run: `document.querySelectorAll('script[type="application/ld+json"]')`
+2. **Google Rich Results Test** — https://search.google.com/test/rich-results
+3. **Screaming Frog export** — if the client provides one, use it (SF renders JavaScript)
+
+**Never report "no schema found" based solely on `web_fetch` or `curl`.** This has led to false audit findings in production.
+
 ### Priority Order
 1. **Crawlability & Indexation** (can Google find and index it?)
 2. **Technical Foundations** (is the site fast and functional?)
@@ -364,9 +377,11 @@ Same format as above
 - Google Search Console (essential)
 - Google PageSpeed Insights
 - Bing Webmaster Tools
-- Rich Results Test
+- Rich Results Test (**use this for schema validation — it renders JavaScript**)
 - Mobile-Friendly Test
 - Schema Validator
+
+> **Note on schema detection:** `web_fetch` strips `<script>` tags (including JSON-LD) and cannot detect JS-injected schema. Always use the browser tool, Rich Results Test, or Screaming Frog for schema checks. See the warning at the top of the Audit Framework section.
 
 **Paid Tools** (if available)
 - Screaming Frog


### PR DESCRIPTION
## Problem

`web_fetch` strips `<script>` tags during HTML→markdown conversion, which silently discards JSON-LD schema blocks. Additionally, many CMS plugins (AIOSEO, Yoast, RankMath) inject schema via client-side JavaScript, making it invisible to both `web_fetch` and `curl`.

## Real-world impact

We ran an automated SEO audit on a client site (noladetox.com) using this skill. The audit reported **"zero structured data / schema markup on the entire site."** The site actually has Organization, Article, BreadcrumbList, LocalBusiness, FAQPage, and more — all injected via AIOSEO.

This led to an incorrect audit finding that had to be manually corrected after the client validated with Google Rich Results Test and Screaming Frog.

## Changes

1. Added a **⚠️ Important** warning section in the Audit Framework, before the Priority Order, explaining the limitation and listing reliable alternatives (browser tool, Rich Results Test, Screaming Frog)
2. Added a note in the **Tools Referenced** section highlighting that Rich Results Test renders JavaScript and should be used for schema validation

## Related

- OpenClaw issue: https://github.com/openclaw/openclaw/issues/17137 (requesting web_fetch preserve JSON-LD)

Thanks for the great skills library — this is a small but important accuracy fix for anyone doing SEO audits with AI agents.