### PR TITLE
Add Claude command definitions for marketing skills

### DIFF
--- a/.claude/commands/ab-test-setup.md
+++ b/.claude/commands/ab-test-setup.md
@@ -1,0 +1,3 @@
+Read the file `skills/ab-test-setup/SKILL.md` and follow its instructions to help the user with their A/B test or experiment request.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/ad-creative.md
+++ b/.claude/commands/ad-creative.md
@@ -1,0 +1,3 @@
+Read the file `skills/ad-creative/SKILL.md` and follow its instructions to help the user generate, iterate, or scale ad creative.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/ai-seo.md
+++ b/.claude/commands/ai-seo.md
@@ -1,0 +1,3 @@
+Read the file `skills/ai-seo/SKILL.md` and follow its instructions to help the user optimize for AI search engines and LLM citations.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/analytics-tracking.md
+++ b/.claude/commands/analytics-tracking.md
@@ -1,0 +1,3 @@
+Read the file `skills/analytics-tracking/SKILL.md` and follow its instructions to help the user set up, improve, or audit analytics tracking.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/churn-prevention.md
+++ b/.claude/commands/churn-prevention.md
@@ -1,0 +1,3 @@
+Read the file `skills/churn-prevention/SKILL.md` and follow its instructions to help the user reduce churn, build cancellation flows, or recover failed payments.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/cold-email.md
+++ b/.claude/commands/cold-email.md
@@ -1,0 +1,3 @@
+Read the file `skills/cold-email/SKILL.md` and follow its instructions to help the user write B2B cold emails and follow-up sequences.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/competitor-alternatives.md
+++ b/.claude/commands/competitor-alternatives.md
@@ -1,0 +1,3 @@
+Read the file `skills/competitor-alternatives/SKILL.md` and follow its instructions to help the user create competitor comparison or alternative pages.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/content-strategy.md
+++ b/.claude/commands/content-strategy.md
@@ -1,0 +1,3 @@
+Read the file `skills/content-strategy/SKILL.md` and follow its instructions to help the user plan a content strategy or decide what content to create.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/copy-editing.md
+++ b/.claude/commands/copy-editing.md
@@ -1,0 +1,3 @@
+Read the file `skills/copy-editing/SKILL.md` and follow its instructions to help the user edit, review, or improve existing marketing copy.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/copywriting.md
+++ b/.claude/commands/copywriting.md
@@ -1,0 +1,3 @@
+Read the file `skills/copywriting/SKILL.md` and follow its instructions to help the user write or improve marketing copy.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/email-sequence.md
+++ b/.claude/commands/email-sequence.md
@@ -1,0 +1,3 @@
+Read the file `skills/email-sequence/SKILL.md` and follow its instructions to help the user create or optimize an email sequence or drip campaign.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/form-cro.md
+++ b/.claude/commands/form-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/form-cro/SKILL.md` and follow its instructions to help the user optimize lead capture forms, contact forms, or any non-signup form.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/free-tool-strategy.md
+++ b/.claude/commands/free-tool-strategy.md
@@ -1,0 +1,3 @@
+Read the file `skills/free-tool-strategy/SKILL.md` and follow its instructions to help the user plan or build a free marketing tool for lead generation or SEO.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/install-skills.md
+++ b/.claude/commands/install-skills.md
@@ -1,0 +1,13 @@
+Install marketing skills from coreyhaines31/marketingskills into the current project.
+
+If specific skill names were provided as arguments, run:
+```bash
+npx skills add coreyhaines31/marketingskills --skill $ARGUMENTS
+```
+
+If no arguments were provided, install all skills:
+```bash
+npx skills add coreyhaines31/marketingskills
+```
+
+Skills are installed to `.agents/skills/` with symlinks to `.claude/skills/` for Claude Code compatibility.

--- a/.claude/commands/launch-strategy.md
+++ b/.claude/commands/launch-strategy.md
@@ -1,0 +1,3 @@
+Read the file `skills/launch-strategy/SKILL.md` and follow its instructions to help the user plan a product launch, feature announcement, or release strategy.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/list-skills.md
+++ b/.claude/commands/list-skills.md
@@ -1,0 +1,8 @@
+List all available marketing skills from coreyhaines31/marketingskills.
+
+Run:
+```bash
+npx skills add coreyhaines31/marketingskills --list
+```
+
+This shows all 32 available skills with their descriptions so you can choose which ones to install.

--- a/.claude/commands/marketing-ideas.md
+++ b/.claude/commands/marketing-ideas.md
@@ -1,0 +1,3 @@
+Read the file `skills/marketing-ideas/SKILL.md` and follow its instructions to generate marketing ideas and strategies for the user's SaaS or software product.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/marketing-psychology.md
+++ b/.claude/commands/marketing-psychology.md
@@ -1,0 +1,3 @@
+Read the file `skills/marketing-psychology/SKILL.md` and follow its instructions to apply psychological principles and behavioral science to marketing.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/onboarding-cro.md
+++ b/.claude/commands/onboarding-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/onboarding-cro/SKILL.md` and follow its instructions to help the user optimize post-signup onboarding and user activation.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/page-cro.md
+++ b/.claude/commands/page-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/page-cro/SKILL.md` and follow its instructions to help the user optimize conversions on any marketing page.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/paid-ads.md
+++ b/.claude/commands/paid-ads.md
@@ -1,0 +1,3 @@
+Read the file `skills/paid-ads/SKILL.md` and follow its instructions to help the user with paid advertising campaigns on Google, Meta, LinkedIn, or other platforms.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/paywall-upgrade-cro.md
+++ b/.claude/commands/paywall-upgrade-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/paywall-upgrade-cro/SKILL.md` and follow its instructions to help the user create or optimize in-app paywalls, upgrade screens, or upsell modals.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/popup-cro.md
+++ b/.claude/commands/popup-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/popup-cro/SKILL.md` and follow its instructions to help the user create or optimize popups, modals, overlays, or banners for conversion.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/pricing-strategy.md
+++ b/.claude/commands/pricing-strategy.md
@@ -1,0 +1,3 @@
+Read the file `skills/pricing-strategy/SKILL.md` and follow its instructions to help the user with pricing decisions, packaging, or monetization strategy.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/product-marketing-context.md
+++ b/.claude/commands/product-marketing-context.md
@@ -1,0 +1,3 @@
+Read the file `skills/product-marketing-context/SKILL.md` and follow its instructions to help the user create or update their product marketing context document.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/programmatic-seo.md
+++ b/.claude/commands/programmatic-seo.md
@@ -1,0 +1,3 @@
+Read the file `skills/programmatic-seo/SKILL.md` and follow its instructions to help the user create SEO-driven pages at scale using templates and data.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/referral-program.md
+++ b/.claude/commands/referral-program.md
@@ -1,0 +1,3 @@
+Read the file `skills/referral-program/SKILL.md` and follow its instructions to help the user create, optimize, or analyze a referral or affiliate program.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/revops.md
+++ b/.claude/commands/revops.md
@@ -1,0 +1,3 @@
+Read the file `skills/revops/SKILL.md` and follow its instructions to help the user with revenue operations, lead lifecycle management, or marketing-to-sales handoff.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/sales-enablement.md
+++ b/.claude/commands/sales-enablement.md
@@ -1,0 +1,3 @@
+Read the file `skills/sales-enablement/SKILL.md` and follow its instructions to help the user create sales collateral, pitch decks, one-pagers, or objection handling docs.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/schema-markup.md
+++ b/.claude/commands/schema-markup.md
@@ -1,0 +1,3 @@
+Read the file `skills/schema-markup/SKILL.md` and follow its instructions to help the user add, fix, or optimize schema markup and structured data.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/seo-audit.md
+++ b/.claude/commands/seo-audit.md
@@ -1,0 +1,3 @@
+Read the file `skills/seo-audit/SKILL.md` and follow its instructions to help the user audit, review, or diagnose SEO issues on their site.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/signup-flow-cro.md
+++ b/.claude/commands/signup-flow-cro.md
@@ -1,0 +1,3 @@
+Read the file `skills/signup-flow-cro/SKILL.md` and follow its instructions to help the user optimize signup, registration, or trial activation flows.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/site-architecture.md
+++ b/.claude/commands/site-architecture.md
@@ -1,0 +1,3 @@
+Read the file `skills/site-architecture/SKILL.md` and follow its instructions to help the user plan or restructure their website's page hierarchy, navigation, or URL structure.
+
+User's request: $ARGUMENTS

--- a/.claude/commands/social-content.md
+++ b/.claude/commands/social-content.md
@@ -1,0 +1,3 @@
+Read the file `skills/social-content/SKILL.md` and follow its instructions to help the user create, schedule, or optimize social media content.
+
+User's request: $ARGUMENTS


### PR DESCRIPTION
## Summary
This PR adds command definition files for 32 marketing skills from the coreyhaines31/marketingskills repository. These commands enable Claude to access specialized marketing skill modules through the `.claude/commands/` interface.

## Changes
- **Added 2 utility commands:**
  - `install-skills.md` - Install marketing skills from the skills repository
  - `list-skills.md` - List all 32 available marketing skills

- **Added 30 skill-specific commands** covering core marketing functions:
  - Content & copywriting: copywriting, copy-editing, content-strategy, social-content
  - Conversion optimization: page-cro, form-cro, signup-flow-cro, onboarding-cro, popup-cro, paywall-upgrade-cro
  - SEO & discovery: seo-audit, ai-seo, schema-markup, programmatic-seo, site-architecture
  - Paid & earned media: paid-ads, ad-creative, cold-email, email-sequence
  - Strategy & planning: marketing-ideas, launch-strategy, pricing-strategy, product-marketing-context, content-strategy, free-tool-strategy
  - Growth & retention: referral-program, churn-prevention, ab-test-setup, analytics-tracking
  - Competitive & sales: competitor-alternatives, sales-enablement, revops, marketing-psychology

## Implementation Details
Each command file follows a consistent pattern:
- References the corresponding skill's `SKILL.md` file in the `skills/` directory
- Passes user arguments via the `$ARGUMENTS` variable
- Provides clear instructions for Claude to follow the skill's guidance
- Enables seamless integration with the Claude Code environment

https://claude.ai/code/session_01FYaBabfQZ9Hm9ykE356QYd