### PR TITLE
Fix README typo and validation script macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Skills reference each other and build on shared context. The `product-marketing-
 │  SEO &   │ │   CRO    │ │Content & │ │  Paid &    │ │ Growth & │ │  Sales &    │ │ Strategy  │
 │ Content  │ │          │ │   Copy   │ │Measurement │ │Retention │ │    GTM      │ │           │
 ├──────────┤ ├──────────┤ ├──────────┤ ├────────────┤ ├──────────┤ ├─────────────┤ ├───────────┤
-│seo-audit │ │page-cro  │ │copywritng│ │paid-ads    │ │referral  │ │revops       │ │mktg-ideas │
+│seo-audit │ │page-cro  │ │copywriting│ │paid-ads    │ │referral  │ │revops       │ │mktg-ideas │
 │ai-seo    │ │signup-cro│ │copy-edit │ │ad-creative │ │free-tool │ │sales-enable │ │mktg-psych │
 │site-arch │ │onboard   │ │cold-email│ │ab-test     │ │churn-    │ │launch       │ │           │
 │programm  │ │form-cro  │ │email-seq │ │analytics   │ │ prevent  │ │pricing      │ │           │

--- a/validate-skills.sh
+++ b/validate-skills.sh
@@ -40,8 +40,8 @@ for skill_dir in "$SKILLS_DIR"/*/; do
         continue
     fi
 
-    # Extract frontmatter
-    frontmatter=$(sed -n '/^---$/,/^---$/p' "$skill_file" | head -n -1 | tail -n +2)
+    # Extract frontmatter (use portable sed syntax for macOS compatibility)
+    frontmatter=$(sed -n '/^---$/,/^---$/p' "$skill_file" | sed '1d;$d')
 
     # Validate frontmatter exists
     if [[ -z "$frontmatter" ]]; then


### PR DESCRIPTION
## Summary

This PR fixes two issues found in the repository:

1. **Typo in README.md**: Fixed "copywritng" → "copywriting" in the skills diagram
2. **macOS compatibility in validate-skills.sh**: Fixed the validation script that was failing on macOS

## Changes

### README.md
- Line 33: Fixed typo in the skills diagram (`copywritng` → `copywriting`)

### validate-skills.sh
- Line 44: Replaced non-portable `head -n -1` with portable `sed '1d;$d'` syntax

## Background

The validation script was failing on all 32 skills on macOS with the error:
```
head: illegal line count -- -1
```

This is because `head -n -1` is a GNU extension that is not available in BSD head (which ships with macOS).

The portable alternative `sed '1d;$d'` removes the first and last lines from the output, achieving the same result across both GNU and BSD systems.

## Testing

After the fix, the validation script now runs successfully on macOS:
```
✓ Passed: 31
⚠️  Warnings: 1
All skills are valid! ✓
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)