### PR TITLE
Add site-architecture skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "29 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, and more",
+      "description": "30 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, and more",
       "source": "./",
       "strict": false,
       "skills": [
@@ -44,6 +44,7 @@
         "./skills/schema-markup",
         "./skills/seo-audit",
         "./skills/signup-flow-cro",
+        "./skills/site-architecture",
         "./skills/social-content"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Skills are markdown files that give AI agents specialized knowledge and workflow
 | [schema-markup](skills/schema-markup/) | When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user... |
 | [seo-audit](skills/seo-audit/) | When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO... |
 | [signup-flow-cro](skills/signup-flow-cro/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
+| [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
 | [social-content](skills/social-content/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
 <!-- SKILLS:END -->
 
@@ -166,6 +167,7 @@ You can also invoke skills directly:
 - `seo-audit` - Technical and on-page SEO
 - `ai-seo` - AI search optimization (AEO, GEO, LLMO)
 - `programmatic-seo` - Scaled page generation
+- `site-architecture` - Page hierarchy, navigation, URL structure
 - `competitor-alternatives` - Comparison and alternative pages
 - `schema-markup` - Structured data
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -32,9 +32,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | schema-markup | 1.0.0 | 2026-01-27 |
 | seo-audit | 1.0.0 | 2026-01-27 |
 | signup-flow-cro | 1.0.0 | 2026-01-27 |
+| site-architecture | 1.0.0 | 2026-02-21 |
 | social-content | 1.0.0 | 2026-01-27 |
 
 ## Recent Changes
+
+### 2026-02-21
+- Added `site-architecture` skill for website structure planning, page hierarchy, navigation design, URL structure, and internal linking strategy
 
 ### 2026-02-18
 - Added `ai-seo` skill for AI search optimization (AEO, GEO, LLMO, AI Overviews)

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -354,5 +354,6 @@ Visual or structured representation of how content interconnects.
 - **seo-audit**: For technical SEO and on-page optimization
 - **ai-seo**: For optimizing content for AI search engines and getting cited by LLMs
 - **programmatic-seo**: For scaled content generation
+- **site-architecture**: For page hierarchy, navigation design, and URL structure
 - **email-sequence**: For email-based content
 - **social-content**: For social media content

--- a/skills/programmatic-seo/SKILL.md
+++ b/skills/programmatic-seo/SKILL.md
@@ -234,4 +234,5 @@ Watch for: Thin content warnings, Ranking drops, Manual actions, Crawl errors
 
 - **seo-audit**: For auditing programmatic pages after launch
 - **schema-markup**: For adding structured data
+- **site-architecture**: For page hierarchy, URL structure, and internal linking
 - **competitor-alternatives**: For comparison page frameworks

--- a/skills/schema-markup/SKILL.md
+++ b/skills/schema-markup/SKILL.md
@@ -176,3 +176,4 @@ You can combine multiple schema types on one page using `@graph`:
 - **seo-audit**: For overall SEO including schema review
 - **ai-seo**: For AI search optimization (schema helps AI understand content)
 - **programmatic-seo**: For templated schema at scale
+- **site-architecture**: For breadcrumb structure and navigation schema planning

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -406,6 +406,7 @@ Same format as above
 
 - **ai-seo**: For optimizing content for AI search engines (AEO, GEO, LLMO)
 - **programmatic-seo**: For building SEO pages at scale
+- **site-architecture**: For page hierarchy, navigation design, and URL structure
 - **schema-markup**: For implementing structured data
 - **page-cro**: For optimizing pages for conversion (not just ranking)
 - **analytics-tracking**: For measuring SEO performance

--- a/skills/site-architecture/SKILL.md
+++ b/skills/site-architecture/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: site-architecture
+description: When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal linking. Also use when the user mentions "sitemap," "site map," "visual sitemap," "site structure," "page hierarchy," "information architecture," "IA," "navigation design," "URL structure," "breadcrumbs," "internal linking strategy," or "website planning." NOT for XML sitemaps (that's technical SEO — see seo-audit). For SEO audits, see seo-audit. For structured data, see schema-markup.
+metadata:
+  version: 1.0.0
+---
+
+# Site Architecture
+
+You are an information architecture expert. Your goal is to help plan website structure — page hierarchy, navigation, URL patterns, and internal linking — so the site is intuitive for users and optimized for search engines.
+
+## Before Planning
+
+**Check for product marketing context first:**
+If `.claude/product-marketing-context.md` exists, read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Business Context
+- What does the company do?
+- Who are the primary audiences?
+- What are the top 3 goals for the site? (conversions, SEO traffic, education, support)
+
+### 2. Current State
+- New site or restructuring an existing one?
+- If restructuring: what's broken? (high bounce, poor SEO, users can't find things)
+- Existing URLs that must be preserved (for redirects)?
+
+### 3. Site Type
+- SaaS marketing site
+- Content/blog site
+- E-commerce
+- Documentation
+- Hybrid (SaaS + content)
+- Small business / local
+
+### 4. Content Inventory
+- How many pages exist or are planned?
+- What are the most important pages? (by traffic, conversions, or business value)
+- Any planned sections or expansions?
+
+---
+
+## Site Types and Starting Points
+
+| Site Type | Typical Depth | Key Sections | URL Pattern |
+|-----------|--------------|--------------|-------------|
+| SaaS marketing | 2-3 levels | Home, Features, Pricing, Blog, Docs | `/features/name`, `/blog/slug` |
+| Content/blog | 2-3 levels | Home, Blog, Categories, About | `/blog/slug`, `/category/slug` |
+| E-commerce | 3-4 levels | Home, Categories, Products, Cart | `/category/subcategory/product` |
+| Documentation | 3-4 levels | Home, Guides, API Reference | `/docs/section/page` |
+| Hybrid SaaS+content | 3-4 levels | Home, Product, Blog, Resources, Docs | `/product/feature`, `/blog/slug` |
+| Small business | 1-2 levels | Home, Services, About, Contact | `/services/name` |
+
+**For full page hierarchy templates**: See [references/site-type-templates.md](references/site-type-templates.md)
+
+---
+
+## Page Hierarchy Design
+
+### The 3-Click Rule
+
+Users should reach any important page within 3 clicks from the homepage. This isn't absolute, but if critical pages are buried 4+ levels deep, something is wrong.
+
+### Flat vs Deep
+
+| Approach | Best For | Tradeoff |
+|----------|----------|----------|
+| Flat (2 levels) | Small sites, portfolios | Simple but doesn't scale |
+| Moderate (3 levels) | Most SaaS, content sites | Good balance of depth and findability |
+| Deep (4+ levels) | E-commerce, large docs | Scales but risks burying content |
+
+**Rule of thumb**: Go as flat as possible while keeping navigation clean. If a nav dropdown has 20+ items, add a level of hierarchy.
+
+### Hierarchy Levels
+
+| Level | What It Is | Example |
+|-------|-----------|---------|
+| L0 | Homepage | `/` |
+| L1 | Primary sections | `/features`, `/blog`, `/pricing` |
+| L2 | Section pages | `/features/analytics`, `/blog/seo-guide` |
+| L3+ | Detail pages | `/docs/api/authentication` |
+
+### ASCII Tree Format
+
+Use this format for page hierarchies:
+
+```
+Homepage (/)
+├── Features (/features)
+│   ├── Analytics (/features/analytics)
+│   ├── Automation (/features/automation)
+│   └── Integrations (/features/integrations)
+├── Pricing (/pricing)
+├── Blog (/blog)
+│   ├── [Category: SEO] (/blog/category/seo)
+│   └── [Category: CRO] (/blog/category/cro)
+├── Resources (/resources)
+│   ├── Case Studies (/resources/case-studies)
+│   └── Templates (/resources/templates)
+├── Docs (/docs)
+│   ├── Getting Started (/docs/getting-started)
+│   └── API Reference (/docs/api)
+├── About (/about)
+│   └── Careers (/about/careers)
+└── Contact (/contact)
+```
+
+**When to use ASCII vs Mermaid**:
+- ASCII: quick hierarchy drafts, text-only contexts, simple structures
+- Mermaid: visual presentations, complex relationships, showing nav zones or linking patterns
+
+---
+
+## Navigation Design
+
+### Navigation Types
+
+| Nav Type | Purpose | Placement |
+|----------|---------|-----------|
+| Header nav | Primary navigation, always visible | Top of every page |
+| Dropdown menus | Organize sub-pages under parent | Expands from header items |
+| Footer nav | Secondary links, legal, sitemap | Bottom of every page |
+| Sidebar nav | Section navigation (docs, blog) | Left side within a section |
+| Breadcrumbs | Show current location in hierarchy | Below header, above content |
+| Contextual links | Related content, next steps | Within page content |
+
+### Header Navigation Rules
+
+- **4-7 items max** in the primary nav (more causes decision paralysis)
+- **CTA button** goes rightmost (e.g., "Start Free Trial," "Get Started")
+- **Logo** links to homepage (left side)
+- **Order by priority**: most important/visited pages first
+- If you have a mega menu, limit to 3-4 columns
+
+### Footer Organization
+
+Group footer links into columns:
+- **Product**: Features, Pricing, Integrations, Changelog
+- **Resources**: Blog, Case Studies, Templates, Docs
+- **Company**: About, Careers, Contact, Press
+- **Legal**: Privacy, Terms, Security
+
+### Breadcrumb Format
+
+```
+Home > Features > Analytics
+Home > Blog > SEO Category > Post Title
+```
+
+Breadcrumbs should mirror the URL hierarchy. Every breadcrumb segment should be a clickable link except the current page.
+
+**For detailed navigation patterns**: See [references/navigation-patterns.md](references/navigation-patterns.md)
+
+---
+
+## URL Structure
+
+### Design Principles
+
+1. **Readable by humans** — `/features/analytics` not `/f/a123`
+2. **Hyphens, not underscores** — `/blog/seo-guide` not `/blog/seo_guide`
+3. **Reflect the hierarchy** — URL path should match site structure
+4. **Consistent trailing slash policy** — pick one (with or without) and enforce it
+5. **Lowercase always** — `/About` should redirect to `/about`
+6. **Short but descriptive** — `/blog/how-to-improve-landing-page-conversion-rates` is too long; `/blog/landing-page-conversions` is better
+
+### URL Patterns by Page Type
+
+| Page Type | Pattern | Example |
+|-----------|---------|---------|
+| Homepage | `/` | `example.com` |
+| Feature page | `/features/{name}` | `/features/analytics` |
+| Pricing | `/pricing` | `/pricing` |
+| Blog post | `/blog/{slug}` | `/blog/seo-guide` |
+| Blog category | `/blog/category/{slug}` | `/blog/category/seo` |
+| Case study | `/customers/{slug}` | `/customers/acme-corp` |
+| Documentation | `/docs/{section}/{page}` | `/docs/api/authentication` |
+| Legal | `/{page}` | `/privacy`, `/terms` |
+| Landing page | `/{slug}` or `/lp/{slug}` | `/free-trial`, `/lp/webinar` |
+| Comparison | `/compare/{competitor}` or `/vs/{competitor}` | `/compare/competitor-name` |
+| Integration | `/integrations/{name}` | `/integrations/slack` |
+| Template | `/templates/{slug}` | `/templates/marketing-plan` |
+
+### Common Mistakes
+
+- **Dates in blog URLs** — `/blog/2024/01/15/post-title` adds no value and makes URLs long. Use `/blog/post-title`.
+- **Over-nesting** — `/products/category/subcategory/item/detail` is too deep. Flatten where possible.
+- **Changing URLs without redirects** — Every old URL must 301 redirect to its new URL. No exceptions.
+- **IDs in URLs** — `/product/12345` is not human-readable. Use slugs.
+- **Query parameters for content** — `/blog?id=123` should be `/blog/post-title`.
+- **Inconsistent patterns** — Don't mix `/features/analytics` and `/product/automation`. Pick one parent.
+
+### Breadcrumb-URL Alignment
+
+The breadcrumb trail should mirror the URL path:
+
+| URL | Breadcrumb |
+|-----|-----------|
+| `/features/analytics` | Home > Features > Analytics |
+| `/blog/seo-guide` | Home > Blog > SEO Guide |
+| `/docs/api/auth` | Home > Docs > API > Authentication |
+
+---
+
+## Visual Sitemap Output (Mermaid)
+
+Use Mermaid `graph TD` for visual sitemaps. This makes hierarchy relationships clear and can annotate navigation zones.
+
+### Basic Hierarchy
+
+```mermaid
+graph TD
+    HOME[Homepage] --> FEAT[Features]
+    HOME --> PRICE[Pricing]
+    HOME --> BLOG[Blog]
+    HOME --> ABOUT[About]
+
+    FEAT --> F1[Analytics]
+    FEAT --> F2[Automation]
+    FEAT --> F3[Integrations]
+
+    BLOG --> B1[Post 1]
+    BLOG --> B2[Post 2]
+```
+
+### With Navigation Zones
+
+```mermaid
+graph TD
+    subgraph Header Nav
+        HOME[Homepage]
+        FEAT[Features]
+        PRICE[Pricing]
+        BLOG[Blog]
+        CTA[Get Started]
+    end
+
+    subgraph Footer Nav
+        ABOUT[About]
+        CAREERS[Careers]
+        CONTACT[Contact]
+        PRIVACY[Privacy]
+    end
+
+    HOME --> FEAT
+    HOME --> PRICE
+    HOME --> BLOG
+    HOME --> ABOUT
+
+    FEAT --> F1[Analytics]
+    FEAT --> F2[Automation]
+```
+
+**For more Mermaid templates**: See [references/mermaid-templates.md](references/mermaid-templates.md)
+
+---
+
+## Internal Linking Strategy
+
+### Link Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| Navigational | Move between sections | Header, footer, sidebar links |
+| Contextual | Related content within text | "Learn more about [analytics](/features/analytics)" |
+| Hub-and-spoke | Connect cluster content to hub | Blog posts linking to pillar page |
+| Cross-section | Connect related pages across sections | Feature page linking to related case study |
+
+### Internal Linking Rules
+
+1. **No orphan pages** — every page must have at least one internal link pointing to it
+2. **Descriptive anchor text** — "our analytics features" not "click here"
+3. **5-10 internal links per 1000 words** of content (approximate guideline)
+4. **Link to important pages more often** — homepage, key feature pages, pricing
+5. **Use breadcrumbs** — free internal links on every page
+6. **Related content sections** — "Related Posts" or "You might also like" at page bottom
+
+### Hub-and-Spoke Model
+
+For content-heavy sites, organize around hub pages:
+
+```
+Hub: /blog/seo-guide (comprehensive overview)
+├── Spoke: /blog/keyword-research (links back to hub)
+├── Spoke: /blog/on-page-seo (links back to hub)
+├── Spoke: /blog/technical-seo (links back to hub)
+└── Spoke: /blog/link-building (links back to hub)
+```
+
+Each spoke links back to the hub. The hub links to all spokes. Spokes link to each other where relevant.
+
+### Link Audit Checklist
+
+- [ ] Every page has at least one inbound internal link
+- [ ] No broken internal links (404s)
+- [ ] Anchor text is descriptive (not "click here" or "read more")
+- [ ] Important pages have the most inbound internal links
+- [ ] Breadcrumbs are implemented on all pages
+- [ ] Related content links exist on blog posts
+- [ ] Cross-section links connect features to case studies, blog to product pages
+
+---
+
+## Output Format
+
+When creating a site architecture plan, provide these deliverables:
+
+### 1. Page Hierarchy (ASCII Tree)
+Full site structure with URLs at each node. Use the ASCII tree format from the Page Hierarchy Design section.
+
+### 2. Visual Sitemap (Mermaid)
+Mermaid diagram showing page relationships and navigation zones. Use `graph TD` with subgraphs for nav zones where helpful.
+
+### 3. URL Map Table
+
+| Page | URL | Parent | Nav Location | Priority |
+|------|-----|--------|-------------|----------|
+| Homepage | `/` | — | Header | High |
+| Features | `/features` | Homepage | Header | High |
+| Analytics | `/features/analytics` | Features | Header dropdown | Medium |
+| Pricing | `/pricing` | Homepage | Header | High |
+| Blog | `/blog` | Homepage | Header | Medium |
+
+### 4. Navigation Spec
+- Header nav items (ordered, with CTA)
+- Footer sections and links
+- Sidebar nav (if applicable)
+- Breadcrumb implementation notes
+
+### 5. Internal Linking Plan
+- Hub pages and their spokes
+- Cross-section link opportunities
+- Orphan page audit (if restructuring)
+- Recommended links per key page
+
+---
+
+## Task-Specific Questions
+
+1. Is this a new site or are you restructuring an existing one?
+2. What type of site is it? (SaaS, content, e-commerce, docs, hybrid, small business)
+3. How many pages exist or are planned?
+4. What are the 5 most important pages on the site?
+5. Are there existing URLs that need to be preserved or redirected?
+6. Who are the primary audiences, and what are they trying to accomplish on the site?
+
+---
+
+## Related Skills
+
+- **content-strategy**: For planning what content to create and topic clusters
+- **programmatic-seo**: For building SEO pages at scale with templates and data
+- **seo-audit**: For technical SEO, on-page optimization, and indexation issues
+- **page-cro**: For optimizing individual pages for conversion
+- **schema-markup**: For implementing breadcrumb and site navigation structured data
+- **competitor-alternatives**: For comparison page frameworks and URL patterns

--- a/skills/site-architecture/references/mermaid-templates.md
+++ b/skills/site-architecture/references/mermaid-templates.md
@@ -1,0 +1,216 @@
+# Mermaid Diagram Templates
+
+Copy-paste-ready Mermaid diagrams for visual sitemaps. Customize node labels and connections for your site.
+
+---
+
+## Basic Hierarchy
+
+Simple top-down page hierarchy.
+
+```mermaid
+graph TD
+    HOME["Homepage<br/>/"] --> FEAT["Features<br/>/features"]
+    HOME --> PRICE["Pricing<br/>/pricing"]
+    HOME --> BLOG["Blog<br/>/blog"]
+    HOME --> ABOUT["About<br/>/about"]
+
+    FEAT --> F1["Analytics<br/>/features/analytics"]
+    FEAT --> F2["Automation<br/>/features/automation"]
+    FEAT --> F3["Integrations<br/>/features/integrations"]
+
+    BLOG --> B1["Post: SEO Guide<br/>/blog/seo-guide"]
+    BLOG --> B2["Post: CRO Tips<br/>/blog/cro-tips"]
+```
+
+---
+
+## Hierarchy with Navigation Zones
+
+Uses subgraphs to show which pages appear in which navigation area.
+
+```mermaid
+graph TD
+    subgraph "Header Nav"
+        HOME["Homepage"]
+        FEAT["Features"]
+        PRICE["Pricing"]
+        BLOG["Blog"]
+        CTA["Get Started ★"]
+    end
+
+    subgraph "Feature Pages"
+        F1["Analytics"]
+        F2["Automation"]
+        F3["Integrations"]
+    end
+
+    subgraph "Footer Nav"
+        ABOUT["About"]
+        CAREERS["Careers"]
+        CONTACT["Contact"]
+        PRIVACY["Privacy"]
+        TERMS["Terms"]
+    end
+
+    HOME --> FEAT
+    HOME --> PRICE
+    HOME --> BLOG
+    FEAT --> F1
+    FEAT --> F2
+    FEAT --> F3
+    HOME --> ABOUT
+    ABOUT --> CAREERS
+    HOME --> CONTACT
+```
+
+---
+
+## Hierarchy with URL Labels
+
+Each node shows the page name and URL path.
+
+```mermaid
+graph TD
+    HOME["Homepage<br/><small>/</small>"] --> PROD["Product<br/><small>/product</small>"]
+    HOME --> PRICE["Pricing<br/><small>/pricing</small>"]
+    HOME --> BLOG["Blog<br/><small>/blog</small>"]
+    HOME --> DOCS["Docs<br/><small>/docs</small>"]
+    HOME --> ABOUT["About<br/><small>/about</small>"]
+
+    PROD --> P1["Analytics<br/><small>/product/analytics</small>"]
+    PROD --> P2["Reports<br/><small>/product/reports</small>"]
+
+    DOCS --> D1["Getting Started<br/><small>/docs/getting-started</small>"]
+    DOCS --> D2["API Reference<br/><small>/docs/api</small>"]
+```
+
+---
+
+## Hub-and-Spoke Content Model
+
+Shows a hub page connected to spoke articles, with spokes linking to each other.
+
+```mermaid
+graph TD
+    HUB["SEO Guide<br/>(Hub Page)"]
+
+    HUB --> S1["Keyword Research"]
+    HUB --> S2["On-Page SEO"]
+    HUB --> S3["Technical SEO"]
+    HUB --> S4["Link Building"]
+
+    S1 -.-> S2
+    S2 -.-> S3
+    S3 -.-> S4
+
+    style HUB fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+Legend:
+- Solid lines = primary hub-spoke links
+- Dashed lines = cross-links between spokes
+
+---
+
+## Internal Linking Flow
+
+Shows how different site sections link to each other.
+
+```mermaid
+graph LR
+    subgraph "Marketing"
+        HOME["Homepage"]
+        FEAT["Features"]
+        PRICE["Pricing"]
+    end
+
+    subgraph "Content"
+        BLOG["Blog"]
+        GUIDE["Guides"]
+        CASE["Case Studies"]
+    end
+
+    subgraph "Product"
+        DOCS["Docs"]
+        API["API Ref"]
+        CHANGE["Changelog"]
+    end
+
+    BLOG --> FEAT
+    BLOG --> CASE
+    CASE --> FEAT
+    CASE --> PRICE
+    FEAT --> DOCS
+    GUIDE --> BLOG
+    GUIDE --> DOCS
+    HOME --> FEAT
+    HOME --> BLOG
+    HOME --> CASE
+```
+
+---
+
+## Before/After Restructuring
+
+Compare current and proposed site structures side by side.
+
+```mermaid
+graph TD
+    subgraph "Before"
+        B_HOME["Homepage"] --> B_P1["Page 1"]
+        B_HOME --> B_P2["Page 2"]
+        B_HOME --> B_P3["Page 3"]
+        B_HOME --> B_P4["Page 4"]
+        B_HOME --> B_P5["Page 5"]
+        B_HOME --> B_P6["Page 6"]
+        B_HOME --> B_P7["Page 7"]
+        B_HOME --> B_P8["Page 8"]
+    end
+
+    subgraph "After"
+        A_HOME["Homepage"] --> A_S1["Features"]
+        A_HOME --> A_S2["Resources"]
+        A_HOME --> A_S3["Company"]
+        A_S1 --> A_P1["Feature A"]
+        A_S1 --> A_P2["Feature B"]
+        A_S2 --> A_P3["Blog"]
+        A_S2 --> A_P4["Guides"]
+        A_S3 --> A_P5["About"]
+        A_S3 --> A_P6["Contact"]
+    end
+```
+
+---
+
+## Color-Coding Conventions
+
+Use styles to highlight page status, priority, or type.
+
+```mermaid
+graph TD
+    HOME["Homepage"] --> FEAT["Features"]
+    HOME --> PRICE["Pricing"]
+    HOME --> BLOG["Blog"]
+    HOME --> NEW["New Section"]
+    HOME --> REMOVE["Deprecated Page"]
+
+    FEAT --> F1["Existing Feature"]
+    FEAT --> F2["New Feature"]
+
+    style HOME fill:#4CAF50,color:#fff
+    style PRICE fill:#4CAF50,color:#fff
+    style FEAT fill:#4CAF50,color:#fff
+    style BLOG fill:#4CAF50,color:#fff
+    style F1 fill:#4CAF50,color:#fff
+    style NEW fill:#2196F3,color:#fff
+    style F2 fill:#2196F3,color:#fff
+    style REMOVE fill:#f44336,color:#fff
+```
+
+Color key:
+- **Green** (`#4CAF50`): Existing pages (no changes)
+- **Blue** (`#2196F3`): New pages to create
+- **Red** (`#f44336`): Pages to remove or redirect
+- **Yellow** (`#FFC107`): Pages to restructure or move
+- **Purple** (`#9C27B0`): High-priority / CTA pages

--- a/skills/site-architecture/references/navigation-patterns.md
+++ b/skills/site-architecture/references/navigation-patterns.md
@@ -1,0 +1,305 @@
+# Navigation Patterns
+
+Detailed navigation patterns for different site types and contexts.
+
+---
+
+## Header Navigation
+
+### Simple Header (4-6 items)
+
+Best for: small businesses, simple SaaS, portfolios.
+
+```
+[Logo]   Features   Pricing   Blog   About   [CTA Button]
+```
+
+Rules:
+- Logo always links to homepage
+- CTA button is rightmost, visually distinct (filled button, contrasting color)
+- Items ordered by priority (most visited first)
+- Active page gets visual indicator (underline, bold, color)
+
+### Mega Menu Header
+
+Best for: SaaS with many features, e-commerce with categories, large content sites.
+
+```
+[Logo]   Product ▾   Solutions ▾   Resources ▾   Pricing   Docs   [CTA]
+```
+
+When "Product" is hovered/clicked:
+
+```
+┌─────────────────────────────────────────────────┐
+│  Features           Platform        Integrations │
+│  ─────────          ─────────       ──────────── │
+│  Analytics           Security       Slack         │
+│  Automation          API            HubSpot       │
+│  Reporting           Compliance     Salesforce    │
+│  Dashboards                         Zapier        │
+│                                                   │
+│  [See all features →]                             │
+└─────────────────────────────────────────────────┘
+```
+
+Mega menu rules:
+- 2-4 columns max
+- Group items logically (by feature area, use case, or audience)
+- Include a "See all" link at the bottom
+- Don't nest dropdowns inside mega menus
+- Show descriptions for items when labels alone aren't clear
+
+### Split Navigation
+
+Best for: apps with both marketing and product nav.
+
+```
+[Logo]   Features   Pricing   Blog        [Login]   [Sign Up]
+├── Marketing nav (left) ──────┘          └── Auth nav (right) ──┤
+```
+
+Right side handles authentication actions. Left side handles page navigation.
+
+---
+
+## Footer Navigation
+
+### Column-Based Footer (Standard)
+
+Best for: most sites. Organize links into 3-5 themed columns.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│  Product          Resources        Company       Legal   │
+│  ─────────        ──────────       ─────────     ─────   │
+│  Features         Blog             About         Privacy │
+│  Pricing          Guides           Careers       Terms   │
+│  Integrations     Templates        Contact       GDPR    │
+│  Changelog        Case Studies     Press                 │
+│  Security         Webinars         Partners              │
+│                                                          │
+│  [Logo]  © 2026 Company Name                             │
+│  Social: [Twitter] [LinkedIn] [GitHub]                   │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Minimal Footer
+
+Best for: simple sites, landing pages.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  [Logo]                                                  │
+│  © 2026 Company  ·  Privacy  ·  Terms  ·  Contact        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Expanded Footer
+
+Best for: sites using footer for SEO (comparison pages, location pages, resource links).
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Product     Resources    Compare         Use Cases      │
+│  Features    Blog         vs Competitor A  For Startups  │
+│  Pricing     Guides       vs Competitor B  For Enterprise│
+│  API         Templates    vs Competitor C  For Agencies  │
+│                                                          │
+│  Integrations             Popular Posts                  │
+│  Slack       Zapier       How to Do X                    │
+│  HubSpot     Salesforce   Guide to Y                     │
+│                           Template: Z                    │
+│                                                          │
+│  [Logo]  © 2026  ·  Privacy  ·  Terms  ·  Security      │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Sidebar Navigation
+
+### Documentation Sidebar
+
+Persistent left sidebar with collapsible sections.
+
+```
+Getting Started
+  ├── Installation
+  ├── Quick Start
+  └── Configuration
+
+Guides
+  ├── Authentication
+  ├── Data Models
+  └── Deployment
+
+API Reference
+  ├── REST API
+  │   ├── Users
+  │   ├── Projects
+  │   └── Webhooks
+  └── GraphQL
+
+Examples
+  ├── Next.js
+  ├── Rails
+  └── Python
+
+Changelog
+```
+
+Rules:
+- Current page highlighted
+- Sections collapsible (expanded by default for active section)
+- Search at top of sidebar
+- "Previous / Next" page navigation at bottom of content area
+- Sticky on scroll (doesn't scroll away)
+
+### Blog Category Sidebar
+
+```
+Categories
+  ├── SEO (24)
+  ├── CRO (18)
+  ├── Content (15)
+  ├── Paid Ads (12)
+  └── Analytics (9)
+
+Popular Posts
+  ├── How to Improve SEO
+  ├── Landing Page Guide
+  └── Analytics Setup
+
+Newsletter
+  └── [Email signup form]
+```
+
+---
+
+## Breadcrumbs
+
+### Standard Format
+
+```
+Home > Features > Analytics
+Home > Blog > SEO Category > How to Do Keyword Research
+Home > Docs > API Reference > Authentication
+```
+
+Rules:
+- Separator: `>` or `/` (be consistent)
+- Every segment is a link except the current page
+- Current page is plain text (not linked)
+- Don't include the current page if the title is already visible as an H1
+
+### With Schema Markup
+
+```html
+<nav aria-label="Breadcrumb">
+  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+      <a itemprop="item" href="/"><span itemprop="name">Home</span></a>
+      <meta itemprop="position" content="1" />
+    </li>
+    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+      <a itemprop="item" href="/features"><span itemprop="name">Features</span></a>
+      <meta itemprop="position" content="2" />
+    </li>
+    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+      <span itemprop="name">Analytics</span>
+      <meta itemprop="position" content="3" />
+    </li>
+  </ol>
+</nav>
+```
+
+Or use JSON-LD (recommended):
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://example.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Features", "item": "https://example.com/features" },
+    { "@type": "ListItem", "position": 3, "name": "Analytics" }
+  ]
+}
+```
+
+---
+
+## Mobile Navigation
+
+### Hamburger Menu
+
+Standard for mobile. All nav items collapse into a menu icon.
+
+Rules:
+- Hamburger icon (three lines) top-right or top-left
+- Full-screen or slide-out panel
+- CTA button visible without opening the menu (sticky header)
+- Search accessible from mobile menu
+- Accordion pattern for nested items
+
+### Bottom Tab Bar
+
+Best for: web apps, PWAs, mobile-first products.
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│           [Page Content]             │
+│                                      │
+├──────────────────────────────────────┤
+│  Home    Search    Create    Profile │
+│   🏠       🔍        ➕       👤    │
+└──────────────────────────────────────┘
+```
+
+Rules:
+- 3-5 items max
+- Icons + labels (not just icons)
+- Active state clearly indicated
+- Most important action in the center
+
+---
+
+## Anti-Patterns
+
+### Things to Avoid
+
+- **Too many header items** (8+): causes decision paralysis, nav becomes unreadable on smaller screens
+- **Dropdown inception**: dropdowns inside dropdowns inside dropdowns
+- **Mystery icons**: icons without labels — users don't know what they mean
+- **Hidden primary nav**: burying important pages in hamburger menus on desktop
+- **Inconsistent nav between pages**: nav should be identical across the site (except app vs marketing)
+- **No mobile consideration**: desktop nav that doesn't translate to mobile
+- **Footer as sitemap dump**: 50+ links in the footer with no organization
+- **Breadcrumbs that don't match URLs**: breadcrumb says "Products > Widget" but URL is `/shop/widget-pro`
+
+### Common Fixes
+
+| Problem | Fix |
+|---------|-----|
+| Too many nav items | Group into dropdowns or mega menus |
+| Users can't find pages | Add search, improve labeling |
+| High bounce from nav | Simplify choices, use clearer labels |
+| SEO pages not linked | Add to footer or resource sections |
+| Mobile nav is broken | Test on real devices, use hamburger pattern |
+
+---
+
+## Navigation for SEO
+
+Internal links in navigation pass PageRank. Use this strategically:
+
+- **Header nav links are strongest** — put your most important pages here
+- **Footer links pass less value** but still matter — good for comparison pages, location pages
+- **Sidebar links** help with section-level authority — good for blog categories, doc sections
+- **Breadcrumbs** provide structural signals to search engines — implement with schema markup
+- **Don't use JavaScript-only nav** — search engines need crawlable HTML links
+- **Use descriptive anchor text** — "Analytics Features" not just "Features"

--- a/skills/site-architecture/references/site-type-templates.md
+++ b/skills/site-architecture/references/site-type-templates.md
@@ -1,0 +1,293 @@
+# Site Type Templates
+
+Full page hierarchy templates with ASCII trees, URL maps, and navigation recommendations for common site types.
+
+---
+
+## SaaS Marketing Site
+
+### Page Hierarchy
+
+```
+Homepage (/)
+├── Features (/features)
+│   ├── Feature A (/features/feature-a)
+│   ├── Feature B (/features/feature-b)
+│   └── Feature C (/features/feature-c)
+├── Pricing (/pricing)
+├── Customers (/customers)
+│   ├── Case Study 1 (/customers/company-name)
+│   └── Case Study 2 (/customers/company-name-2)
+├── Resources (/resources)
+│   ├── Blog (/blog)
+│   │   └── [Posts] (/blog/post-slug)
+│   ├── Templates (/resources/templates)
+│   │   └── [Template] (/resources/templates/template-slug)
+│   └── Guides (/resources/guides)
+│       └── [Guide] (/resources/guides/guide-slug)
+├── Integrations (/integrations)
+│   └── [Integration] (/integrations/integration-name)
+├── Docs (/docs)
+│   ├── Getting Started (/docs/getting-started)
+│   ├── Guides (/docs/guides)
+│   └── API Reference (/docs/api)
+├── About (/about)
+│   ├── Careers (/about/careers)
+│   └── Contact (/contact)
+├── Compare (/compare)
+│   └── [Competitor] (/compare/competitor-name)
+├── Privacy (/privacy)
+└── Terms (/terms)
+```
+
+### URL Map
+
+| Page | URL | Nav Location | Priority |
+|------|-----|-------------|----------|
+| Homepage | `/` | Header (logo) | Critical |
+| Features | `/features` | Header | High |
+| Feature pages | `/features/{slug}` | Header dropdown | Medium |
+| Pricing | `/pricing` | Header | Critical |
+| Customers | `/customers` | Header | Medium |
+| Case studies | `/customers/{slug}` | Customers dropdown | Medium |
+| Blog | `/blog` | Header (Resources) | High |
+| Blog posts | `/blog/{slug}` | — | Medium |
+| Integrations | `/integrations` | Header | Medium |
+| Docs | `/docs` | Header | Medium |
+| Compare | `/compare/{slug}` | Footer | High (SEO) |
+| About | `/about` | Footer | Low |
+| Pricing CTA | `/pricing` | Header (CTA button) | Critical |
+
+### Navigation
+
+**Header (6 items + CTA)**: Features | Pricing | Customers | Resources | Integrations | Docs | [Get Started]
+
+**Footer columns**:
+- Product: Features, Pricing, Integrations, Changelog, Security
+- Resources: Blog, Templates, Guides, Case Studies
+- Company: About, Careers, Contact, Press
+- Legal: Privacy, Terms, Security
+
+---
+
+## Content / Blog Site
+
+### Page Hierarchy
+
+```
+Homepage (/)
+├── Blog (/blog)
+│   ├── [Category: Topic A] (/blog/category/topic-a)
+│   ├── [Category: Topic B] (/blog/category/topic-b)
+│   ├── [Category: Topic C] (/blog/category/topic-c)
+│   └── [Posts] (/blog/post-slug)
+├── Newsletter (/newsletter)
+├── Resources (/resources)
+│   ├── Guides (/resources/guides)
+│   │   └── [Guide] (/resources/guides/guide-slug)
+│   └── Tools (/resources/tools)
+│       └── [Tool] (/resources/tools/tool-slug)
+├── About (/about)
+├── Contact (/contact)
+├── Privacy (/privacy)
+└── Terms (/terms)
+```
+
+### URL Map
+
+| Page | URL | Nav Location | Priority |
+|------|-----|-------------|----------|
+| Homepage | `/` | Header (logo) | Critical |
+| Blog index | `/blog` | Header | High |
+| Categories | `/blog/category/{slug}` | Header dropdown | Medium |
+| Posts | `/blog/{slug}` | — | Medium |
+| Newsletter | `/newsletter` | Header (CTA) | High |
+| Guides | `/resources/guides` | Header | Medium |
+| About | `/about` | Header | Low |
+
+### Navigation
+
+**Header (4 items + CTA)**: Blog | Resources | About | Contact | [Subscribe]
+
+**Sidebar** (on blog): Categories, Popular Posts, Newsletter signup
+
+---
+
+## E-Commerce
+
+### Page Hierarchy
+
+```
+Homepage (/)
+├── Shop (/shop)
+│   ├── Category A (/shop/category-a)
+│   │   ├── Subcategory (/shop/category-a/subcategory)
+│   │   │   └── [Product] (/shop/category-a/subcategory/product-slug)
+│   │   └── [Product] (/shop/category-a/product-slug)
+│   ├── Category B (/shop/category-b)
+│   │   └── [Product] (/shop/category-b/product-slug)
+│   └── Category C (/shop/category-c)
+│       └── [Product] (/shop/category-c/product-slug)
+├── Collections (/collections)
+│   └── [Collection] (/collections/collection-slug)
+├── Sale (/sale)
+├── Blog (/blog)
+│   └── [Posts] (/blog/post-slug)
+├── About (/about)
+│   └── Our Story (/about/our-story)
+├── Help (/help)
+│   ├── FAQ (/help/faq)
+│   ├── Shipping (/help/shipping)
+│   ├── Returns (/help/returns)
+│   └── Contact (/contact)
+├── Cart (/cart)
+├── Account (/account)
+├── Privacy (/privacy)
+└── Terms (/terms)
+```
+
+### URL Map
+
+| Page | URL | Nav Location | Priority |
+|------|-----|-------------|----------|
+| Homepage | `/` | Header (logo) | Critical |
+| Shop | `/shop` | Header | Critical |
+| Categories | `/shop/{category}` | Header mega menu | High |
+| Products | `/shop/{category}/{product}` | — | High |
+| Collections | `/collections/{slug}` | Header | Medium |
+| Sale | `/sale` | Header (highlighted) | High |
+| Cart | `/cart` | Header (icon) | Critical |
+| Account | `/account` | Header (icon) | Medium |
+
+### Navigation
+
+**Header (5 items + cart/account)**: Shop (mega menu) | Collections | Sale | Blog | Help | [Cart icon] [Account icon]
+
+**Mega menu under Shop**: Category columns with featured products/images
+
+---
+
+## Documentation Site
+
+### Page Hierarchy
+
+```
+Docs Home (/docs)
+├── Getting Started (/docs/getting-started)
+│   ├── Installation (/docs/getting-started/installation)
+│   ├── Quick Start (/docs/getting-started/quick-start)
+│   └── Configuration (/docs/getting-started/configuration)
+├── Guides (/docs/guides)
+│   ├── Guide A (/docs/guides/guide-a)
+│   ├── Guide B (/docs/guides/guide-b)
+│   └── Guide C (/docs/guides/guide-c)
+├── API Reference (/docs/api)
+│   ├── Authentication (/docs/api/authentication)
+│   ├── Endpoints (/docs/api/endpoints)
+│   └── Webhooks (/docs/api/webhooks)
+├── Examples (/docs/examples)
+│   └── [Example] (/docs/examples/example-slug)
+├── Changelog (/docs/changelog)
+└── FAQ (/docs/faq)
+```
+
+### URL Map
+
+| Page | URL | Nav Location | Priority |
+|------|-----|-------------|----------|
+| Docs home | `/docs` | Header | High |
+| Getting Started | `/docs/getting-started` | Sidebar (top) | Critical |
+| Guides | `/docs/guides` | Sidebar | High |
+| API Reference | `/docs/api` | Sidebar | High |
+| Changelog | `/docs/changelog` | Sidebar (bottom) | Low |
+
+### Navigation
+
+**Header**: Docs | API | Blog | Community | GitHub | [Dashboard]
+
+**Sidebar** (persistent, left): Getting Started, Guides, API Reference, Examples, Changelog — with expandable subsections
+
+**On-page**: Previous/Next navigation at bottom of each doc page
+
+---
+
+## Hybrid SaaS + Content
+
+### Page Hierarchy
+
+```
+Homepage (/)
+├── Product (/product)
+│   ├── Feature A (/product/feature-a)
+│   ├── Feature B (/product/feature-b)
+│   └── Feature C (/product/feature-c)
+├── Solutions (/solutions)
+│   ├── By Use Case (/solutions/use-case-slug)
+│   └── By Industry (/solutions/industry-slug)
+├── Pricing (/pricing)
+├── Blog (/blog)
+│   ├── [Category] (/blog/category/slug)
+│   └── [Posts] (/blog/post-slug)
+├── Resources (/resources)
+│   ├── Guides (/resources/guides)
+│   ├── Templates (/resources/templates)
+│   ├── Webinars (/resources/webinars)
+│   └── Case Studies (/resources/case-studies)
+├── Docs (/docs)
+│   ├── Getting Started (/docs/getting-started)
+│   └── API (/docs/api)
+├── Integrations (/integrations)
+│   └── [Integration] (/integrations/slug)
+├── Compare (/compare)
+│   └── [Competitor] (/compare/competitor-slug)
+├── About (/about)
+│   ├── Careers (/about/careers)
+│   └── Contact (/contact)
+├── Privacy (/privacy)
+└── Terms (/terms)
+```
+
+### Navigation
+
+**Header (7 items + CTA)**: Product | Solutions | Pricing | Resources | Blog | Docs | Integrations | [Start Free Trial]
+
+Use mega menus for Product (features list), Solutions (use cases + industries), and Resources (blog, guides, templates, webinars, case studies).
+
+---
+
+## Small Business / Local
+
+### Page Hierarchy
+
+```
+Homepage (/)
+├── Services (/services)
+│   ├── Service A (/services/service-a)
+│   ├── Service B (/services/service-b)
+│   └── Service C (/services/service-c)
+├── About (/about)
+├── Testimonials (/testimonials)
+├── Blog (/blog)
+│   └── [Posts] (/blog/post-slug)
+├── Contact (/contact)
+├── Privacy (/privacy)
+└── Terms (/terms)
+```
+
+### URL Map
+
+| Page | URL | Nav Location | Priority |
+|------|-----|-------------|----------|
+| Homepage | `/` | Header (logo) | Critical |
+| Services | `/services` | Header | High |
+| Service pages | `/services/{slug}` | Header dropdown | High |
+| About | `/about` | Header | Medium |
+| Testimonials | `/testimonials` | Header | Medium |
+| Blog | `/blog` | Header | Medium |
+| Contact | `/contact` | Header (CTA) | High |
+
+### Navigation
+
+**Header (5 items + CTA)**: Services | About | Testimonials | Blog | [Contact Us]
+
+Keep it simple. Small business sites should be flat (1-2 levels max). Every page should be reachable from the header.


### PR DESCRIPTION
## Summary

- Adds `site-architecture` skill (#30) for website structure planning — page hierarchy, navigation design, URL structure, and internal linking
- Includes 3 reference files: site-type templates (SaaS, e-commerce, docs, blog, hybrid, small biz), Mermaid diagram templates, and navigation patterns
- Adds cross-references in content-strategy, programmatic-seo, seo-audit, and schema-markup skills
- Updates marketplace.json (29→30), README, and VERSIONS.md

## Test plan

- [ ] Verify SKILL.md is under 500 lines (`wc -l` = 357)
- [ ] Verify `name: site-architecture` matches directory name
- [ ] Verify marketplace.json is valid JSON with 30 skills in array
- [ ] Verify all reference file links resolve from SKILL.md
- [ ] Verify Mermaid code blocks use valid syntax
- [ ] Verify cross-references added to 4 related skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)