### PR TITLE
feat: add Cowork plugin support with build/sync scripts and guide

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "cowork-plugin",
+  "version": "1.1.0",
+  "description": "32 marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth.",
+  "author": {
+    "name": "Corey Haines",
+    "url": "https://corey.co"
+  },
+  "repository": "https://github.com/coreyhaines31/marketingskills",
+  "license": "MIT",
+  "keywords": ["marketing", "seo", "cro", "copywriting", "paid-ads", "email", "growth", "saas"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ video/
 *~
 .idea/
 .vscode/
+
+# Cowork plugin build output
+*.plugin
+.upstream-cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,19 @@ This repository contains **Agent Skills** for AI agents following the [Agent Ski
 ```
 marketingskills/
 ├── .claude-plugin/
-│   └── marketplace.json   # Claude Code plugin marketplace manifest
+│   ├── marketplace.json   # Claude Code plugin marketplace manifest
+│   └── plugin.json        # Claude Cowork plugin manifest
 ├── skills/                # Agent Skills
 │   └── skill-name/
 │       └── SKILL.md       # Required skill file
+├── scripts/
+│   ├── build-cowork-plugin.sh  # Builds marketing-skills.plugin
+│   └── sync-upstream.sh        # Pulls upstream skills + rebuilds plugin
 ├── tools/
 │   ├── clis/              # Zero-dependency Node.js CLI tools (51 tools)
 │   ├── integrations/      # API integration guides per tool
 │   └── REGISTRY.md        # Tool index with capabilities
+├── COWORK.md
 ├── CONTRIBUTING.md
 ├── LICENSE
 └── README.md
@@ -136,6 +141,16 @@ This repo also serves as a plugin marketplace. The manifest at `.claude-plugin/m
 ```
 
 See [Claude Code plugins documentation](https://code.claude.com/docs/en/plugins.md) for details.
+
+## Cowork Plugin
+
+This repo also ships as a Claude Cowork plugin. Build `marketing-skills.plugin` and upload it to Cowork:
+
+```bash
+bash scripts/build-cowork-plugin.sh
+```
+
+See [COWORK.md](COWORK.md) for upload steps, sync instructions, and what's included in the archive.
 
 ## Git Workflow
 

--- a/COWORK.md
+++ b/COWORK.md
@@ -1,0 +1,87 @@
+# Using marketingskills as a Cowork Plugin
+
+This repo ships as both a **Claude Code marketplace plugin** and a **Claude Cowork plugin**. Both formats coexist — the same `skills/` directory powers both.
+
+## Quick Start
+
+### 1. Build the plugin file
+
+```bash
+bash scripts/build-cowork-plugin.sh
+```
+
+This produces `marketing-skills.plugin` (a zip archive) at the repo root.
+
+### 2. Upload to Cowork
+
+1. Open [Claude Cowork](https://cowork.claude.ai)
+2. Go to **Plugins** → **Upload Plugin**
+3. Select `marketing-skills.plugin`
+4. All 32 marketing skills will be available immediately
+
+## Dual Format: How It Works
+
+| File | Used by |
+|------|---------|
+| `.claude-plugin/marketplace.json` | Claude Code plugin marketplace |
+| `.claude-plugin/plugin.json` | Claude Cowork |
+| `skills/*/SKILL.md` | Both — same files, one source of truth |
+
+Claude Code reads `marketplace.json` to list and install skills via `/plugin`. Cowork reads `plugin.json` for standalone plugin identity and loads skills from the bundled `skills/` directory.
+
+## What's Included in the Plugin
+
+The `.plugin` archive contains:
+
+```
+.claude-plugin/
+├── marketplace.json
+└── plugin.json
+skills/
+├── ab-test-setup/
+├── ad-creative/
+├── ai-seo/
+└── ... (32 skills total)
+README.md
+LICENSE
+AGENTS.md
+VERSIONS.md
+```
+
+**Excluded** (not needed at runtime): `.git/`, `.github/`, `tools/`, `scripts/`
+
+## Keeping Skills Up to Date
+
+### If you cloned directly
+
+```bash
+git pull
+bash scripts/build-cowork-plugin.sh
+```
+
+Then re-upload `marketing-skills.plugin` to Cowork.
+
+### If you forked or copied into a separate project
+
+Use the sync script to pull the latest skills from upstream and rebuild the plugin in one step:
+
+```bash
+bash scripts/sync-upstream.sh
+```
+
+This:
+1. Shallow-clones (or updates) the upstream repo into `.upstream-cache/`
+2. Copies `skills/`, `.claude-plugin/`, and supporting docs into your local structure
+3. Rebuilds `marketing-skills.plugin`
+
+`.upstream-cache/` is gitignored — it's a local fetch cache only.
+
+## Verifying the Build
+
+After building, inspect the archive contents:
+
+```bash
+unzip -l marketing-skills.plugin
+```
+
+You should see `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, all `skills/*/SKILL.md` files, `README.md`, and `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ npx skillkit install coreyhaines31/marketingskills --skill page-cro copywriting
 npx skillkit install coreyhaines31/marketingskills --list
 ```
 
+### Option 7: Cowork Plugin
+
+Upload directly to [Claude Cowork](https://cowork.claude.ai) as a standalone plugin:
+
+```bash
+bash scripts/build-cowork-plugin.sh
+# Then upload marketing-skills.plugin to Cowork
+```
+
+See [COWORK.md](COWORK.md) for full details, including how to keep skills in sync.
+
 ## Upgrading from v1.0
 
 Skills now use `.agents/` instead of `.claude/` for the product marketing context file. Move your existing context file:

--- a/scripts/build-cowork-plugin.sh
+++ b/scripts/build-cowork-plugin.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# build-cowork-plugin.sh
+# Builds marketing-skills.plugin (a zip archive) for upload to Claude Cowork.
+# Output: <repo-root>/marketing-skills.plugin
+#
+# Requires: zip (macOS/Linux) or PowerShell (Windows fallback)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_NAME="marketing-skills.plugin"
+OUTPUT="${REPO_ROOT}/${PLUGIN_NAME}"
+
+cd "${REPO_ROOT}"
+
+echo "Building Cowork plugin..."
+
+# Files/dirs to include in the archive
+INCLUDE_ITEMS=(
+  ".claude-plugin"
+  "skills"
+  "README.md"
+  "LICENSE"
+  "AGENTS.md"
+)
+
+# Add VERSIONS.md if it exists
+[ -f "VERSIONS.md" ] && INCLUDE_ITEMS+=("VERSIONS.md")
+
+if command -v zip &>/dev/null; then
+  # ---- zip (macOS / Linux) ----
+  TMP_FILE="/tmp/${PLUGIN_NAME}"
+  rm -f "${TMP_FILE}"
+
+  zip -r "${TMP_FILE}" "${INCLUDE_ITEMS[@]}" \
+    --exclude "*.git*" \
+    --exclude "*/.DS_Store" \
+    --exclude "*/node_modules/*"
+
+  # cp instead of mv to handle cross-device moves (e.g. Docker volumes)
+  cp "${TMP_FILE}" "${OUTPUT}"
+  rm -f "${TMP_FILE}"
+
+elif command -v powershell &>/dev/null || command -v pwsh &>/dev/null; then
+  # ---- PowerShell (Windows fallback) ----
+  PS_CMD="powershell"
+  command -v pwsh &>/dev/null && PS_CMD="pwsh"
+
+  # Build a temp staging directory then compress
+  STAGING="$(mktemp -d)"
+  for item in "${INCLUDE_ITEMS[@]}"; do
+    if [ -d "${item}" ]; then
+      cp -r "${item}" "${STAGING}/${item}"
+    elif [ -f "${item}" ]; then
+      cp "${item}" "${STAGING}/${item}"
+    fi
+  done
+
+  # Convert paths for PowerShell
+  STAGING_WIN="$(cygpath -w "${STAGING}" 2>/dev/null || echo "${STAGING}")"
+  OUTPUT_WIN="$(cygpath -w "${OUTPUT}" 2>/dev/null || echo "${OUTPUT}")"
+
+  # PowerShell only accepts .zip extension; compress then rename
+  TMP_ZIP="${OUTPUT%.plugin}.zip"
+  TMP_ZIP_WIN="$(cygpath -w "${TMP_ZIP}" 2>/dev/null || echo "${TMP_ZIP}")"
+
+  rm -f "${OUTPUT}" "${TMP_ZIP}"
+  ${PS_CMD} -NoProfile -Command \
+    "Compress-Archive -Path '${STAGING_WIN}\\*' -DestinationPath '${TMP_ZIP_WIN}' -Force"
+
+  mv "${TMP_ZIP}" "${OUTPUT}"
+  rm -rf "${STAGING}"
+
+else
+  echo "Error: neither 'zip' nor PowerShell found. Install zip and retry." >&2
+  exit 1
+fi
+
+echo "Built: ${OUTPUT}"
+echo ""
+echo "Verify contents with:"
+echo "  unzip -l ${PLUGIN_NAME}"

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# sync-upstream.sh
+# Syncs skills and plugin config from the upstream marketingskills repo,
+# then rebuilds the .plugin file. Safe to run repeatedly.
+#
+# Usage: bash scripts/sync-upstream.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPSTREAM_URL="https://github.com/coreyhaines31/marketingskills.git"
+CACHE_DIR="${REPO_ROOT}/.upstream-cache"
+
+echo "Syncing from upstream: ${UPSTREAM_URL}"
+
+if [ -d "${CACHE_DIR}/.git" ]; then
+  echo "Cache found — fetching latest..."
+  git -C "${CACHE_DIR}" fetch origin main
+  git -C "${CACHE_DIR}" reset --hard origin/main
+else
+  echo "No cache found — cloning (shallow)..."
+  rm -rf "${CACHE_DIR}"
+  git clone --depth 1 "${UPSTREAM_URL}" "${CACHE_DIR}"
+fi
+
+echo "Copying skills/..."
+rsync -a --delete "${CACHE_DIR}/skills/" "${REPO_ROOT}/skills/"
+
+echo "Copying .claude-plugin/..."
+rsync -a --delete "${CACHE_DIR}/.claude-plugin/" "${REPO_ROOT}/.claude-plugin/"
+
+echo "Copying supporting docs..."
+for doc in AGENTS.md VERSIONS.md; do
+  if [ -f "${CACHE_DIR}/${doc}" ]; then
+    cp "${CACHE_DIR}/${doc}" "${REPO_ROOT}/${doc}"
+  fi
+done
+
+echo "Rebuilding plugin..."
+bash "${REPO_ROOT}/scripts/build-cowork-plugin.sh"
+
+echo ""
+echo "Sync complete."


### PR DESCRIPTION
Decided to migrate my non code work to claude cowork, did this stuff add hoc, thought it would be nice to add it to the repo

## What this adds

Cowork plugin support so marketingskills can be uploaded directly to Claude Cowork as a standalone `.plugin` file.

## Changes

- `.claude-plugin/plugin.json` — Cowork plugin manifest
- `scripts/build-cowork-plugin.sh` — builds `marketing-skills.plugin` (zip archive); works on macOS/Linux via `zip`, Windows via PowerShell fallback
- `scripts/sync-upstream.sh` — pulls latest skills from upstream and rebuilds the plugin
- `COWORK.md` — guide covering quick start, dual-format explanation, and sync workflow
- `.gitignore` — excludes `*.plugin` and `.upstream-cache/`
- `README.md` — adds Option 7: Cowork Plugin
- `AGENTS.md` — updated repo tree and added Cowork plugin section