### PR TITLE
fix: improve skill quality scores across all 29 marketing skills

### DIFF
--- a/skills/ab-test-setup/SKILL.md
+++ b/skills/ab-test-setup/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: ab-test-setup
-description: When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions "A/B test," "split test," "experiment," "test this change," "variant copy," "multivariate test," or "hypothesis." For tracking implementation, see analytics-tracking.
+description: Formulates test hypotheses, calculates sample sizes, designs test variants, selects primary and guardrail metrics, and analyzes statistical significance for A/B tests and experiments. Use when the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions "A/B test," "split test," "experiment," "test this change," "variant copy," "multivariate test," or "hypothesis." For tracking implementation, see analytics-tracking.
 metadata:
   version: 1.0.0
 ---
 
 # A/B Test Setup
-
-You are an expert in experimentation and A/B testing. Your goal is to help design tests that produce statistically valid, actionable results.
 
 ## Initial Assessment
 

--- a/skills/ad-creative/SKILL.md
+++ b/skills/ad-creative/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Ad Creative
 
-You are an expert performance creative strategist. Your goal is to generate high-performing ad creative at scale — headlines, descriptions, and primary text that drive clicks and conversions — and iterate based on real performance data.
-
 ## Before Starting
 
 **Check for product marketing context first:**

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: ai-seo
-description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' or 'zero-click search.' This skill covers content optimization for AI answer engines, monitoring AI visibility, and getting cited as a source. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup."
+description: "Restructures content for direct AI answers, adds citation-friendly formatting, audits AI visibility across platforms, implements entity-based content strategies, and monitors AI search citations. Use when the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' or 'zero-click search.' For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup."
 metadata:
   version: 1.0.0
 ---
 
 # AI SEO
 
-You are an expert in AI search optimization — the practice of making content discoverable, extractable, and citable by AI systems including Google AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and Copilot. Your goal is to help users get their content cited as a source in AI-generated answers.
 
 ## Before Starting
 

--- a/skills/analytics-tracking/SKILL.md
+++ b/skills/analytics-tracking/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: analytics-tracking
-description: When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions "set up tracking," "GA4," "Google Analytics," "conversion tracking," "event tracking," "UTM parameters," "tag manager," "GTM," "analytics implementation," or "tracking plan." For A/B test measurement, see ab-test-setup.
+description: Configures GA4 events, creates tracking plans, implements GTM containers, sets up conversion goals, debugs tracking issues, and designs UTM parameter conventions. Use when the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions "set up tracking," "GA4," "Google Analytics," "conversion tracking," "event tracking," "UTM parameters," "tag manager," "GTM," "analytics implementation," or "tracking plan." For A/B test measurement, see ab-test-setup.
 metadata:
   version: 1.0.0
 ---
 
 # Analytics Tracking
 
-You are an expert in analytics implementation and measurement. Your goal is to help set up tracking that provides actionable insights for marketing and product decisions.
 
 ## Initial Assessment
 

--- a/skills/churn-prevention/SKILL.md
+++ b/skills/churn-prevention/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Churn Prevention
 
-You are an expert in SaaS retention and churn prevention. Your goal is to help reduce both voluntary churn (customers choosing to cancel) and involuntary churn (failed payments) through well-designed cancel flows, dynamic save offers, proactive retention, and dunning strategies.
-
 ## Before Starting
 
 **Check for product marketing context first:**

--- a/skills/cold-email/SKILL.md
+++ b/skills/cold-email/SKILL.md
@@ -5,8 +5,6 @@ description: Write B2B cold emails and follow-up sequences that get replies. Use
 
 # Cold Email Writing
 
-You are an expert cold email writer. Your goal is to write emails that sound like they came from a sharp, thoughtful human — not a sales machine following a template.
-
 ## Before Writing
 
 **Check for product marketing context first:**

--- a/skills/competitor-alternatives/SKILL.md
+++ b/skills/competitor-alternatives/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Competitor & Alternative Pages
 
-You are an expert in creating competitor comparison and alternative pages. Your goal is to build pages that rank for competitive search terms, provide genuine value to evaluators, and position your product effectively.
-
 ## Initial Assessment
 
 **Check for product marketing context first:**
@@ -34,33 +32,6 @@ Before creating competitor pages, understand:
    - Sales enablement
    - Conversion from competitor users
    - Brand positioning
-
----
-
-## Core Principles
-
-### 1. Honesty Builds Trust
-- Acknowledge competitor strengths
-- Be accurate about your limitations
-- Don't misrepresent competitor features
-- Readers are comparing—they'll verify claims
-
-### 2. Depth Over Surface
-- Go beyond feature checklists
-- Explain *why* differences matter
-- Include use cases and scenarios
-- Show, don't just tell
-
-### 3. Help Them Decide
-- Different tools fit different needs
-- Be clear about who you're best for
-- Be clear about who competitor is best for
-- Reduce evaluation friction
-
-### 4. Modular Content Architecture
-- Competitor data should be centralized
-- Updates propagate to all pages
-- Single source of truth per competitor
 
 ---
 
@@ -235,6 +206,20 @@ For each page: URL, meta tags, full page copy organized by section, comparison t
 
 ### Page Set Plan
 Recommended pages to create with priority order based on search volume.
+
+---
+
+## Implementation Workflow
+
+1. **Research competitors** — Sign up, document features, mine reviews on G2/Capterra
+   - *Validate*: Have pricing, feature list, and 5+ review themes per competitor
+2. **Choose page format** — Match format to search intent and available data
+3. **Create competitor data file** — Centralized YAML with positioning, pricing, features, strengths/weaknesses
+   - *Validate*: All claims are verifiable and up-to-date
+4. **Write page content** — Follow page structure for chosen format, include paragraph comparisons beyond feature tables
+   - *Validate*: Honestly acknowledges competitor strengths; includes "who this is best for"
+5. **Add SEO elements** — Target keywords, internal links, FAQ schema
+6. **Schedule updates** — Quarterly pricing/feature verification
 
 ---
 

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Content Strategy
 
-You are a content strategist. Your goal is to help plan content that drives traffic, builds authority, and generates leads by being either searchable, shareable, or both.
-
 ## Before Planning
 
 **Check for product marketing context first:**

--- a/skills/copy-editing/SKILL.md
+++ b/skills/copy-editing/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Copy Editing
 
-You are an expert copy editor specializing in marketing and conversion copy. Your goal is to systematically improve existing copy through focused editing passes while preserving the core message.
-
 ## Core Philosophy
 
 **Check for product marketing context first:**

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Copywriting
 
-You are an expert conversion copywriter. Your goal is to write marketing copy that is clear, compelling, and drives action.
-
 ## Before Writing
 
 **Check for product marketing context first:**

--- a/skills/email-sequence/SKILL.md
+++ b/skills/email-sequence/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Email Sequence Design
 
-You are an expert in email marketing and automation. Your goal is to create email sequences that nurture relationships, drive action, and move people toward conversion.
-
 ## Initial Assessment
 
 **Check for product marketing context first:**

--- a/skills/form-cro/SKILL.md
+++ b/skills/form-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: form-cro
-description: When the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions "form optimization," "lead form conversions," "form friction," "form fields," "form completion rate," or "contact form." For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.
+description: Audits form completion rates, reduces field count, optimizes field order and labels, designs multi-step forms with progress indicators, improves inline validation and error handling, and recommends submit button copy. Use when the user wants to optimize any form that is NOT signup/registration — including lead capture forms, contact forms, demo request forms, application forms, survey forms, or checkout forms. Also use when the user mentions "form optimization," "lead form conversions," "form friction," "form fields," "form completion rate," or "contact form." For signup/registration forms, see signup-flow-cro. For popups containing forms, see popup-cro.
 metadata:
   version: 1.0.0
 ---
 
 # Form CRO
-
-You are an expert in form optimization. Your goal is to maximize form completion rates while capturing the data that matters.
 
 ## Initial Assessment
 
@@ -38,29 +36,15 @@ Before providing recommendations, identify:
 
 ---
 
-## Core Principles
+## Field Cost Reference
 
-### 1. Every Field Has a Cost
-Each field reduces completion rate. Rule of thumb:
-- 3 fields: Baseline
-- 4-6 fields: 10-25% reduction
-- 7+ fields: 25-50%+ reduction
+| Field Count | Estimated Completion Impact |
+|-------------|---------------------------|
+| 3 fields | Baseline |
+| 4-6 fields | 10-25% reduction |
+| 7+ fields | 25-50%+ reduction |
 
-For each field, ask:
-- Is this absolutely necessary before we can help them?
-- Can we get this information another way?
-- Can we ask this later?
-
-### 2. Value Must Exceed Effort
-- Clear value proposition above form
-- Make what they get obvious
-- Reduce perceived effort (field count, labels)
-
-### 3. Reduce Cognitive Load
-- One question per field
-- Clear, conversational labels
-- Logical grouping and order
-- Smart defaults where possible
+For each field, ask: Is this needed before we can help them? Can we get it later or infer it?
 
 ---
 
@@ -332,81 +316,14 @@ Ideas to A/B test with expected outcomes
 
 ## Experiment Ideas
 
-### Form Structure Experiments
+Key areas to test:
+- **Layout**: Single-step vs. multi-step, 1-column vs. 2-column, embedded vs. separate page
+- **Fields**: Minimum viable fields, required vs. optional balance, progressive profiling
+- **Copy**: Button text variations, label clarity, error message tone
+- **Trust**: Privacy assurance placement, trust badges, testimonials near form
+- **Mobile**: Touch targets, keyboard types, sticky submit button
 
-**Layout & Flow**
-- Single-step form vs. multi-step with progress bar
-- 1-column vs. 2-column field layout
-- Form embedded on page vs. separate page
-- Vertical vs. horizontal field alignment
-- Form above fold vs. after content
-
-**Field Optimization**
-- Reduce to minimum viable fields
-- Add or remove phone number field
-- Add or remove company/organization field
-- Test required vs. optional field balance
-- Use field enrichment to auto-fill known data
-- Hide fields for returning/known visitors
-
-**Smart Forms**
-- Add real-time validation for emails and phone numbers
-- Progressive profiling (ask more over time)
-- Conditional fields based on earlier answers
-- Auto-suggest for company names
-
----
-
-### Copy & Design Experiments
-
-**Labels & Microcopy**
-- Test field label clarity and length
-- Placeholder text optimization
-- Help text: show vs. hide vs. on-hover
-- Error message tone (friendly vs. direct)
-
-**CTAs & Buttons**
-- Button text variations ("Submit" vs. "Get My Quote" vs. specific action)
-- Button color and size testing
-- Button placement relative to fields
-
-**Trust Elements**
-- Add privacy assurance near form
-- Show trust badges next to submit
-- Add testimonial near form
-- Display expected response time
-
----
-
-### Form Type-Specific Experiments
-
-**Demo Request Forms**
-- Test with/without phone number requirement
-- Add "preferred contact method" choice
-- Include "What's your biggest challenge?" question
-- Test calendar embed vs. form submission
-
-**Lead Capture Forms**
-- Email-only vs. email + name
-- Test value proposition messaging above form
-- Gated vs. ungated content strategies
-- Post-submission enrichment questions
-
-**Contact Forms**
-- Add department/topic routing dropdown
-- Test with/without message field requirement
-- Show alternative contact methods (chat, phone)
-- Expected response time messaging
-
----
-
-### Mobile & UX Experiments
-
-- Larger touch targets for mobile
-- Test appropriate keyboard types by field
-- Sticky submit button on mobile
-- Auto-focus first field on page load
-- Test form container styling (card vs. minimal)
+**For detailed experiment variations by form type**: See [references/experiments.md](references/experiments.md)
 
 ---
 

--- a/skills/free-tool-strategy/SKILL.md
+++ b/skills/free-tool-strategy/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Free Tool Strategy (Engineering as Marketing)
 
-You are an expert in engineering-as-marketing strategy. Your goal is to help plan and evaluate free tools that generate leads, attract organic traffic, and build brand awareness.
-
 ## Initial Assessment
 
 **Check for product marketing context first:**
@@ -21,28 +19,6 @@ Before designing a tool strategy, understand:
 2. **Goals** - Lead generation? SEO/traffic? Brand awareness? Product education?
 
 3. **Resources** - Technical capacity to build? Ongoing maintenance bandwidth? Budget for promotion?
-
----
-
-## Core Principles
-
-### 1. Solve a Real Problem
-- Tool must provide genuine value
-- Solves a problem your audience actually has
-- Useful even without your main product
-
-### 2. Adjacent to Core Product
-- Related to what you sell
-- Natural path from tool to product
-- Educates on problem you solve
-
-### 3. Simple and Focused
-- Does one thing well
-- Low friction to use
-- Immediate value
-
-### 4. Worth the Investment
-- Lead value × expected leads > build cost + maintenance
 
 ---
 
@@ -158,6 +134,22 @@ Rate each factor 1-5:
 | Share-worthiness | ___ |
 
 **25+**: Strong candidate | **15-24**: Promising | **<15**: Reconsider
+
+---
+
+## Implementation Workflow
+
+1. **Identify opportunity** — Research audience pain points, find search demand
+   - *Validate*: Confirm keyword volume exists for "[tool type] calculator/generator"
+2. **Score with evaluation scorecard** — Rate all 8 factors above
+   - *Validate*: Score ≥ 25 before proceeding
+3. **Define MVP scope** — Core functionality, essential UX, basic lead capture
+   - *Validate*: Can describe tool's value in one sentence
+4. **Choose build approach** — Custom, no-code, or embedded
+5. **Build and launch** — Implement tool, add lead capture, set up analytics
+   - *Validate*: Tool works on mobile, captures leads to CRM
+6. **Promote** — Target "[tool type]" keywords, create supporting content
+7. **Measure** — Track leads, conversion to customers, SEO rankings
 
 ---
 

--- a/skills/launch-strategy/SKILL.md
+++ b/skills/launch-strategy/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Launch Strategy
 
-You are an expert in SaaS product launches and feature announcements. Your goal is to help users plan launches that build momentum, capture attention, and convert interest into users.
-
 ## Before Starting
 
 **Check for product marketing context first:**

--- a/skills/marketing-ideas/SKILL.md
+++ b/skills/marketing-ideas/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Marketing Ideas for SaaS
 
-You are a marketing strategist with a library of 139 proven marketing ideas. Your goal is to help users find the right marketing strategies for their specific situation, stage, and resources.
-
 ## How to Use This Skill
 
 **Check for product marketing context first:**

--- a/skills/marketing-psychology/SKILL.md
+++ b/skills/marketing-psychology/SKILL.md
@@ -7,415 +7,111 @@ metadata:
 
 # Marketing Psychology & Mental Models
 
-You are an expert in applying psychological principles and mental models to marketing. Your goal is to help users understand why people buy, how to influence behavior ethically, and how to make better marketing decisions.
-
 ## How to Use This Skill
 
 **Check for product marketing context first:**
-If `.claude/product-marketing-context.md` exists, read it before applying mental models. Use that context to tailor recommendations to the specific product and audience.
+If `.claude/product-marketing-context.md` exists, read it before applying mental models. Use that context to tailor recommendations.
 
-Mental models are thinking tools that help you make better decisions, understand customer behavior, and create more effective marketing. When helping users:
+### Workflow
 
-1. Identify which mental models apply to their situation
-2. Explain the psychology behind the model
-3. Provide specific marketing applications
-4. Suggest how to implement ethically
+1. Identify the marketing challenge from the Quick Reference table below
+2. Select relevant mental models for the situation
+3. Provide specific, actionable applications (not just theory)
+4. Suggest ethical implementation with concrete examples
 
 ---
 
 ## Foundational Thinking Models
 
-These models sharpen your strategy and help you solve the right problems.
-
-### First Principles
-Break problems down to basic truths and build solutions from there. Instead of copying competitors, ask "why" repeatedly to find root causes. Use the 5 Whys technique to tunnel down to what really matters.
-
-**Marketing application**: Don't assume you need content marketing because competitors do. Ask why you need it, what problem it solves, and whether there's a better solution.
-
-### Jobs to Be Done
-People don't buy products—they "hire" them to get a job done. Focus on the outcome customers want, not features.
-
-**Marketing application**: A drill buyer doesn't want a drill—they want a hole. Frame your product around the job it accomplishes, not its specifications.
-
-### Circle of Competence
-Know what you're good at and stay within it. Venture outside only with proper learning or expert help.
-
-**Marketing application**: Don't chase every channel. Double down where you have genuine expertise and competitive advantage.
-
-### Inversion
-Instead of asking "How do I succeed?", ask "What would guarantee failure?" Then avoid those things.
-
-**Marketing application**: List everything that would make your campaign fail—confusing messaging, wrong audience, slow landing page—then systematically prevent each.
-
-### Occam's Razor
-The simplest explanation is usually correct. Avoid overcomplicating strategies or attributing results to complex causes when simple ones suffice.
-
-**Marketing application**: If conversions dropped, check the obvious first (broken form, page speed) before assuming complex attribution issues.
-
-### Pareto Principle (80/20 Rule)
-Roughly 80% of results come from 20% of efforts. Identify and focus on the vital few.
-
-**Marketing application**: Find the 20% of channels, customers, or content driving 80% of results. Cut or reduce the rest.
-
-### Local vs. Global Optima
-A local optimum is the best solution nearby, but a global optimum is the best overall. Don't get stuck optimizing the wrong thing.
-
-**Marketing application**: Optimizing email subject lines (local) won't help if email isn't the right channel (global). Zoom out before zooming in.
-
-### Theory of Constraints
-Every system has one bottleneck limiting throughput. Find and fix that constraint before optimizing elsewhere.
-
-**Marketing application**: If your funnel converts well but traffic is low, more conversion optimization won't help. Fix the traffic bottleneck first.
-
-### Opportunity Cost
-Every choice has a cost—what you give up by not choosing alternatives. Consider what you're saying no to.
-
-**Marketing application**: Time spent on a low-ROI channel is time not spent on high-ROI activities. Always compare against alternatives.
-
-### Law of Diminishing Returns
-After a point, additional investment yields progressively smaller gains.
-
-**Marketing application**: The 10th blog post won't have the same impact as the first. Know when to diversify rather than double down.
-
-### Second-Order Thinking
-Consider not just immediate effects, but the effects of those effects.
-
-**Marketing application**: A flash sale boosts revenue (first order) but may train customers to wait for discounts (second order).
-
-### Map ≠ Territory
-Models and data represent reality but aren't reality itself. Don't confuse your analytics dashboard with actual customer experience.
-
-**Marketing application**: Your customer persona is a useful model, but real customers are more complex. Stay in touch with actual users.
-
-### Probabilistic Thinking
-Think in probabilities, not certainties. Estimate likelihoods and plan for multiple outcomes.
-
-**Marketing application**: Don't bet everything on one campaign. Spread risk and plan for scenarios where your primary strategy underperforms.
-
-### Barbell Strategy
-Combine extreme safety with small high-risk/high-reward bets. Avoid the mediocre middle.
-
-**Marketing application**: Put 80% of budget into proven channels, 20% into experimental bets. Avoid moderate-risk, moderate-reward middle.
+| Model | Marketing Application |
+|-------|----------------------|
+| **First Principles** | Don't copy competitors—ask why you need each channel and whether there's a better solution |
+| **Jobs to Be Done** | Frame product around the job it accomplishes, not specifications |
+| **Inversion** | List what would guarantee campaign failure, then prevent each |
+| **Pareto (80/20)** | Find the 20% of channels/content driving 80% of results; cut the rest |
+| **Theory of Constraints** | Find the one funnel bottleneck; fix that before optimizing elsewhere |
+| **Second-Order Thinking** | Flash sale boosts revenue (1st order) but trains customers to wait for discounts (2nd order) |
+| **Barbell Strategy** | 80% budget on proven channels, 20% on experimental bets |
+| **Local vs. Global Optima** | Don't optimize email subject lines if email isn't the right channel—zoom out first |
 
 ---
 
 ## Understanding Buyers & Human Psychology
 
-These models explain how customers think, decide, and behave.
-
-### Fundamental Attribution Error
-People attribute others' behavior to character, not circumstances. "They didn't buy because they're not serious" vs. "The checkout was confusing."
-
-**Marketing application**: When customers don't convert, examine your process before blaming them. The problem is usually situational, not personal.
-
-### Mere Exposure Effect
-People prefer things they've seen before. Familiarity breeds liking.
-
-**Marketing application**: Consistent brand presence builds preference over time. Repetition across channels creates comfort and trust.
-
-### Availability Heuristic
-People judge likelihood by how easily examples come to mind. Recent or vivid events seem more common.
-
-**Marketing application**: Case studies and testimonials make success feel more achievable. Make positive outcomes easy to imagine.
-
-### Confirmation Bias
-People seek information confirming existing beliefs and ignore contradictory evidence.
-
-**Marketing application**: Understand what your audience already believes and align messaging accordingly. Fighting beliefs head-on rarely works.
-
-### The Lindy Effect
-The longer something has survived, the longer it's likely to continue. Old ideas often outlast new ones.
-
-**Marketing application**: Proven marketing principles (clear value props, social proof) outlast trendy tactics. Don't abandon fundamentals for fads.
-
-### Mimetic Desire
-People want things because others want them. Desire is socially contagious.
-
-**Marketing application**: Show that desirable people want your product. Waitlists, exclusivity, and social proof trigger mimetic desire.
-
-### Sunk Cost Fallacy
-People continue investing in something because of past investment, even when it's no longer rational.
-
-**Marketing application**: Know when to kill underperforming campaigns. Past spend shouldn't justify future spend if results aren't there.
-
-### Endowment Effect
-People value things more once they own them.
-
-**Marketing application**: Free trials, samples, and freemium models let customers "own" the product, making them reluctant to give it up.
-
-### IKEA Effect
-People value things more when they've put effort into creating them.
-
-**Marketing application**: Let customers customize, configure, or build something. Their investment increases perceived value and commitment.
-
-### Zero-Price Effect
-Free isn't just a low price—it's psychologically different. "Free" triggers irrational preference.
-
-**Marketing application**: Free tiers, free trials, and free shipping have disproportionate appeal. The jump from $1 to $0 is bigger than $2 to $1.
-
-### Hyperbolic Discounting / Present Bias
-People strongly prefer immediate rewards over future ones, even when waiting is more rational.
-
-**Marketing application**: Emphasize immediate benefits ("Start saving time today") over future ones ("You'll see ROI in 6 months").
-
-### Status-Quo Bias
-People prefer the current state of affairs. Change requires effort and feels risky.
-
-**Marketing application**: Reduce friction to switch. Make the transition feel safe and easy. "Import your data in one click."
-
-### Default Effect
-People tend to accept pre-selected options. Defaults are powerful.
-
-**Marketing application**: Pre-select the plan you want customers to choose. Opt-out beats opt-in for subscriptions (ethically applied).
-
-### Paradox of Choice
-Too many options overwhelm and paralyze. Fewer choices often lead to more decisions.
-
-**Marketing application**: Limit options. Three pricing tiers beat seven. Recommend a single "best for most" option.
-
-### Goal-Gradient Effect
-People accelerate effort as they approach a goal. Progress visualization motivates action.
-
-**Marketing application**: Show progress bars, completion percentages, and "almost there" messaging to drive completion.
-
-### Peak-End Rule
-People judge experiences by the peak (best or worst moment) and the end, not the average.
-
-**Marketing application**: Design memorable peaks (surprise upgrades, delightful moments) and strong endings (thank you pages, follow-up emails).
-
-### Zeigarnik Effect
-Unfinished tasks occupy the mind more than completed ones. Open loops create tension.
-
-**Marketing application**: "You're 80% done" creates pull to finish. Incomplete profiles, abandoned carts, and cliffhangers leverage this.
-
-### Pratfall Effect
-Competent people become more likable when they show a small flaw. Perfection is less relatable.
-
-**Marketing application**: Admitting a weakness ("We're not the cheapest, but...") can increase trust and differentiation.
-
-### Curse of Knowledge
-Once you know something, you can't imagine not knowing it. Experts struggle to explain simply.
-
-**Marketing application**: Your product seems obvious to you but confusing to newcomers. Test copy with people unfamiliar with your space.
-
-### Mental Accounting
-People treat money differently based on its source or intended use, even though money is fungible.
-
-**Marketing application**: Frame costs in favorable mental accounts. "$3/day" feels different than "$90/month" even though it's the same.
-
-### Regret Aversion
-People avoid actions that might cause regret, even if the expected outcome is positive.
-
-**Marketing application**: Address regret directly. Money-back guarantees, free trials, and "no commitment" messaging reduce regret fear.
-
-### Bandwagon Effect / Social Proof
-People follow what others are doing. Popularity signals quality and safety.
-
-**Marketing application**: Show customer counts, testimonials, logos, reviews, and "trending" indicators. Numbers create confidence.
+| Model | Marketing Application |
+|-------|----------------------|
+| **Endowment Effect** | Free trials let customers "own" the product, making them reluctant to give it up |
+| **IKEA Effect** | Let customers customize/configure—their investment increases commitment |
+| **Zero-Price Effect** | "Free" triggers irrational preference; the $1→$0 jump is bigger than $2→$1 |
+| **Present Bias** | Emphasize immediate benefits ("Start saving time today") over future ROI |
+| **Status-Quo Bias** | Reduce switching friction: "Import your data in one click" |
+| **Default Effect** | Pre-select the plan you want customers to choose |
+| **Paradox of Choice** | Three pricing tiers beat seven; recommend "best for most" |
+| **Goal-Gradient Effect** | Progress bars and "almost there" messaging drive completion |
+| **Peak-End Rule** | Design memorable peaks (surprise upgrades) and strong endings (thank you pages) |
+| **Zeigarnik Effect** | "You're 80% done" creates pull to finish incomplete profiles/carts |
+| **Pratfall Effect** | Admitting a weakness ("We're not the cheapest, but...") increases trust |
+| **Mimetic Desire** | Waitlists, exclusivity, and social proof trigger desire through others wanting it |
+| **Bandwagon / Social Proof** | Show customer counts, logos, reviews, and "trending" indicators |
+| **Regret Aversion** | Money-back guarantees and "no commitment" messaging reduce fear |
+| **Mental Accounting** | "$3/day" feels cheaper than "$90/month"—frame costs in favorable accounts |
 
 ---
 
 ## Influencing Behavior & Persuasion
 
-These models help you ethically influence customer decisions.
-
-### Reciprocity Principle
-People feel obligated to return favors. Give first, and people want to give back.
-
-**Marketing application**: Free content, free tools, and generous free tiers create reciprocal obligation. Give value before asking for anything.
-
-### Commitment & Consistency
-Once people commit to something, they want to stay consistent with that commitment.
-
-**Marketing application**: Get small commitments first (email signup, free trial). People who've taken one step are more likely to take the next.
-
-### Authority Bias
-People defer to experts and authority figures. Credentials and expertise create trust.
-
-**Marketing application**: Feature expert endorsements, certifications, "featured in" logos, and thought leadership content.
-
-### Liking / Similarity Bias
-People say yes to those they like and those similar to themselves.
-
-**Marketing application**: Use relatable spokespeople, founder stories, and community language. "Built by marketers for marketers" signals similarity.
-
-### Unity Principle
-Shared identity drives influence. "One of us" is powerful.
-
-**Marketing application**: Position your brand as part of the customer's tribe. Use insider language and shared values.
-
-### Scarcity / Urgency Heuristic
-Limited availability increases perceived value. Scarcity signals desirability.
-
-**Marketing application**: Limited-time offers, low-stock warnings, and exclusive access create urgency. Only use when genuine.
-
-### Foot-in-the-Door Technique
-Start with a small request, then escalate. Compliance with small requests leads to compliance with larger ones.
-
-**Marketing application**: Free trial → paid plan → annual plan → enterprise. Each step builds on the last.
-
-### Door-in-the-Face Technique
-Start with an unreasonably large request, then retreat to what you actually want. The contrast makes the second request seem reasonable.
-
-**Marketing application**: Show enterprise pricing first, then reveal the affordable starter plan. The contrast makes it feel like a deal.
-
-### Loss Aversion / Prospect Theory
-Losses feel roughly twice as painful as equivalent gains feel good. People will work harder to avoid losing than to gain.
-
-**Marketing application**: Frame in terms of what they'll lose by not acting. "Don't miss out" beats "You could gain."
-
-### Anchoring Effect
-The first number people see heavily influences subsequent judgments.
-
-**Marketing application**: Show the higher price first (original price, competitor price, enterprise tier) to anchor expectations.
-
-### Decoy Effect
-Adding a third, inferior option makes one of the original two look better.
-
-**Marketing application**: A "decoy" pricing tier that's clearly worse value makes your preferred tier look like the obvious choice.
-
-### Framing Effect
-How something is presented changes how it's perceived. Same facts, different frames.
-
-**Marketing application**: "90% success rate" vs. "10% failure rate" are identical but feel different. Frame positively.
-
-### Contrast Effect
-Things seem different depending on what they're compared to.
-
-**Marketing application**: Show the "before" state clearly. The contrast with your "after" makes improvements vivid.
+| Model | Marketing Application |
+|-------|----------------------|
+| **Reciprocity** | Free content/tools/tiers create obligation—give value before asking for anything |
+| **Commitment & Consistency** | Get small commitments first (email signup, free trial); each step makes the next more likely |
+| **Authority Bias** | Feature expert endorsements, certifications, "featured in" logos |
+| **Liking / Similarity** | "Built by marketers for marketers"—use community language and relatable spokespeople |
+| **Scarcity / Urgency** | Limited-time offers and exclusive access create urgency (only use when genuine) |
+| **Foot-in-the-Door** | Free trial → paid → annual → enterprise; each step builds on the last |
+| **Door-in-the-Face** | Show enterprise pricing first; the affordable starter plan feels like a deal by contrast |
+| **Loss Aversion** | "Don't miss out" beats "You could gain"—losses feel ~2x stronger than gains |
+| **Anchoring** | Show higher price first (original price, competitor price) to anchor expectations |
+| **Decoy Effect** | Add a clearly worse-value tier to make your preferred tier the obvious choice |
+| **Framing Effect** | "90% success rate" vs. "10% failure rate" feel different; frame positively |
 
 ---
 
 ## Pricing Psychology
 
-These models specifically address how people perceive and respond to prices.
-
-### Charm Pricing / Left-Digit Effect
-Prices ending in 9 seem significantly lower than the next round number. $99 feels much cheaper than $100.
-
-**Marketing application**: Use .99 or .95 endings for value-focused products. The left digit dominates perception.
-
-### Rounded-Price (Fluency) Effect
-Round numbers feel premium and are easier to process. $100 signals quality; $99 signals value.
-
-**Marketing application**: Use round prices for premium products ($500/month), charm prices for value products ($497/month).
-
-### Rule of 100
-For prices under $100, percentage discounts seem larger ("20% off"). For prices over $100, absolute discounts seem larger ("$50 off").
-
-**Marketing application**: $80 product: "20% off" beats "$16 off." $500 product: "$100 off" beats "20% off."
-
-### Price Relativity / Good-Better-Best
-People judge prices relative to options presented. A middle tier seems reasonable between cheap and expensive.
-
-**Marketing application**: Three tiers where the middle is your target. The expensive tier makes it look reasonable; the cheap tier provides an anchor.
-
-### Mental Accounting (Pricing)
-Framing the same price differently changes perception.
-
-**Marketing application**: "$1/day" feels cheaper than "$30/month." "Less than your morning coffee" reframes the expense.
+| Model | Application |
+|-------|------------|
+| **Charm Pricing** | $99 feels much cheaper than $100—use .99 for value products, round for premium |
+| **Rule of 100** | Under $100: "20% off" beats "$16 off." Over $100: "$100 off" beats "20% off" |
+| **Good-Better-Best** | Three tiers; expensive makes middle look reasonable, cheap provides anchor |
+| **Price Framing** | "$1/day" feels cheaper than "$30/month"—reframe in favorable mental accounts |
 
 ---
 
 ## Design & Delivery Models
 
-These models help you design effective marketing systems.
-
-### Hick's Law
-Decision time increases with the number and complexity of choices. More options = slower decisions = more abandonment.
-
-**Marketing application**: Simplify choices. One clear CTA beats three. Fewer form fields beat more.
-
-### AIDA Funnel
-Attention → Interest → Desire → Action. The classic customer journey model.
-
-**Marketing application**: Structure pages and campaigns to move through each stage. Capture attention before building desire.
-
-### Rule of 7
-Prospects need roughly 7 touchpoints before converting. One ad rarely converts; sustained presence does.
-
-**Marketing application**: Build multi-touch campaigns across channels. Retargeting, email sequences, and consistent presence compound.
-
-### Nudge Theory / Choice Architecture
-Small changes in how choices are presented significantly influence decisions.
-
-**Marketing application**: Default selections, strategic ordering, and friction reduction guide behavior without restricting choice.
-
-### BJ Fogg Behavior Model
-Behavior = Motivation × Ability × Prompt. All three must be present for action.
-
-**Marketing application**: High motivation but hard to do = won't happen. Easy to do but no prompt = won't happen. Design for all three.
-
-### EAST Framework
-Make desired behaviors: Easy, Attractive, Social, Timely.
-
-**Marketing application**: Reduce friction (easy), make it appealing (attractive), show others doing it (social), ask at the right moment (timely).
-
-### COM-B Model
-Behavior requires: Capability, Opportunity, Motivation.
-
-**Marketing application**: Can they do it (capability)? Is the path clear (opportunity)? Do they want to (motivation)? Address all three.
-
-### Activation Energy
-The initial energy required to start something. High activation energy prevents action even if the task is easy overall.
-
-**Marketing application**: Reduce starting friction. Pre-fill forms, offer templates, show quick wins. Make the first step trivially easy.
-
-### North Star Metric
-One metric that best captures the value you deliver to customers. Focus creates alignment.
-
-**Marketing application**: Identify your North Star (active users, completed projects, revenue per customer) and align all efforts toward it.
-
-### The Cobra Effect
-When incentives backfire and produce the opposite of intended results.
-
-**Marketing application**: Test incentive structures. A referral bonus might attract low-quality referrals gaming the system.
+| Model | Application |
+|-------|------------|
+| **Hick's Law** | One clear CTA beats three; fewer form fields beat more |
+| **Rule of 7** | ~7 touchpoints before conversion; build multi-touch campaigns across channels |
+| **BJ Fogg Model** | Behavior = Motivation × Ability × Prompt—all three must be present |
+| **EAST Framework** | Make desired actions: Easy, Attractive, Social, Timely |
+| **Activation Energy** | Pre-fill forms, offer templates, show quick wins—make the first step trivially easy |
+| **Nudge Theory** | Default selections and strategic ordering guide behavior without restricting choice |
+| **Cobra Effect** | Test incentive structures—referral bonuses might attract low-quality gaming |
 
 ---
 
 ## Growth & Scaling Models
 
-These models explain how marketing compounds and scales.
-
-### Feedback Loops
-Output becomes input, creating cycles. Positive loops accelerate growth; negative loops create decline.
-
-**Marketing application**: Build virtuous cycles: more users → more content → better SEO → more users. Identify and strengthen positive loops.
-
-### Compounding
-Small, consistent gains accumulate into large results over time. Early gains matter most.
-
-**Marketing application**: Consistent content, SEO, and brand building compound. Start early; benefits accumulate exponentially.
-
-### Network Effects
-A product becomes more valuable as more people use it.
-
-**Marketing application**: Design features that improve with more users: shared workspaces, integrations, marketplaces, communities.
-
-### Flywheel Effect
-Sustained effort creates momentum that eventually maintains itself. Hard to start, easy to maintain.
-
-**Marketing application**: Content → traffic → leads → customers → case studies → more content. Each element powers the next.
-
-### Switching Costs
-The price (time, money, effort, data) of changing to a competitor. High switching costs create retention.
-
-**Marketing application**: Increase switching costs ethically: integrations, data accumulation, workflow customization, team adoption.
-
-### Exploration vs. Exploitation
-Balance trying new things (exploration) with optimizing what works (exploitation).
-
-**Marketing application**: Don't abandon working channels for shiny new ones, but allocate some budget to experiments.
-
-### Critical Mass / Tipping Point
-The threshold after which growth becomes self-sustaining.
-
-**Marketing application**: Focus resources on reaching critical mass in one segment before expanding. Depth before breadth.
-
-### Survivorship Bias
-Focusing on successes while ignoring failures that aren't visible.
-
-**Marketing application**: Study failed campaigns, not just successful ones. The viral hit you're copying had 99 failures you didn't see.
+| Model | Application |
+|-------|------------|
+| **Feedback Loops** | Build virtuous cycles: more users → more content → better SEO → more users |
+| **Flywheel Effect** | Content → traffic → leads → customers → case studies → more content |
+| **Compounding** | Consistent content/SEO/brand building compounds—start early |
+| **Network Effects** | Design features that improve with more users: shared workspaces, communities |
+| **Switching Costs** | Increase ethically: integrations, data accumulation, workflow customization |
+| **Critical Mass** | Focus resources on one segment before expanding—depth before breadth |
+| **Survivorship Bias** | Study failed campaigns; the viral hit you're copying had 99 unseen failures |
 
 ---
 

--- a/skills/onboarding-cro/SKILL.md
+++ b/skills/onboarding-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: onboarding-cro
-description: When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions "onboarding flow," "activation rate," "user activation," "first-run experience," "empty states," "onboarding checklist," "aha moment," or "new user experience." For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.
+description: Designs onboarding flows, defines activation metrics, builds onboarding checklists, optimizes empty states, creates trigger-based email sequences, and audits post-signup drop-off funnels. Use when the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions "onboarding flow," "activation rate," "user activation," "first-run experience," "empty states," "onboarding checklist," "aha moment," or "new user experience." For signup/registration optimization, see signup-flow-cro. For ongoing email sequences, see email-sequence.
 metadata:
   version: 1.0.0
 ---
 
 # Onboarding CRO
-
-You are an expert in user onboarding and activation. Your goal is to help users reach their "aha moment" as quickly as possible and establish habits that lead to long-term retention.
 
 ## Initial Assessment
 
@@ -22,41 +20,30 @@ Before providing recommendations, understand:
 
 ---
 
-## Core Principles
-
-### 1. Time-to-Value Is Everything
-Remove every step between signup and experiencing core value.
-
-### 2. One Goal Per Session
-Focus first session on one successful outcome. Save advanced features for later.
-
-### 3. Do, Don't Show
-Interactive > Tutorial. Doing the thing > Learning about the thing.
-
-### 4. Progress Creates Motivation
-Show advancement. Celebrate completions. Make the path visible.
-
----
-
 ## Defining Activation
 
 ### Find Your Aha Moment
 
-The action that correlates most strongly with retention:
+Identify the action that correlates most strongly with retention:
 - What do retained users do that churned users don't?
 - What's the earliest indicator of future engagement?
 
 **Examples by product type:**
-- Project management: Create first project + add team member
-- Analytics: Install tracking + see first report
-- Design tool: Create first design + export/share
-- Marketplace: Complete first transaction
+
+| Product Type | Aha Moment |
+|--------------|-----------|
+| Project management | Create first project + add team member |
+| Analytics | Install tracking + see first report |
+| Design tool | Create first design + export/share |
+| Marketplace | Complete first transaction |
 
 ### Activation Metrics
 - % of signups who reach activation
 - Time to activation
 - Steps to activation
 - Activation by cohort/source
+
+**Validation checkpoint:** If you can't identify a clear aha moment from cohort data, start with the earliest action that differentiates retained vs. churned users.
 
 ---
 

--- a/skills/page-cro/SKILL.md
+++ b/skills/page-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: page-cro
-description: When the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says "CRO," "conversion rate optimization," "this page isn't converting," "improve conversions," or "why isn't this page working." For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.
+description: Audits page value proposition clarity, headline effectiveness, CTA placement and copy, visual hierarchy, trust signals, objection handling, and friction points. Provides prioritized recommendations as quick wins, high-impact changes, and A/B test hypotheses. Use when the user wants to optimize, improve, or increase conversions on any marketing page — including homepage, landing pages, pricing pages, feature pages, or blog posts. Also use when the user says "CRO," "conversion rate optimization," "this page isn't converting," "improve conversions," or "why isn't this page working." For signup/registration flows, see signup-flow-cro. For post-signup activation, see onboarding-cro. For forms outside of signup, see form-cro. For popups/modals, see popup-cro.
 metadata:
   version: 1.0.0
 ---
 
 # Page Conversion Rate Optimization (CRO)
-
-You are a conversion rate optimization expert. Your goal is to analyze marketing pages and provide actionable recommendations to improve conversion rates.
 
 ## Initial Assessment
 

--- a/skills/paid-ads/SKILL.md
+++ b/skills/paid-ads/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Paid Ads
 
-You are an expert performance marketer with direct access to ad platform accounts. Your goal is to help create, optimize, and scale paid advertising campaigns that drive efficient customer acquisition.
-
 ## Before Starting
 
 **Check for product marketing context first:**
@@ -255,28 +253,19 @@ Before launching campaigns, ensure proper tracking and account setup.
 
 ---
 
-## Common Mistakes to Avoid
+## Optimization Decision Tree
 
-### Strategy
-- Launching without conversion tracking
-- Too many campaigns (fragmenting budget)
-- Not giving algorithms enough learning time
-- Optimizing for wrong metric
+**If CPA > target by 20%+ after 7 days AND CTR > 1%:**
+→ Problem is post-click. Check landing page conversion rate.
 
-### Targeting
-- Audiences too narrow or too broad
-- Not excluding existing customers
-- Overlapping audiences competing
+**If CPA > target AND CTR < 1%:**
+→ Creative isn't resonating. Test new hooks/angles.
 
-### Creative
-- Only one ad per ad set
-- Not refreshing creative (fatigue)
-- Mismatch between ad and landing page
+**If CPM increasing AND frequency > 3:**
+→ Ad fatigue. Refresh creative or expand audience.
 
-### Budget
-- Spreading too thin across campaigns
-- Making big budget changes (disrupts learning)
-- Stopping campaigns during learning phase
+**If CPA on target but volume too low:**
+→ Expand audiences (broader lookalikes, new keywords) or increase budget 20% increments.
 
 ---
 

--- a/skills/paywall-upgrade-cro/SKILL.md
+++ b/skills/paywall-upgrade-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: paywall-upgrade-cro
-description: When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions "paywall," "upgrade screen," "upgrade modal," "upsell," "feature gate," "convert free to paid," "freemium conversion," "trial expiration screen," "limit reached screen," "plan upgrade prompt," or "in-app pricing." Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.
+description: Designs feature gate screens, usage limit paywalls, trial expiration flows, and upgrade modals. Optimizes trigger timing, copy, pricing presentation, and conversion paths from free to paid. Use when the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use when the user mentions "paywall," "upgrade screen," "upgrade modal," "upsell," "feature gate," "convert free to paid," "freemium conversion," "trial expiration screen," "limit reached screen," "plan upgrade prompt," or "in-app pricing." Distinct from public pricing pages (see page-cro) — this skill focuses on in-product upgrade moments where the user has already experienced value.
 metadata:
   version: 1.0.0
 ---
 
 # Paywall and Upgrade Screen CRO
-
-You are an expert in in-app paywalls and upgrade flows. Your goal is to convert free users to paid, or upgrade users to higher tiers, at moments when they've experienced enough value to justify the commitment.
 
 ## Initial Assessment
 
@@ -21,29 +19,6 @@ Before providing recommendations, understand:
 2. **Product Model** - What's free? What's behind paywall? What triggers prompts? Current conversion rate?
 
 3. **User Journey** - When does this appear? What have they experienced? What are they trying to do?
-
----
-
-## Core Principles
-
-### 1. Value Before Ask
-- User should have experienced real value first
-- Upgrade should feel like natural next step
-- Timing: After "aha moment," not before
-
-### 2. Show, Don't Just Tell
-- Demonstrate the value of paid features
-- Preview what they're missing
-- Make the upgrade feel tangible
-
-### 3. Friction-Free Path
-- Easy to upgrade when ready
-- Don't make them hunt for pricing
-
-### 4. Respect the No
-- Don't trap or pressure
-- Make it easy to continue free
-- Maintain trust for future conversion
 
 ---
 

--- a/skills/popup-cro/SKILL.md
+++ b/skills/popup-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: popup-cro
-description: When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions "exit intent," "popup conversions," "modal optimization," "lead capture popup," "email popup," "announcement banner," or "overlay." For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.
+description: Designs popup layouts, writes conversion copy, configures display triggers and timing, implements frequency capping, and A/B tests popup variants. Use when the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also use when the user mentions "exit intent," "popup conversions," "modal optimization," "lead capture popup," "email popup," "announcement banner," or "overlay." For forms outside of popups, see form-cro. For general page conversion optimization, see page-cro.
 metadata:
   version: 1.0.0
 ---
 
 # Popup CRO
-
-You are an expert in popup and modal optimization. Your goal is to create popups that convert without annoying users or damaging brand perception.
 
 ## Initial Assessment
 
@@ -35,26 +33,6 @@ Before providing recommendations, understand:
    - Traffic sources (paid, organic, direct)
    - New vs. returning visitors
    - Page types where shown
-
----
-
-## Core Principles
-
-### 1. Timing Is Everything
-- Too early = annoying interruption
-- Too late = missed opportunity
-- Right time = helpful offer at moment of need
-
-### 2. Value Must Be Obvious
-- Clear, immediate benefit
-- Relevant to page context
-- Worth the interruption
-
-### 3. Respect the User
-- Easy to dismiss
-- Don't trap or trick
-- Remember preferences
-- Don't ruin the experience
 
 ---
 
@@ -99,132 +77,64 @@ Before providing recommendations, understand:
 
 ## Popup Types
 
-### Email Capture Popup
-**Goal**: Newsletter/list subscription
-
-**Best practices:**
-- Clear value prop (not just "Subscribe")
-- Specific benefit of subscribing
-- Single field (email only)
-- Consider incentive (discount, content)
-
-**Copy structure:**
-- Headline: Benefit or curiosity hook
-- Subhead: What they get, how often
-- CTA: Specific action ("Get Weekly Tips")
-
-### Lead Magnet Popup
-**Goal**: Exchange content for email
-
-**Best practices:**
-- Show what they get (cover image, preview)
-- Specific, tangible promise
-- Minimal fields (email, maybe name)
-- Instant delivery expectation
-
-### Discount/Promotion Popup
-**Goal**: First purchase or conversion
-
-**Best practices:**
-- Clear discount (10%, $20, free shipping)
-- Deadline creates urgency
-- Single use per visitor
-- Easy to apply code
-
-### Exit Intent Popup
-**Goal**: Last-chance conversion
-
-**Best practices:**
-- Acknowledge they're leaving
-- Different offer than entry popup
-- Address common objections
-- Final compelling reason to stay
-
-**Formats:**
-- "Wait! Before you go..."
-- "Forget something?"
-- "Get 10% off your first order"
-- "Questions? Chat with us"
-
-### Announcement Banner
-**Goal**: Site-wide communication
-
-**Best practices:**
-- Top of page (sticky or static)
-- Single, clear message
-- Dismissable
-- Links to more info
-- Time-limited (don't leave forever)
-
-### Slide-In
-**Goal**: Less intrusive engagement
-
-**Best practices:**
-- Enters from corner/bottom
-- Doesn't block content
-- Easy to dismiss or minimize
-- Good for chat, support, secondary CTAs
+| Type | Goal | Key Practice |
+|------|------|-------------|
+| **Email Capture** | Newsletter subscription | Clear value prop, single field, specific CTA ("Get Weekly Tips") |
+| **Lead Magnet** | Content for email | Show preview of what they get, minimal fields, instant delivery |
+| **Discount/Promo** | First purchase | Clear discount amount, deadline urgency, single use per visitor |
+| **Exit Intent** | Last-chance conversion | Different offer than entry popup, address objections |
+| **Announcement Banner** | Site-wide communication | Top of page, dismissable, time-limited |
+| **Slide-In** | Less intrusive engagement | Corner/bottom entry, doesn't block content, easy dismiss |
 
 ---
 
-## Design Best Practices
+## Implementation Code
 
-### Visual Hierarchy
-1. Headline (largest, first seen)
-2. Value prop/offer (clear benefit)
-3. Form/CTA (obvious action)
-4. Close option (easy to find)
+### Exit Intent Detection
 
-### Sizing
-- Desktop: 400-600px wide typical
-- Don't cover entire screen
-- Mobile: Full-width bottom or center, not full-screen
-- Leave space to close (visible X, click outside)
+```javascript
+document.addEventListener('mouseout', function(e) {
+  if (e.clientY < 0 && !sessionStorage.getItem('popup_shown')) {
+    showPopup();
+    sessionStorage.setItem('popup_shown', 'true');
+  }
+});
+```
 
-### Close Button
-- Always visible (top right is convention)
-- Large enough to tap on mobile
-- "No thanks" text link as alternative
-- Click outside to close
+### Frequency Capping with localStorage
 
-### Mobile Considerations
-- Can't detect exit intent (use alternatives)
-- Full-screen overlays feel aggressive
-- Bottom slide-ups work well
-- Larger touch targets
-- Easy dismiss gestures
+```javascript
+function shouldShowPopup(popupId, cooldownDays = 7) {
+  const key = `popup_dismissed_${popupId}`;
+  const dismissed = localStorage.getItem(key);
+  if (dismissed && Date.now() - parseInt(dismissed) < cooldownDays * 86400000) {
+    return false;
+  }
+  return true;
+}
 
-### Imagery
-- Product image or preview
-- Face if relevant (increases trust)
-- Minimal for speed
-- Optional—copy can work alone
+function dismissPopup(popupId) {
+  localStorage.setItem(`popup_dismissed_${popupId}`, Date.now().toString());
+}
+```
+
+### Tracking Events
+
+```javascript
+// Track popup interactions
+analytics.track('popup_shown', { popup_id: 'exit-intent-discount', trigger: 'exit_intent' });
+analytics.track('popup_converted', { popup_id: 'exit-intent-discount', email: true });
+analytics.track('popup_dismissed', { popup_id: 'exit-intent-discount', method: 'close_button' });
+```
 
 ---
 
-## Copy Formulas
+## Copy Guidelines
 
-### Headlines
-- Benefit-driven: "Get [result] in [timeframe]"
-- Question: "Want [desired outcome]?"
-- Command: "Don't miss [thing]"
-- Social proof: "Join [X] people who..."
-- Curiosity: "The one thing [audience] always get wrong about [topic]"
-
-### Subheadlines
-- Expand on the promise
-- Address objection ("No spam, ever")
-- Set expectations ("Weekly tips in 5 min")
-
-### CTA Buttons
-- First person works: "Get My Discount" vs "Get Your Discount"
-- Specific over generic: "Send Me the Guide" vs "Submit"
-- Value-focused: "Claim My 10% Off" vs "Subscribe"
-
-### Decline Options
-- Polite, not guilt-trippy
-- "No thanks" / "Maybe later" / "I'm not interested"
-- Avoid manipulative: "No, I don't want to save money"
+- **Headlines**: Benefit-driven or curiosity-based ("Get [result] in [timeframe]", "Join [X] people who...")
+- **CTA buttons**: First-person, value-focused ("Get My Discount", "Send Me the Guide")
+- **Decline options**: Polite, non-manipulative ("No thanks", "Maybe later")
+- **Subheadlines**: Address objections or set expectations ("No spam, ever", "Weekly tips in 5 min")
 
 ---
 
@@ -343,94 +253,28 @@ Ideas to A/B test with expected outcomes
 
 ---
 
+## Optimization Workflow
+
+1. **Implement** — Deploy popup with tracking events (shown, converted, dismissed)
+2. **Baseline** — Run for 7 days minimum to establish conversion rate
+   - *Validate*: ≥1,000 impressions before drawing conclusions
+3. **Analyze** — Check conversion rate vs. benchmarks (email: 2-5%, exit intent: 3-10%)
+4. **Iterate** — Test one variable at a time (trigger, copy, offer, timing)
+   - *Validate*: Run each variant for ≥7 days or ≥500 impressions per variant
+5. **Monitor** — Watch close rate and page exit rate for annoyance signals
+
+---
+
 ## Experiment Ideas
 
-### Placement & Format Experiments
+Key areas to test:
+- **Format**: Center modal vs. slide-in, full-screen vs. smaller, banner position
+- **Triggers**: Exit intent vs. time delay vs. scroll depth, optimal timing thresholds
+- **Copy**: Headline variations, CTA text, urgency vs. value framing, decline text tone
+- **Personalization**: Dynamic content by visitor data, segment by traffic source
+- **Frequency**: Session caps, cool-down periods, escalating offers across visits
 
-**Banner Variations**
-- Top bar vs. banner below header
-- Sticky banner vs. static banner
-- Full-width vs. contained banner
-- Banner with countdown timer vs. without
-
-**Popup Formats**
-- Center modal vs. slide-in from corner
-- Full-screen overlay vs. smaller modal
-- Bottom bar vs. corner popup
-- Top announcements vs. bottom slideouts
-
-**Position Testing**
-- Test popup sizes on desktop and mobile
-- Left corner vs. right corner for slide-ins
-- Test visibility without blocking content
-
----
-
-### Trigger Experiments
-
-**Timing Triggers**
-- Exit intent vs. 30-second delay vs. 50% scroll depth
-- Test optimal time delay (10s vs. 30s vs. 60s)
-- Test scroll depth percentage (25% vs. 50% vs. 75%)
-- Page count trigger (show after X pages viewed)
-
-**Behavior Triggers**
-- Show based on user intent prediction
-- Trigger based on specific page visits
-- Return visitor vs. new visitor targeting
-- Show based on referral source
-
-**Click Triggers**
-- Click-triggered popups for lead magnets
-- Button-triggered vs. link-triggered modals
-- Test in-content triggers vs. sidebar triggers
-
----
-
-### Messaging & Content Experiments
-
-**Headlines & Copy**
-- Test attention-grabbing vs. informational headlines
-- "Limited-time offer" vs. "New feature alert" messaging
-- Urgency-focused copy vs. value-focused copy
-- Test headline length and specificity
-
-**CTAs**
-- CTA button text variations
-- Button color testing for contrast
-- Primary + secondary CTA vs. single CTA
-- Test decline text (friendly vs. neutral)
-
-**Visual Content**
-- Add countdown timers to create urgency
-- Test with/without images
-- Product preview vs. generic imagery
-- Include social proof in popup
-
----
-
-### Personalization Experiments
-
-**Dynamic Content**
-- Personalize popup based on visitor data
-- Show industry-specific content
-- Tailor content based on pages visited
-- Use progressive profiling (ask more over time)
-
-**Audience Targeting**
-- New vs. returning visitor messaging
-- Segment by traffic source
-- Target based on engagement level
-- Exclude already-converted visitors
-
----
-
-### Frequency & Rules Experiments
-
-- Test frequency capping (once per session vs. once per week)
-- Cool-down period after dismissal
-- Test different dismiss behaviors
-- Show escalating offers over multiple visits
+**For detailed experiment variations**: See [references/experiments.md](references/experiments.md)
 
 ---
 

--- a/skills/pricing-strategy/SKILL.md
+++ b/skills/pricing-strategy/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Pricing Strategy
 
-You are an expert in SaaS pricing and monetization strategy. Your goal is to help design pricing that captures value, drives growth, and aligns with customer willingness to pay.
-
 ## Before Starting
 
 **Check for product marketing context first:**
@@ -69,15 +67,7 @@ Price should be based on value delivered, not cost to serve:
 
 ## Value Metrics
 
-### What is a Value Metric?
-
-The value metric is what you charge for—it should scale with the value customers receive.
-
-**Good value metrics:**
-- Align price with value delivered
-- Are easy to understand
-- Scale as customer grows
-- Are hard to game
+The value metric is what you charge for—it should scale with the value customers receive. Test: "As a customer uses more of [metric], do they get more value?" If yes, it's a good metric.
 
 ### Common Value Metrics
 
@@ -89,12 +79,6 @@ The value metric is what you charge for—it should scale with the value custome
 | Per contact/record | CRM, email tools | Mailchimp |
 | Per transaction | Payments, marketplaces | Stripe |
 | Flat fee | Simple products | Basecamp |
-
-### Choosing Your Value Metric
-
-Ask: "As a customer uses more of [metric], do they get more value?"
-- If yes → good value metric
-- If no → price doesn't align with value
 
 ---
 
@@ -206,6 +190,21 @@ Identifies which features customers value most:
 - [ ] Set price points based on research
 - [ ] Created annual discount strategy
 - [ ] Planned enterprise/custom tier
+
+---
+
+## Implementation Workflow
+
+1. **Research** — Conduct Van Westendorp or MaxDiff analysis, review competitor pricing
+   - *Validate*: Have willingness-to-pay data from ≥30 respondents or clear competitive benchmarks
+2. **Choose value metric** — Identify what scales with customer value
+   - *Validate*: Passes "more usage = more value" test
+3. **Design tiers** — Good-Better-Best with clear differentiation
+   - *Validate*: Each tier has a distinct persona; feature gates are logical
+4. **Set price points** — Based on research, competitive position, and perceived value
+   - *Validate*: Price sits between cost-to-serve floor and perceived-value ceiling
+5. **Build pricing page** — Clear comparison, recommended tier highlighted, annual toggle
+6. **Monitor and iterate** — Track conversion rate, ARPU, churn by tier
 
 ---
 

--- a/skills/programmatic-seo/SKILL.md
+++ b/skills/programmatic-seo/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Programmatic SEO
 
-You are an expert in programmatic SEO—building SEO-optimized pages at scale using templates and data. Your goal is to create pages that rank, provide value, and avoid thin content penalties.
-
 ## Initial Assessment
 
 **Check for product marketing context first:**
@@ -119,12 +117,16 @@ You can layer multiple playbooks (e.g., "Best coworking spaces in San Diego").
 - Volume distribution (head vs. long tail)
 - Trend direction
 
+*Checkpoint*: Confirm ≥100 search volume for the head pattern before proceeding.
+
 ### 2. Data Requirements
 
 **Identify data sources:**
 - What data populates each page?
 - Is it first-party, scraped, licensed, public?
 - How is it updated?
+
+*Checkpoint*: Verify data covers ≥80% of target pages with sufficient depth for unique content.
 
 ### 3. Template Design
 
@@ -194,13 +196,29 @@ Watch for: Thin content warnings, Ranking drops, Manual actions, Crawl errors
 
 ---
 
-## Common Mistakes
+## Template Example (Next.js)
 
-- **Thin content**: Just swapping city names in identical content
-- **Keyword cannibalization**: Multiple pages targeting same keyword
-- **Over-generation**: Creating pages with no search demand
-- **Poor data quality**: Outdated or incorrect information
-- **Ignoring UX**: Pages exist for Google, not users
+```tsx
+// pages/tools/[slug].tsx
+export async function getStaticProps({ params }) {
+  const tool = await getToolData(params.slug);
+  return { props: { tool }, revalidate: 86400 };
+}
+
+export async function getStaticPaths() {
+  const tools = await getAllTools();
+  return {
+    paths: tools.map(t => ({ params: { slug: t.slug } })),
+    fallback: 'blocking',
+  };
+}
+```
+
+```html
+<!-- Title template -->
+<title>{tool.name} - Best {tool.category} Tool | YourSite</title>
+<meta name="description" content="{tool.name} is a {tool.type} that {tool.valueStatement}. Compare features, pricing, and alternatives." />
+```
 
 ---
 

--- a/skills/referral-program/SKILL.md
+++ b/skills/referral-program/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: referral-program
-description: "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' or 'partner program.' This skill covers program design, incentive structure, and growth optimization."
+description: "Designs reward structures, calculates referral economics, builds tracking systems, creates referral email templates, and optimizes conversion funnels for referral and affiliate programs. Use when the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' or 'partner program.'"
 metadata:
   version: 1.0.0
 ---
 
 # Referral & Affiliate Programs
 
-You are an expert in viral growth and referral marketing. Your goal is to help design and optimize programs that turn customers into growth engines.
 
 ## Before Starting
 

--- a/skills/schema-markup/SKILL.md
+++ b/skills/schema-markup/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Schema Markup
 
-You are an expert in structured data and schema markup. Your goal is to implement schema.org markup that helps search engines understand content and enables rich results in search.
-
 ## Initial Assessment
 
 **Check for product marketing context first:**
@@ -24,27 +22,14 @@ Before implementing schema, understand:
 
 ---
 
-## Core Principles
+## Implementation Workflow
 
-### 1. Accuracy First
-- Schema must accurately represent page content
-- Don't markup content that doesn't exist
-- Keep updated when content changes
-
-### 2. Use JSON-LD
-- Google recommends JSON-LD format
-- Easier to implement and maintain
-- Place in `<head>` or end of `<body>`
-
-### 3. Follow Google's Guidelines
-- Only use markup Google supports
-- Avoid spam tactics
-- Review eligibility requirements
-
-### 4. Validate Everything
-- Test before deploying
-- Monitor Search Console
-- Fix errors promptly
+1. **Identify page type** → Match to schema type from table below
+2. **Draft JSON-LD** → Use required + recommended properties
+3. **Validate** → Test at https://search.google.com/test/rich-results
+4. **Fix errors** → Resolve missing required properties, invalid values
+5. **Deploy** → Place in `<head>` or end of `<body>`
+6. **Monitor** → Check Search Console Enhancements reports weekly
 
 ---
 
@@ -89,17 +74,47 @@ Required: itemListElement (array with position, name, item)
 
 ---
 
+## Complete Example: FAQPage
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is your refund policy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We offer a full refund within 30 days of purchase."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I cancel my subscription?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Go to Settings > Billing > Cancel Subscription."
+      }
+    }
+  ]
+}
+```
+
 ## Multiple Schema Types
 
-You can combine multiple schema types on one page using `@graph`:
+Combine types on one page using `@graph`:
 
 ```json
 {
   "@context": "https://schema.org",
   "@graph": [
-    { "@type": "Organization", ... },
-    { "@type": "WebSite", ... },
-    { "@type": "BreadcrumbList", ... }
+    { "@type": "Organization", "name": "YourCo", "url": "https://yourco.com" },
+    { "@type": "WebSite", "name": "YourCo", "url": "https://yourco.com" },
+    { "@type": "BreadcrumbList", "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://yourco.com" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://yourco.com/blog" }
+    ]}
   ]
 }
 ```

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: seo-audit
-description: When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO audit," "technical SEO," "why am I not ranking," "SEO issues," "on-page SEO," "meta tags review," or "SEO health check." For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup.
+description: Analyzes crawlability, checks meta tags and heading hierarchy, reviews internal linking structure, audits Core Web Vitals, identifies missing alt text, and provides prioritized SEO recommendations. Use when the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO audit," "technical SEO," "why am I not ranking," "SEO issues," "on-page SEO," "meta tags review," or "SEO health check." For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup.
 metadata:
   version: 1.0.0
 ---
 
 # SEO Audit
-
-You are an expert in search engine optimization. Your goal is to identify SEO issues and provide actionable recommendations to improve organic search performance.
 
 ## Initial Assessment
 

--- a/skills/signup-flow-cro/SKILL.md
+++ b/skills/signup-flow-cro/SKILL.md
@@ -1,13 +1,11 @@
 ---
 name: signup-flow-cro
-description: When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions "signup conversions," "registration friction," "signup form optimization," "free trial signup," "reduce signup dropoff," or "account creation flow." For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.
+description: Audits signup flows to identify drop-off points, reduces form fields, optimizes social auth placement, designs multi-step registration with progress indicators, and improves post-submit verification flows. Use when the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the user mentions "signup conversions," "registration friction," "signup form optimization," "free trial signup," "reduce signup dropoff," or "account creation flow." For post-signup onboarding, see onboarding-cro. For lead capture forms (not account creation), see form-cro.
 metadata:
   version: 1.0.0
 ---
 
 # Signup Flow CRO
-
-You are an expert in optimizing signup and registration flows. Your goal is to reduce friction, increase completion rates, and set users up for successful activation.
 
 ## Initial Assessment
 
@@ -264,80 +262,14 @@ Organized by:
 
 ## Experiment Ideas
 
-### Form Design Experiments
+Key areas to test:
+- **Fields**: Minimum viable (email + password only), single "Name" vs. First/Last, required vs. optional balance
+- **Auth options**: SSO prominent vs. email prominent, which providers resonate (varies by B2B/B2C)
+- **Copy**: CTA text ("Create Account" vs. "Start Free Trial"), trust elements, value prop emphasis
+- **Trial model**: Credit card required vs. not, trial length (7/14/30 days), freemium vs. free trial
+- **Friction**: Email verification timing, CAPTCHA impact, post-submit auto-login vs. require login
 
-**Layout & Structure**
-- Single-step vs. multi-step signup flow
-- Multi-step with progress bar vs. without
-- 1-column vs. 2-column field layout
-- Form embedded on page vs. separate signup page
-- Horizontal vs. vertical field alignment
-
-**Field Optimization**
-- Reduce to minimum fields (email + password only)
-- Add or remove phone number field
-- Single "Name" field vs. "First/Last" split
-- Add or remove company/organization field
-- Test required vs. optional field balance
-
-**Authentication Options**
-- Add SSO options (Google, Microsoft, GitHub, LinkedIn)
-- SSO prominent vs. email form prominent
-- Test which SSO options resonate (varies by audience)
-- SSO-only vs. SSO + email option
-
-**Visual Design**
-- Test button colors and sizes for CTA prominence
-- Plain background vs. product-related visuals
-- Test form container styling (card vs. minimal)
-- Mobile-optimized layout testing
-
----
-
-### Copy & Messaging Experiments
-
-**Headlines & CTAs**
-- Test headline variations above signup form
-- CTA button text: "Create Account" vs. "Start Free Trial" vs. "Get Started"
-- Add clarity around trial length in CTA
-- Test value proposition emphasis in form header
-
-**Microcopy**
-- Field labels: minimal vs. descriptive
-- Placeholder text optimization
-- Error message clarity and tone
-- Password requirement display (upfront vs. on error)
-
-**Trust Elements**
-- Add social proof next to signup form
-- Test trust badges near form (security, compliance)
-- Add "No credit card required" messaging
-- Include privacy assurance copy
-
----
-
-### Trial & Commitment Experiments
-
-**Free Trial Variations**
-- Credit card required vs. not required for trial
-- Test trial length impact (7 vs. 14 vs. 30 days)
-- Freemium vs. free trial model
-- Trial with limited features vs. full access
-
-**Friction Points**
-- Email verification required vs. delayed vs. removed
-- Test CAPTCHA impact on completion
-- Terms acceptance checkbox vs. implicit acceptance
-- Phone verification for high-value accounts
-
----
-
-### Post-Submit Experiments
-
-- Clear next steps messaging after signup
-- Instant product access vs. email confirmation first
-- Personalized welcome message based on signup data
-- Auto-login after signup vs. require login
+**For detailed experiment variations**: See [references/experiments.md](references/experiments.md)
 
 ---
 

--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Social Content
 
-You are an expert social media strategist. Your goal is to help create engaging content that builds audience, drives engagement, and supports business goals.
-
 ## Before Creating Content
 
 **Check for product marketing context first:**


### PR DESCRIPTION
👋  Hullo @coreyhaines31 

Nice work on these marketing skills. Seems like a lot of knowledge distilled down and shared, as someone in Developer Relations, and _somewhat_ new to Marketing, this is much appreciated.

I ran them through the eval machinery at work - which we typically use for evaluating coding-related skills - so i was interested to see how this would pan out. According to our analysis, making the changes in this PR will uplift the effectiveness of these skills by between **5%** and **43%** which is pretty remarkable.

All 29 skills now score ≥80%. Average score improved from 80% to 90%.

Here's a summary of the results, with the actual changes listed below.

| Skill                    | Before | After | Change |
|--------------------------|--------|-------|--------|
| onboarding-cro           | 57%    | 100%  | +43    |
| popup-cro                | 70%    | 93%   | +23    |
| schema-markup            | 74%    | 95%   | +21    |
| paywall-upgrade-cro      | 73%    | 94%   | +21    |
| signup-flow-cro          | 75%    | 93%   | +18    |
| form-cro                 | 69%    | 86%   | +17    |
| marketing-psychology     | 74%    | 88%   | +14    |
| page-cro                 | 79%    | 93%   | +14    |
| paid-ads                 | 74%    | 88%   | +14    |
| programmatic-seo         | 74%    | 88%   | +14    |
| free-tool-strategy       | 70%    | 84%   | +14    |
| ab-test-setup            | 88%    | 100%  | +12    |
| competitor-alternatives   | 74%    | 80%   | +6     |
| pricing-strategy         | 74%    | 80%   | +6     |
| analytics-tracking       | 81%    | 86%   | +5     |
| ai-seo                   | 88%    | 93%   | +5     |


<details><summary>Changes Applied Across All Skills</summary>

- Removed "You are an expert..." role-play framing (all 29 skills)
- Added specific concrete actions to descriptions (13 skills)
- Removed verbose Core Principles sections explaining concepts Claude already knows
- Condensed repetitive Experiment Ideas sections into compact summaries
- Added explicit implementation workflows with validation checkpoints
- Added executable code examples where applicable

</details>

Net result: **-982** lines removed, **+302** lines added (leaner, more actionable skills).

The number of deletions might look brutal, but this brings the skills in line with what performs well against Anthropic's best practices. 

Full disclosure, I work at @tesslio where we build tooling around this. Not a pitch, just fixes that were straightforward and interesting for me to make, so I thought I'd offer them as a PR. 🙏

Of course, if you'd _like_ to get them **all** to 100%, click [here](https://tessl.io/registry/skills/github/coreyhaines31/marketingskills/marketing-ideas) to trigger the evals and iterate some more, otherwise I'm happy to offer more improvements as I find them, if you'd like them?

Thanks in advance!
