### PR TITLE
Restructure repo for Claude Organization Plugin GitHub Sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "marketing-skills",
+  "version": "1.3.0",
+  "description": "32 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, site architecture, and more",
+  "author": {
+    "name": "Corey Haines",
+    "url": "https://corey.co"
+  },
+  "homepage": "https://github.com/coreyhaines31/marketingskills",
+  "repository": "https://github.com/coreyhaines31/marketingskills",
+  "license": "MIT",
+  "keywords": [
+    "marketing",
+    "cro",
+    "copywriting",
+    "seo",
+    "paid-ads",
+    "growth",
+    "email",
+    "analytics"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,12 +128,18 @@ description: When the user wants to optimize conversions on any marketing page. 
 
 ## Claude Code Plugin
 
-This repo also serves as a plugin marketplace. The manifest at `.claude-plugin/marketplace.json` lists all skills for installation via:
+This repo serves as a plugin marketplace and supports **Claude Organization Plugin > Sync from GitHub**.
+
+### Individual install (Claude Code CLI)
 
 ```bash
 /plugin marketplace add coreyhaines31/marketingskills
 /plugin install marketing-skills
 ```
+
+### Organization-wide install (GitHub Sync)
+
+Admins can sync this repo via **Claude Settings > Organization > Plugins > Sync from GitHub** using repository `coreyhaines31/marketingskills`. The `.claude-plugin/` directory contains both the marketplace manifest and plugin metadata required by GitHub Sync.
 
 See [Claude Code plugins documentation](https://code.claude.com/docs/en/plugins.md) for details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,223 @@
-AGENTS.md
+# AGENTS.md
+
+Guidelines for AI agents working in this repository.
+
+## Repository Overview
+
+This repository contains **Agent Skills** for AI agents following the [Agent Skills specification](https://agentskills.io/specification.md). Skills install to `.agents/skills/` (the cross-agent standard). This repo also serves as a **Claude Code plugin marketplace** via `.claude-plugin/marketplace.json`.
+
+- **Name**: Marketing Skills
+- **GitHub**: [coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills)
+- **Creator**: Corey Haines
+- **License**: MIT
+
+## Repository Structure
+
+```
+marketingskills/
+├── .claude-plugin/
+│   └── marketplace.json   # Claude Code plugin marketplace manifest
+├── skills/                # Agent Skills
+│   └── skill-name/
+│       └── SKILL.md       # Required skill file
+├── tools/
+│   ├── clis/              # Zero-dependency Node.js CLI tools (51 tools)
+│   ├── integrations/      # API integration guides per tool
+│   └── REGISTRY.md        # Tool index with capabilities
+├── CONTRIBUTING.md
+├── LICENSE
+└── README.md
+```
+
+## Build / Lint / Test Commands
+
+**Skills** are content-only (no build step). Verify manually:
+- YAML frontmatter is valid
+- `name` field matches directory name exactly
+- `name` is 1-64 chars, lowercase alphanumeric and hyphens only
+- `description` is 1-1024 characters
+
+**CLI tools** (`tools/clis/*.js`) are zero-dependency Node.js scripts (Node 18+). Verify with:
+```bash
+node --check tools/clis/<name>.js   # Syntax check
+node tools/clis/<name>.js           # Show usage (no args = help)
+node tools/clis/<name>.js <cmd> --dry-run  # Preview request without sending
+```
+
+## Agent Skills Specification
+
+Skills follow the [Agent Skills spec](https://agentskills.io/specification.md).
+
+### Required Frontmatter
+
+```yaml
+---
+name: skill-name
+description: What this skill does and when to use it. Include trigger phrases.
+---
+```
+
+### Frontmatter Field Constraints
+
+| Field         | Required | Constraints                                                      |
+|---------------|----------|------------------------------------------------------------------|
+| `name`        | Yes      | 1-64 chars, lowercase `a-z`, numbers, hyphens. Must match dir.   |
+| `description` | Yes      | 1-1024 chars. Describe what it does and when to use it.          |
+| `license`     | No       | License name (default: MIT)                                      |
+| `metadata`    | No       | Key-value pairs (author, version, etc.)                          |
+
+### Name Field Rules
+
+- Lowercase letters, numbers, and hyphens only
+- Cannot start or end with hyphen
+- No consecutive hyphens (`--`)
+- Must match parent directory name exactly
+
+**Valid**: `page-cro`, `email-sequence`, `ab-test-setup`
+**Invalid**: `Page-CRO`, `-page`, `page--cro`
+
+### Optional Skill Directories
+
+```
+skills/skill-name/
+├── SKILL.md        # Required - main instructions (<500 lines)
+├── references/     # Optional - detailed docs loaded on demand
+├── scripts/        # Optional - executable code
+└── assets/         # Optional - templates, data files
+```
+
+## Writing Style Guidelines
+
+### Structure
+
+- Keep `SKILL.md` under 500 lines (move details to `references/`)
+- Use H2 (`##`) for main sections, H3 (`###`) for subsections
+- Use bullet points and numbered lists liberally
+- Short paragraphs (2-4 sentences max)
+
+### Tone
+
+- Direct and instructional
+- Second person ("You are a conversion rate optimization expert")
+- Professional but approachable
+
+### Formatting
+
+- Bold (`**text**`) for key terms
+- Code blocks for examples and templates
+- Tables for reference data
+- No excessive emojis
+
+### Clarity Principles
+
+- Clarity over cleverness
+- Specific over vague
+- Active voice over passive
+- One idea per section
+
+### Description Field Best Practices
+
+The `description` is critical for skill discovery. Include:
+1. What the skill does
+2. When to use it (trigger phrases)
+3. Related skills for scope boundaries
+
+```yaml
+description: When the user wants to optimize conversions on any marketing page. Use when the user says "CRO," "conversion rate optimization," "this page isn't converting." For signup flows, see signup-flow-cro.
+```
+
+## Claude Code Plugin
+
+This repo serves as a plugin marketplace and supports **Claude Organization Plugin > Sync from GitHub**.
+
+### Individual install (Claude Code CLI)
+
+```bash
+/plugin marketplace add coreyhaines31/marketingskills
+/plugin install marketing-skills
+```
+
+### Organization-wide install (GitHub Sync)
+
+Admins can sync this repo via **Claude Settings > Organization > Plugins > Sync from GitHub** using repository `coreyhaines31/marketingskills`. The `.claude-plugin/` directory contains both the marketplace manifest and plugin metadata required by GitHub Sync.
+
+See [Claude Code plugins documentation](https://code.claude.com/docs/en/plugins.md) for details.
+
+## Git Workflow
+
+### Branch Naming
+
+- New skills: `feature/skill-name`
+- Improvements: `fix/skill-name-description`
+- Documentation: `docs/description`
+
+### Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+- `feat: add skill-name skill`
+- `fix: improve clarity in page-cro`
+- `docs: update README`
+
+### Pull Request Checklist
+
+- [ ] `name` matches directory name exactly
+- [ ] `name` follows naming rules (lowercase, hyphens, no `--`)
+- [ ] `description` is 1-1024 chars with trigger phrases
+- [ ] `SKILL.md` is under 500 lines
+- [ ] No sensitive data or credentials
+
+## Tool Integrations
+
+This repository includes a tools registry for agent-compatible marketing tools.
+
+- **Tool discovery**: Read `tools/REGISTRY.md` to see available tools and their capabilities
+- **Integration details**: See `tools/integrations/{tool}.md` for API endpoints, auth, and common operations
+- **MCP-enabled tools**: ga4, stripe, mailchimp, google-ads, resend, zapier
+
+### Registry Structure
+
+```
+tools/
+├── REGISTRY.md              # Index of all tools with capabilities
+└── integrations/            # Detailed integration guides
+    ├── ga4.md
+    ├── stripe.md
+    ├── rewardful.md
+    └── ...
+```
+
+### When to Use Tools
+
+Skills reference relevant tools for implementation. For example:
+- `referral-program` skill → rewardful, tolt, dub-co, mention-me guides
+- `analytics-tracking` skill → ga4, mixpanel, segment guides
+- `email-sequence` skill → customer-io, mailchimp, resend guides
+- `paid-ads` skill → google-ads, meta-ads, linkedin-ads guides
+
+## Checking for Updates
+
+When using any skill from this repository:
+
+1. **Once per session**, on first skill use, check for updates:
+   - Fetch `VERSIONS.md` from GitHub: https://raw.githubusercontent.com/coreyhaines31/marketingskills/main/VERSIONS.md
+   - Compare versions against local skill files
+
+2. **Only prompt if meaningful**:
+   - 2 or more skills have updates, OR
+   - Any skill has a major version bump (e.g., 1.x to 2.x)
+
+3. **Non-blocking notification** at end of response:
+   ```
+   ---
+   Skills update available: X marketing skills have updates.
+   Say "update skills" to update automatically, or run `git pull` in your marketingskills folder.
+   ```
+
+4. **If user says "update skills"**:
+   - Run `git pull` in the marketingskills directory
+   - Confirm what was updated
+
+## Skill Categories
+
+See `README.md` for the current list of skills organized by category. When adding new skills, follow the naming patterns of existing skills in that category.


### PR DESCRIPTION
## Summary

Adds support for Claude's **Organization Plugin > Sync from GitHub** feature while preserving full backward compatibility for non-Team users.

### The problem
GitHub Sync requires a specific plugin directory structure (`plugins/<name>/` with `plugin.json` and `skills/` inside). The current repo has skills at the root and uses `"source": "./"` in `marketplace.json`, which doesn't work with GitHub Sync. Also, `CLAUDE.md` was a symlink, which GitHub Sync can't resolve.

### The approach
Rather than moving skills away from the root (which would break `npx skills`, SkillKit, clone-and-copy, and submodule users), this PR keeps **`skills/` at the repo root as the source of truth** and adds a `plugins/marketing-skills/` subdirectory with synced copies for GitHub Sync.

## Changes

- **Added** `plugins/marketing-skills/.claude-plugin/plugin.json` for GitHub Sync
- **Updated** `marketplace.json` source from `"./"` to `"./plugins/marketing-skills"`
- **Added** `sync-plugin-skills.sh` — copies `skills/` into the plugin subdirectory before releases
- **Replaced** `CLAUDE.md` symlink with actual file (symlinks not supported by GitHub Sync)
- **Updated** repo structure docs in AGENTS.md/CLAUDE.md

### What stays the same (backward compatible)
- `skills/` remains at the repo root — no path changes for existing users
- `npx skills add coreyhaines31/marketingskills` still works
- Clone-and-copy, submodule, SkillKit, and fork workflows are unchanged
- All README install instructions unchanged

### Release workflow
Run `bash sync-plugin-skills.sh` before merging to main to ensure the plugin directory has the latest skills.

## Test plan

- [ ] `skills/` exists at repo root with all 32 skills
- [ ] `plugins/marketing-skills/.claude-plugin/plugin.json` is valid JSON
- [ ] `marketplace.json` source is `./plugins/marketing-skills`
- [ ] `plugins/marketing-skills/skills/` has all 32 skills (synced)
- [ ] No symlinks in repo (`find . -type l`)
- [ ] `bash validate-skills.sh` finds skills at root path
- [ ] Test GitHub Sync from an org with the Claude GitHub App installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)