### PR TITLE
feat: add marketing-index skill for quick skill discovery

### DIFF
--- a/skills/marketing-index/SKILL.md
+++ b/skills/marketing-index/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: marketing-index
+description: Use when the user wants to see available marketing skills, needs help choosing which marketing skill to use, or asks about marketing capabilities. Also use when you are unsure which marketing skill applies to a task.
+---
+
+# Marketing Skills Index
+
+**When this skill is invoked, display the full table below to the user.** Then ask which skill they'd like to use, or if they need help choosing.
+
+## Conversion Optimization
+
+| Skill | Description |
+|-------|-------------|
+| page-cro | When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing... |
+| signup-flow-cro | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
+| onboarding-cro | When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also... |
+| form-cro | When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms,... |
+| popup-cro | When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also... |
+| paywall-upgrade-cro | When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use... |
+
+## Content & Copy
+
+| Skill | Description |
+|-------|-------------|
+| copywriting | When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages,... |
+| copy-editing | When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this... |
+| cold-email | Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails,... |
+| email-sequence | When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email... |
+| social-content | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
+
+## SEO & Discovery
+
+| Skill | Description |
+|-------|-------------|
+| seo-audit | When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO... |
+| ai-seo | When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers.... |
+| programmatic-seo | When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions... |
+| competitor-alternatives | When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when... |
+| schema-markup | When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user... |
+
+## Paid & Distribution
+
+| Skill | Description |
+|-------|-------------|
+| paid-ads | When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X,... |
+| ad-creative | When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad... |
+
+## Measurement & Testing
+
+| Skill | Description |
+|-------|-------------|
+| analytics-tracking | When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions... |
+| ab-test-setup | When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions "A/B... |
+
+## Retention
+
+| Skill | Description |
+|-------|-------------|
+| churn-prevention | When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or... |
+
+## Growth Engineering
+
+| Skill | Description |
+|-------|-------------|
+| free-tool-strategy | When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or... |
+| referral-program | When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy.... |
+
+## Strategy & Monetization
+
+| Skill | Description |
+|-------|-------------|
+| marketing-ideas | When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the... |
+| marketing-psychology | When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when... |
+| launch-strategy | When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user... |
+| pricing-strategy | When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions... |
+| product-marketing-context | When the user wants to create or update their product marketing context document. Also use when the user mentions... |


### PR DESCRIPTION
## Summary

- Adds a `marketing-index` skill that displays a categorized table of all available marketing skills when invoked with `/marketing-index`
- Uses the same category groupings from the README (Conversion Optimization, Content & Copy, SEO & Discovery, etc.)
- Helps users quickly find the right skill for their task without leaving the terminal

## Motivation

With 29 skills installed, it's not always obvious which one to reach for. This gives users a quick-reference directory they can invoke anytime. It's additive — doesn't change any existing skills or structure.

## Test plan

- [ ] Install skill and invoke with `/marketing-index`
- [ ] Verify all 29 skills are listed with correct descriptions
- [ ] Verify categories match the README's Skill Categories section
- [ ] Confirm `validate-skill` CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)