### PR TITLE
Add persona-messaging skill for buyer-centric sales messaging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,6 +35,7 @@
         "./skills/onboarding-cro",
         "./skills/page-cro",
         "./skills/paid-ads",
+        "./skills/persona-messaging",
         "./skills/paywall-upgrade-cro",
         "./skills/popup-cro",
         "./skills/pricing-strategy",

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -23,6 +23,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | onboarding-cro | 1.1.0 | 2026-02-27 |
 | page-cro | 1.1.0 | 2026-02-27 |
 | paid-ads | 1.1.0 | 2026-02-27 |
+| persona-messaging | 1.1.0 | 2026-03-08 |
 | paywall-upgrade-cro | 1.1.0 | 2026-02-27 |
 | popup-cro | 1.1.0 | 2026-02-27 |
 | pricing-strategy | 1.1.0 | 2026-02-27 |
@@ -38,6 +39,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | social-content | 1.1.0 | 2026-02-27 |
 
 ## Recent Changes
+
+### 2026-03-08
+- Added `persona-messaging` skill for buyer persona dossiers, persona-specific messaging, and research fallback for unknown personas
+- Cross-referenced from `cold-email`, `email-sequence`, and `sales-enablement`
 
 ### 2026-02-27
 - Migrated context path from `.claude/` to `.agents/` for agent-agnostic compatibility

--- a/skills/cold-email/SKILL.md
+++ b/skills/cold-email/SKILL.md
@@ -156,3 +156,4 @@ Use this data to inform your writing — not as a checklist to satisfy.
 - **social-content**: For LinkedIn and social posts
 - **product-marketing-context**: For establishing foundational positioning
 - **revops**: For lead scoring, routing, and pipeline management
+- **persona-messaging**: For detailed buyer persona intelligence and role-specific messaging angles

--- a/skills/email-sequence/SKILL.md
+++ b/skills/email-sequence/SKILL.md
@@ -307,3 +307,4 @@ For implementation, see the [tools registry](../../tools/REGISTRY.md). Key email
 - **ab-test-setup**: For testing email elements
 - **popup-cro**: For email capture popups
 - **revops**: For lifecycle stages that trigger email sequences
+- **persona-messaging**: For buyer persona research dossiers and persona-specific tone

--- a/skills/persona-messaging/SKILL.md
+++ b/skills/persona-messaging/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: persona-messaging
+description: "When the user wants to craft messaging, emails, call scripts, decks, or sales collateral tailored to a specific buyer persona. Use when the user mentions 'persona,' 'buyer brief,' 'who am I selling to,' 'tailor messaging,' 'adapt for audience,' 'ITSM buyer,' 'sales research,' 'buyer intelligence,' 'how do I talk to a CIO,' 'what does this persona care about,' or 'persona dossier.' Works with cold-email, email-sequence, and sales-enablement to provide persona-specific context. For foundational product/audience context, see product-marketing-context."
+metadata:
+  version: 1.1.0
+---
+
+# Persona Messaging
+
+You are an expert in persona-driven B2B enterprise sales messaging for Atlassian. Your job is to advise on language, positioning, mindset, and tone for each buyer persona — translating deep buyer research into messaging that resonates as a peer, not a vendor.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+## Workflow
+
+1. Identify the target persona (ask if unclear — title, function, or role description)
+2. Read `references/persona-index.md` to find the right dossier
+3. **If found:** Load the dossier file, proceed to Scenario Routing
+4. **If NOT found:** Switch to Persona Research Fallback (see below)
+5. Use the **Scenario Routing** table to determine which sections to prioritize
+6. Apply persona intelligence to the task
+7. Generate output: openers, Poke the Bear questions, DISCOVER questions, messaging recommendations
+
+---
+
+## Persona Research Fallback
+
+When a persona is NOT in the library:
+
+1. **Inform the user:** "I don't have a dossier for [title]. Switching to research mode."
+2. **Research the persona** using web search and the 28-subheading framework:
+   1. What they're in charge of
+   2. What they're expected to manage
+   3. Day-to-day duties
+   4. How they spend their time
+   5. What they want to achieve
+   6. How success is measured
+   7. How they're evaluated
+   8. How they/their boss knows they're doing a good job
+   9. External factors that could make things harder
+   10. Industry trends that may negatively impact them
+   11. Strategies in place to help them achieve goals
+   12. Common initiatives people in this role roll out
+   13. Tools they may use
+   14. Who their peers are
+   15. Who reports to them
+   16. Who they report to
+   17. Who outside the company they interact with
+   18. Status quo relationship with Atlassian's product space
+   19. What they're doing now to achieve what Atlassian's products try to achieve
+   20. Why they use those things now
+   21. What would cause them to change from the status quo
+   22. What would have to go wrong
+   23. What you'd have to prove to them
+   24. Barriers to change
+   25. Fears and objections
+   26. Where Atlassian may be weak in their eyes
+   27. How to win the meeting
+   28. Competitive landscape from their perspective
+3. **Generate** the Quick Reference header + full dossier
+4. **Save** as `references/persona-{slug}.md`
+5. **Update** `references/persona-index.md` with the new row
+6. **Flag to the user:** "New persona profile created. You can review and refine it."
+7. **Proceed** with the original task using the new dossier
+
+---
+
+## Scenario Routing
+
+Load different dossier sections depending on what the user needs.
+
+| Task | Priority Sections | What to Extract |
+|------|-------------------|-----------------|
+| Cold outreach / email | 1-5, 21, 33 | Role pain, change triggers, their vocabulary |
+| Cold call scripts | 1-5, 21-22, 25, 33 | Pain, triggers, objections, vocabulary for Poke the Bear and DISCOVER |
+| Meeting prep | 3-4, 25, 27, 28 | Daily reality, objections, how to win, competitors |
+| Objection handling | 23-26 | What to prove, barriers, fears, perceived weaknesses |
+| Business case / ROI | 5-8, 30-32 | Goals, success metrics, solution mapping, plays, proof |
+| Sales collateral / battle cards | 5, 6-8, 29, 33 | Goals, metrics, title variations, key language |
+| Competitive positioning | 18-20, 26, 28 | Status quo, current tools, weaknesses, landscape |
+| Discovery call prep | 1-5, 9-10, 21, 25 | Role context, external pressures, change triggers, objections |
+| Champion enablement | 5-8, 23, 30 | Goals, metrics, what to prove, solution mapping |
+| Deal strategy (MEDDPICC) | 14-16, 21-25, 28 | Org structure, change triggers, barriers, competition |
+
+For the full section-by-section breakdown, see [references/section-guide.md](references/section-guide.md).
+
+---
+
+## How to Apply Persona Data to Messaging
+
+### Pain → Angle
+Map section 21 (change triggers) and section 22 (what would go wrong) into email hooks and Poke the Bear questions. Frame as LOSS, never savings.
+
+### Language → Tone
+Use section 33 terms verbatim in subject lines, headers, CTAs, and call openers. Sound like their world, not yours. If the persona says "catalog rationalization," you say "catalog rationalization" — not "streamlining your service catalog."
+
+### Objections → Preemptive Framing
+Convert section 25 fears into "you might be thinking..." frames or objection-handling talk tracks. Anticipate, don't react.
+
+### Metrics → Proof
+Match section 6-8 success metrics with section 32 proof points for ROI conversations. Their KPIs become your evidence framework.
+
+### Title Variations → Personalization
+Use section 29 to adjust seniority/scope framing. VP gets strategic framing. Director gets operational framing. Manager gets day-to-day workflow framing.
+
+### Org Structure → Multithreading
+Use sections 14-16 to identify who else to engage and how to position for each. Map the buying committee from the dossier.
+
+---
+
+## Quality Rules
+
+1. **Sound like a top 0.1% peer.** Not a vendor. Not a marketer. Not a rep reading a script.
+2. **Pain framing: LOSS not savings.** Always. "You're losing $X" beats "You could save $X."
+3. **CTO/Engineering:** Architecture and data layer framing.
+4. **IT/Ops:** Operational pain framing — uptime, tickets, SLAs, firefighting.
+5. **C-suite:** Strategic risk and business impact framing — board-level language.
+6. **Never fabricate.** If data is thin, say so. "I don't have strong signal here" is better than making something up.
+7. **Every source dated and linked.** No unsourced claims.
+
+---
+
+## Working with Other Skills
+
+This skill provides the **buyer layer** that other skills need. Load persona data first, then hand off:
+
+- **Before `cold-email`** — Feed persona pain points, language, and objections into the R.E.P.L.Y. framework
+- **Before `email-sequence`** — Tailor sequence messaging to persona's buying journey and vocabulary
+- **Before `sales-enablement`** — Align battle cards, talk tracks, and objection docs to the specific buyer
+- **Before discovery prep** — Build need-development problems and implication questions from persona knowledge
+- **`product-marketing-context`** provides product positioning; this skill adds the buyer-specific layer on top
+
+---
+
+## Related Skills
+
+- **product-marketing-context**: Foundational product and audience positioning
+- **cold-email**: Outbound email frameworks (R.E.P.L.Y. method)
+- **email-sequence**: Lifecycle and nurture sequences
+- **sales-enablement**: Battle cards, talk tracks, objection docs, demo scripts
+- **competitor-alternatives**: Comparison pages and battle cards
+- **copywriting**: Landing page and web copy

--- a/skills/persona-messaging/references/persona-index.md
+++ b/skills/persona-messaging/references/persona-index.md
@@ -1,0 +1,18 @@
+# Persona Index
+
+Lookup table for all buyer persona dossiers. Each row maps a **role cluster** (functional role, not individual title) to its dossier file.
+
+## How to Use
+
+1. Identify the buyer's functional role (not their exact title)
+2. Find the matching role cluster below
+3. Load the corresponding dossier file
+4. If no match exists, use the **Persona Research Fallback** in SKILL.md to build a new dossier
+
+## Dossiers
+
+| Role Cluster | Slug | Titles Covered | Use When | File |
+|---|---|---|---|---|
+| VP/Dir of Service Management | vp-service-management | VP of SM, Director of SM Ops, SMO Director, Head of SM, Sr Dir of Service Portfolio | Selling JSM/ESM to service management leaders | `persona-vp-service-management.md` |
+
+<!-- Add new persona rows here in alphabetical order by role cluster -->

--- a/skills/persona-messaging/references/persona-vp-service-management.md
+++ b/skills/persona-messaging/references/persona-vp-service-management.md
@@ -1,0 +1,147 @@
+# VP/Director of Service Management
+
+## Quick Reference
+
+- **Core pain**: Delivering consistent, high-quality internal services at optimized cost while managing complex multi-vendor, multi-BU service ecosystems
+- **Change triggers**: Unsustainable licensing costs, poor UX, mandate to extend ESM beyond IT, M&A consolidation, DevOps transformation, vendor EOL
+- **Top objections**: JSM lacks mature CMDB/asset mgmt, insufficient scalability, can't meet regulatory reqs, switching disrupts operations, Atlassian support is dev-centric not enterprise-class
+- **Key language**: service portfolio, catalog rationalization, process governance, CAB, SLA/XLA, CMDB fidelity, deflection rate, MTTR, total cost of ownership, federated model
+- **Best sales play**: Start with DevOps alignment pilot (Play 2), expand to enterprise portal (Play 3)
+- **Strongest proof point**: Teach for All — ticket resolution 8 days → 9 minutes, CSAT +6 points
+
+## Full Dossier
+
+> **Placeholder:** Paste the full VP/Director of Service Management dossier content below.
+> Replace this section with all 33 sections from your research brief, preserving the original content as-is.
+
+### 1. What they are in charge of
+
+[Paste section content here]
+
+### 2. What they are expected to manage
+
+[Paste section content here]
+
+### 3. Day-to-day duties
+
+[Paste section content here]
+
+### 4. How they spend their time
+
+[Paste section content here]
+
+### 5. What they want to achieve
+
+[Paste section content here]
+
+### 6. How success is measured
+
+[Paste section content here]
+
+### 7. How they are evaluated
+
+[Paste section content here]
+
+### 8. How they/their boss knows they're doing a good job
+
+[Paste section content here]
+
+### 9. External factors that could make things harder
+
+[Paste section content here]
+
+### 10. Industry trends that may negatively impact them
+
+[Paste section content here]
+
+### 11. Strategies in place to help them achieve goals
+
+[Paste section content here]
+
+### 12. Common initiatives people in this role roll out
+
+[Paste section content here]
+
+### 13. Tools they may use
+
+[Paste section content here]
+
+### 14. Who their peers are
+
+[Paste section content here]
+
+### 15. Who reports to them
+
+[Paste section content here]
+
+### 16. Who they report to
+
+[Paste section content here]
+
+### 17. Who outside the company they interact with
+
+[Paste section content here]
+
+### 18. Status quo relationship with Atlassian's product space
+
+[Paste section content here]
+
+### 19. What they're doing now to achieve what Atlassian's products try to achieve
+
+[Paste section content here]
+
+### 20. Why they use those things now
+
+[Paste section content here]
+
+### 21. What would cause them to change from the status quo
+
+[Paste section content here]
+
+### 22. What would have to go wrong
+
+[Paste section content here]
+
+### 23. What you'd have to prove to them
+
+[Paste section content here]
+
+### 24. Barriers to change
+
+[Paste section content here]
+
+### 25. Fears and objections
+
+[Paste section content here]
+
+### 26. Where Atlassian may be weak in their eyes
+
+[Paste section content here]
+
+### 27. How to win the meeting
+
+[Paste section content here]
+
+### 28. Competitive landscape from their perspective
+
+[Paste section content here]
+
+### 29. Sub-title variations
+
+[Paste section content here]
+
+### 30. Atlassian solution mapping
+
+[Paste section content here]
+
+### 31. Sales play mapping
+
+[Paste section content here]
+
+### 32. Proof points
+
+[Paste section content here]
+
+### 33. Key language
+
+[Paste section content here]

--- a/skills/persona-messaging/references/section-guide.md
+++ b/skills/persona-messaging/references/section-guide.md
@@ -1,0 +1,74 @@
+# Dossier Section Guide
+
+Maps persona dossier sections to sales scenarios. The core framework is 28 subheadings (used for both stored dossiers and fallback research). Some dossiers have additional sections (29-33) for title variations, solution mapping, sales plays, proof points, and key language.
+
+## By Section Number
+
+| # | Section | Contains |
+|---|---------|----------|
+| 1 | What they are in charge of | Scope of authority, budget, platform ownership |
+| 2 | What they are expected to manage | Teams, vendors, processes, compliance |
+| 3 | Day-to-day duties | What fills their calendar |
+| 4 | How they spend their time | Time allocation across activities |
+| 5 | What they want to achieve | Primary objectives and goals |
+| 6 | How success is measured | KPIs, metrics, scorecards |
+| 7 | How they are evaluated | Performance review criteria |
+| 8 | How they/boss knows they're doing well | Signals of success |
+| 9 | External factors that could make things harder | Regulatory, economic, market pressures |
+| 10 | Industry trends that may negatively impact them | Sector-specific headwinds |
+| 11 | Strategies in place to help them achieve goals | Current frameworks and approaches |
+| 12 | Common initiatives people in this role roll out | Typical projects they sponsor |
+| 13 | Tools they may use | Technology stack and platforms |
+| 14 | Who their peers are | Cross-functional counterparts |
+| 15 | Who reports to them | Direct reports and team structure |
+| 16 | Who they report to | Reporting line and budget authority |
+| 17 | Who outside the company they interact with | Vendors, auditors, industry groups |
+| 18 | Status quo relationship with Atlassian's product space | Current perception of Atlassian |
+| 19 | What they're doing now to achieve what Atlassian tries to achieve | Incumbent solutions |
+| 20 | Why they use those things now | Switching costs, embedded workflows, certifications |
+| 21 | What would cause them to change from status quo | Change triggers |
+| 22 | What would have to go wrong | Breaking points with current solution |
+| 23 | What you'd have to prove to them | Evidence they need to move |
+| 24 | Barriers to change | Sunk costs, migration risk, politics |
+| 25 | Fears and objections | What keeps them from saying yes |
+| 26 | Where Atlassian may be weak in their eyes | Perceived gaps |
+| 27 | How to win the meeting | Tactical meeting advice |
+| 28 | Competitive landscape from their perspective | How they see the vendor market |
+
+### Extended Sections (Optional)
+
+These sections appear in some dossiers but are not part of the 28-subheading fallback research framework.
+
+| # | Section | Contains |
+|---|---------|----------|
+| 29 | Sub-title variations | Title clusters and how messaging shifts per title |
+| 30 | Atlassian solution mapping | Product/collection to problem mapping |
+| 31 | Sales play mapping | Recommended plays in sequence with triggers |
+| 32 | Proof points | Customer stories and evidence |
+| 33 | Key language | Words and phrases they actually use |
+
+## By Use Case
+
+| Group | Sections | Use When |
+|-------|----------|----------|
+| Role context | 1-8 | Understanding who you're writing to |
+| External pressures | 9-10 | Adding urgency or trend-based angles |
+| Current state | 11-13, 18-20 | Understanding their world before pitching |
+| Atlassian positioning | 18-20 | Understanding incumbent tools and why they stay |
+| Sales intelligence | 21-28 | Preparing for meetings, handling objections |
+| Sales execution | 29-33 | Title variations, solution mapping, plays, proof, language |
+
+## By Sales Task
+
+| Task | Priority Sections | What to Extract |
+|------|-------------------|-----------------|
+| Cold outreach / email | 1-5, 21, 33 | Role pain, change triggers, their vocabulary |
+| Cold call scripts | 1-5, 21-22, 25, 33 | Pain, triggers, objections, vocabulary for Poke the Bear and DISCOVER |
+| Meeting prep | 3-4, 25, 27, 28 | Daily reality, objections, how to win, competitors |
+| Objection handling | 23-26 | What to prove, barriers, fears, perceived weaknesses |
+| Business case / ROI | 5-8, 30-32 | Goals, success metrics, solution mapping, plays, proof |
+| Sales collateral / battle cards | 5, 6-8, 29, 33 | Goals, metrics, title variations, key language |
+| Competitive positioning | 18-20, 26, 28 | Status quo, current tools, weaknesses, landscape |
+| Discovery call prep | 1-5, 9-10, 21, 25 | Role context, external pressures, change triggers, objections |
+| Champion enablement | 5-8, 23, 30 | Goals, metrics, what to prove, solution mapping |
+| Deal strategy (MEDDPICC) | 14-16, 21-25, 28 | Org structure, change triggers, barriers, competition |

--- a/skills/sales-enablement/SKILL.md
+++ b/skills/sales-enablement/SKILL.md
@@ -347,3 +347,4 @@ If context is missing, ask:
 - **revops**: For lead lifecycle, scoring, routing, and pipeline management
 - **pricing-strategy**: For pricing decisions and packaging
 - **product-marketing-context**: For foundational positioning and messaging
+- **persona-messaging**: For buyer research dossiers and persona-specific messaging


### PR DESCRIPTION
## Summary
Introduces a new `persona-messaging` skill that enables persona-driven B2B enterprise sales messaging for Atlassian. This skill translates deep buyer research into peer-level messaging, positioning, and sales collateral tailored to specific buyer personas.

## Key Changes

- **New skill: `persona-messaging`** (`skills/persona-messaging/SKILL.md`)
  - Provides expert guidance on language, positioning, mindset, and tone for each buyer persona
  - Includes workflow for identifying personas, loading dossiers, and routing to relevant sections
  - Implements "Persona Research Fallback" to auto-generate dossiers for personas not yet in the library using a 28-subheading framework
  - Defines scenario routing table mapping sales tasks (cold outreach, objection handling, deal strategy, etc.) to priority dossier sections
  - Establishes quality rules for peer-level messaging, loss-framing, and persona-specific language

- **Persona dossier infrastructure**
  - `references/persona-index.md`: Lookup table for all buyer persona dossiers with role clusters and file mappings
  - `references/section-guide.md`: Complete mapping of dossier sections (1-33) to sales scenarios and use cases
  - `references/persona-vp-service-management.md`: First persona dossier covering VP/Director of Service Management roles (with quick reference, pain points, objections, and 33-section placeholder structure)

- **Integration with existing skills**
  - Updated `cold-email/SKILL.md`, `email-sequence/SKILL.md`, and `sales-enablement/SKILL.md` to reference `persona-messaging` as a prerequisite skill
  - Establishes `persona-messaging` as the buyer intelligence layer that feeds into outbound, sequence, and enablement workflows

- **Version and registry updates**
  - Added `persona-messaging` v1.1.0 (2026-03-08) to `VERSIONS.md`
  - Registered skill in `.claude-plugin/marketplace.json`

## Implementation Details

- Dossier framework supports both 28-core sections (for fallback research) and extended sections 29-33 (title variations, solution mapping, sales plays, proof points, key language)
- Scenario routing table enables context-aware section loading based on sales task (e.g., cold outreach prioritizes sections 1-5, 21, 33)
- Fallback research workflow auto-generates new persona profiles using web search and the 28-subheading framework, then saves and indexes them
- Quality rules enforce peer-level tone, loss-framing for pain, and persona-specific language usage

https://claude.ai/code/session_011yv4WQGYdsVMBk471A6EZ7