### PR TITLE
Patched the main security issues.

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: true
 
@@ -22,9 +22,15 @@ jobs:
         run: node .github/scripts/sync-skills.js
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          commit_user_name: Coreybot
-          commit_user_email: coreybot+github-actions[bot]@users.noreply.github.com
-          commit_message: "chore: sync skills with marketplace.json and README"
-          file_pattern: ".claude-plugin/marketplace.json README.md"
+        shell: bash
+        run: |
+          if git diff --quiet -- .claude-plugin/marketplace.json README.md; then
+            echo "No sync changes to commit"
+            exit 0
+          fi
+
+          git config user.name "Coreybot"
+          git config user.email "coreybot+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json README.md
+          git commit -m "chore: sync skills with marketplace.json and README"
+          git push

--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -14,6 +14,9 @@ concurrency:
   group: validate-skill-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-slim
@@ -22,8 +25,9 @@ jobs:
       skills: ${{ steps.changed-skills.outputs.skills }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Get changed skills
@@ -57,9 +61,10 @@ jobs:
         skill: ${{ fromJson(needs.detect-changes.outputs.skills) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Validate ${{ matrix.skill }}
-        uses: Flash-Brew-Digital/validate-skill@v1
-        with:
-          path: ${{ matrix.skill }}
+        shell: bash
+        run: ./validate-skills.sh "${{ matrix.skill }}"

--- a/tools/clis/README.md
+++ b/tools/clis/README.md
@@ -51,7 +51,7 @@ Every CLI reads credentials from environment variables:
 | `demio` | `DEMIO_API_KEY`, `DEMIO_API_SECRET` |
 | `dub` | `DUB_API_KEY` |
 | `g2` | `G2_API_TOKEN` |
-| `ga4` | `GA4_ACCESS_TOKEN` |
+| `ga4` | `GA4_ACCESS_TOKEN`, `GA4_MP_API_SECRET` (Measurement Protocol, optional) |
 | `google-ads` | `GOOGLE_ADS_TOKEN`, `GOOGLE_ADS_DEVELOPER_TOKEN`, `GOOGLE_ADS_CUSTOMER_ID` |
 | `google-search-console` | `GSC_ACCESS_TOKEN` |
 | `hotjar` | `HOTJAR_CLIENT_ID`, `HOTJAR_CLIENT_SECRET` |
@@ -76,6 +76,8 @@ Every CLI reads credentials from environment variables:
 | `savvycal` | `SAVVYCAL_API_KEY` |
 | `segment` | `SEGMENT_WRITE_KEY` (tracking), `SEGMENT_ACCESS_TOKEN` (profile) |
 | `semrush` | `SEMRUSH_API_KEY` |
+| `similarweb` | `SIMILARWEB_API_KEY` |
+| `supermetrics` | `SUPERMETRICS_API_KEY` |
 | `sendgrid` | `SENDGRID_API_KEY` |
 | `tiktok-ads` | `TIKTOK_ACCESS_TOKEN`, `TIKTOK_ADVERTISER_ID` |
 | `tolt` | `TOLT_API_KEY` |
@@ -87,6 +89,7 @@ Every CLI reads credentials from environment variables:
 | `snov` | `SNOV_CLIENT_ID`, `SNOV_CLIENT_SECRET` |
 | `wistia` | `WISTIA_API_KEY` |
 | `zapier` | `ZAPIER_API_KEY` |
+| `zoominfo` | `ZOOMINFO_ACCESS_TOKEN` or `ZOOMINFO_USERNAME`, `ZOOMINFO_PRIVATE_KEY` |
 
 ## Security
 
@@ -95,6 +98,9 @@ Every CLI reads credentials from environment variables:
 - Store keys in your shell profile (`~/.zshrc`, `~/.bashrc`) or a `.env` file
 - The `.env` file is gitignored — but double-check before committing
 - Use `--dry-run` on any command to preview the request without sending it (credentials are masked as `***`)
+- Prefer env vars over CLI flags for one-time secrets. For GA4 Measurement Protocol, set `GA4_MP_API_SECRET` or pass `--api-secret-env`.
+- `zoominfo auth` now masks JWTs by default. Only use `--show-token` when you explicitly need the raw token.
+- Some vendor APIs only support query-string auth (for example Hunter, Similarweb, Instantly, and some Kit endpoints). Use least-privileged keys and avoid verbose proxy logging when calling them.
 - If you fork this repo, audit your commits to ensure no secrets are included
 
 ## Command Pattern

--- a/tools/clis/ga4.js
+++ b/tools/clis/ga4.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 
 const ACCESS_TOKEN = process.env.GA4_ACCESS_TOKEN
+const MP_API_SECRET = process.env.GA4_MP_API_SECRET
 const DATA_API = 'https://analyticsdata.googleapis.com/v1beta'
 const ADMIN_API = 'https://analyticsadmin.googleapis.com/v1beta'
 const MP_URL = 'https://www.google-analytics.com/mp/collect'
 
-if (!ACCESS_TOKEN) {
-  console.error(JSON.stringify({ error: 'GA4_ACCESS_TOKEN environment variable required' }))
-  process.exit(1)
-}
-
 async function api(method, baseUrl, path, body) {
+  if (!ACCESS_TOKEN) {
+    throw new Error('GA4_ACCESS_TOKEN environment variable required')
+  }
   if (args['dry-run']) {
     return { _dry_run: true, method, url: `${baseUrl}${path}`, headers: { Authorization: '***', 'Content-Type': 'application/json' }, body: body || undefined }
   }
@@ -147,7 +146,13 @@ async function main() {
       switch (sub) {
         case 'send': {
           if (!args['measurement-id']) { result = { error: '--measurement-id required' }; break }
-          if (!args['api-secret']) { result = { error: '--api-secret required' }; break }
+          const apiSecretEnv = args['api-secret-env']
+          if (apiSecretEnv && !process.env[apiSecretEnv]) {
+            result = { error: `Environment variable ${apiSecretEnv} is not set` }
+            break
+          }
+          const apiSecret = args['api-secret'] || (apiSecretEnv ? process.env[apiSecretEnv] : undefined) || MP_API_SECRET
+          if (!apiSecret) { result = { error: '--api-secret, --api-secret-env <ENV_VAR>, or GA4_MP_API_SECRET required' }; break }
           if (!args['client-id']) { result = { error: '--client-id required' }; break }
           if (!args['event-name']) { result = { error: '--event-name required' }; break }
           let eventParams = {}
@@ -165,7 +170,7 @@ async function main() {
               params: eventParams,
             }],
           }
-          result = await mpApi(args['measurement-id'], args['api-secret'], body)
+          result = await mpApi(args['measurement-id'], apiSecret, body)
           break
         }
         default:
@@ -180,7 +185,7 @@ async function main() {
           reports: 'reports run --property <id> [--start-date <date>] [--end-date <date>] [--dimensions <dims>] [--metrics <metrics>]',
           realtime: 'realtime run --property <id> [--dimensions <dims>] [--metrics <metrics>]',
           conversions: 'conversions [list|create] --property <id> [--event-name <name>]',
-          events: 'events send --measurement-id <id> --api-secret <secret> --client-id <id> --event-name <name> [--params <json>]',
+          events: 'events send --measurement-id <id> [--api-secret <secret> | --api-secret-env <ENV_VAR>] --client-id <id> --event-name <name> [--params <json>] (or set GA4_MP_API_SECRET)',
         }
       }
   }

--- a/tools/clis/instantly.js
+++ b/tools/clis/instantly.js
@@ -12,10 +12,7 @@ async function api(method, path, body) {
   const separator = path.includes('?') ? '&' : '?'
   const url = `${BASE_URL}${path}${separator}api_key=${API_KEY}`
   if (args['dry-run']) {
-    const maskedUrl = url.replace(API_KEY, '***')
-    const maskedBody = body ? JSON.parse(JSON.stringify(body)) : undefined
-    if (maskedBody && maskedBody.api_key) maskedBody.api_key = '***'
-    return { _dry_run: true, method, url: maskedUrl, headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }, body: maskedBody }
+    return { _dry_run: true, method, url: url.replace(API_KEY, '***'), headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }, body: body || undefined }
   }
   const res = await fetch(url, {
     method,
@@ -87,13 +84,13 @@ async function main() {
         case 'launch': {
           const id = args.id
           if (!id) { result = { error: '--id required' }; break }
-          result = await api('POST', '/campaign/launch', { api_key: API_KEY, campaign_id: id })
+          result = await api('POST', '/campaign/launch', { campaign_id: id })
           break
         }
         case 'pause': {
           const id = args.id
           if (!id) { result = { error: '--id required' }; break }
-          result = await api('POST', '/campaign/pause', { api_key: API_KEY, campaign_id: id })
+          result = await api('POST', '/campaign/pause', { campaign_id: id })
           break
         }
         default:
@@ -121,7 +118,7 @@ async function main() {
           if (args['first-name']) lead.first_name = args['first-name']
           if (args['last-name']) lead.last_name = args['last-name']
           if (args.company) lead.company_name = args.company
-          result = await api('POST', '/lead/add', { api_key: API_KEY, campaign_id: campaignId, leads: [lead] })
+          result = await api('POST', '/lead/add', { campaign_id: campaignId, leads: [lead] })
           break
         }
         case 'delete': {
@@ -129,7 +126,7 @@ async function main() {
           const email = args.email
           if (!campaignId) { result = { error: '--campaign-id required' }; break }
           if (!email) { result = { error: '--email required' }; break }
-          result = await api('POST', '/lead/delete', { api_key: API_KEY, campaign_id: campaignId, delete_list: [email] })
+          result = await api('POST', '/lead/delete', { campaign_id: campaignId, delete_list: [email] })
           break
         }
         case 'status': {
@@ -180,7 +177,7 @@ async function main() {
         case 'campaign': {
           const campaignId = args['campaign-id']
           if (!campaignId) { result = { error: '--campaign-id required' }; break }
-          const body = { api_key: API_KEY, campaign_id: campaignId }
+          const body = { campaign_id: campaignId }
           if (args['start-date']) body.start_date = args['start-date']
           if (args['end-date']) body.end_date = args['end-date']
           result = await api('POST', '/analytics/campaign/summary', body)
@@ -189,7 +186,7 @@ async function main() {
         case 'steps': {
           const campaignId = args['campaign-id']
           if (!campaignId) { result = { error: '--campaign-id required' }; break }
-          const body = { api_key: API_KEY, campaign_id: campaignId }
+          const body = { campaign_id: campaignId }
           if (args['start-date']) body.start_date = args['start-date']
           if (args['end-date']) body.end_date = args['end-date']
           result = await api('POST', '/analytics/campaign/step', body)
@@ -200,7 +197,7 @@ async function main() {
           const endDate = args['end-date']
           if (!startDate) { result = { error: '--start-date required' }; break }
           if (!endDate) { result = { error: '--end-date required' }; break }
-          result = await api('POST', '/analytics/campaign/count', { api_key: API_KEY, start_date: startDate, end_date: endDate })
+          result = await api('POST', '/analytics/campaign/count', { start_date: startDate, end_date: endDate })
           break
         }
         default:
@@ -217,7 +214,7 @@ async function main() {
           const entries = args.entries
           if (!entries) { result = { error: '--entries required (comma-separated emails or domains)' }; break }
           const entryList = entries.split(',').map(e => e.trim())
-          result = await api('POST', '/blocklist/add', { api_key: API_KEY, entries: entryList })
+          result = await api('POST', '/blocklist/add', { entries: entryList })
           break
         }
         default:

--- a/tools/clis/supermetrics.js
+++ b/tools/clis/supermetrics.js
@@ -9,17 +9,24 @@ if (!API_KEY) {
 }
 
 async function api(method, path, body) {
-  const separator = path.includes('?') ? '&' : '?'
-  const url = `${BASE_URL}${path}${separator}api_key=${API_KEY}`
+  const url = `${BASE_URL}${path}`
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'x-api-key': API_KEY,
+  }
   if (args['dry-run']) {
-    return { _dry_run: true, method, url: url.replace(API_KEY, '***'), headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }, body: body || undefined }
+    return {
+      _dry_run: true,
+      method,
+      url,
+      headers: { ...headers, 'x-api-key': '***' },
+      body: body || undefined,
+    }
   }
   const res = await fetch(url, {
     method,
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    },
+    headers,
     body: body ? JSON.stringify(body) : undefined,
   })
   const text = await res.text()

--- a/tools/clis/zoominfo.js
+++ b/tools/clis/zoominfo.js
@@ -57,6 +57,12 @@ async function api(method, path, body) {
   }
 }
 
+function maskToken(token) {
+  if (!token) return '***'
+  if (token.length <= 12) return '***'
+  return `${token.slice(0, 6)}...${token.slice(-4)}`
+}
+
 function parseArgs(args) {
   const result = { _: [] }
   for (let i = 0; i < args.length; i++) {
@@ -92,7 +98,9 @@ async function main() {
         break
       }
       const token = await authenticate()
-      result = { jwt: token }
+      result = args['show-token']
+        ? { jwt: token }
+        : { authenticated: true, jwt_preview: maskToken(token), note: 'Use --show-token to print the full JWT' }
       break
     }
 
@@ -188,7 +196,7 @@ async function main() {
       result = {
         error: 'Unknown command',
         usage: {
-          auth: 'auth — authenticate and get JWT token',
+          auth: 'auth [--show-token] — authenticate and print the JWT only when explicitly requested',
           contacts: {
             search: 'contacts search [--job-title <t>] [--company <c>] [--location <l>] [--seniority <s>] [--department <d>] [--page <n>]',
             enrich: 'contacts enrich --email <email> | --person-id <id>',

--- a/validate-skills-official.sh
+++ b/validate-skills-official.sh
@@ -1,45 +1,98 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Validation script using official skills-ref library
 # https://github.com/agentskills/agentskills/tree/main/skills-ref
 
 SKILLS_DIR="skills"
-SKILLS_REF_DIR="/tmp/agentskills/skills-ref"
+TARGET_PATH="${1:-$SKILLS_DIR}"
+SKILLS_REF_REPO="${SKILLS_REF_REPO:-https://github.com/agentskills/agentskills.git}"
+SKILLS_REF_SHA="${SKILLS_REF_SHA:-}"
+SKILLS_REF_WORKDIR=""
+SKILLS_REF_BIN=""
+
+cleanup() {
+    if [ -n "$SKILLS_REF_WORKDIR" ] && [ -d "$SKILLS_REF_WORKDIR" ]; then
+        rm -rf "$SKILLS_REF_WORKDIR"
+    fi
+}
+
+trap cleanup EXIT
+
+resolve_skill_paths() {
+    shopt -s nullglob
+
+    if [[ -f "$TARGET_PATH" && "$(basename "$TARGET_PATH")" == "SKILL.md" ]]; then
+        SKILL_PATHS=("$(dirname "$TARGET_PATH")/")
+    elif [[ -d "$TARGET_PATH" && -f "$TARGET_PATH/SKILL.md" ]]; then
+        SKILL_PATHS=("${TARGET_PATH%/}/")
+    elif [[ -d "$TARGET_PATH" ]]; then
+        SKILL_PATHS=("${TARGET_PATH%/}"/*/)
+    else
+        echo "❌ Invalid path: $TARGET_PATH"
+        exit 1
+    fi
+
+    if [ "${#SKILL_PATHS[@]}" -eq 0 ]; then
+        echo "❌ No skills found at: $TARGET_PATH"
+        exit 1
+    fi
+}
+
+bootstrap_skills_ref() {
+    if command -v skills-ref >/dev/null 2>&1; then
+        SKILLS_REF_BIN="$(command -v skills-ref)"
+        return
+    fi
+
+    if [[ -z "$SKILLS_REF_SHA" ]]; then
+        echo "❌ skills-ref is not installed."
+        echo "   Set SKILLS_REF_SHA to an immutable commit SHA to bootstrap a pinned copy."
+        echo "   Example: SKILLS_REF_SHA=<full-commit-sha> ./validate-skills-official.sh"
+        exit 1
+    fi
+
+    if [[ ! "$SKILLS_REF_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+        echo "❌ SKILLS_REF_SHA must be an immutable git commit SHA."
+        exit 1
+    fi
+
+    SKILLS_REF_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/marketingskills-skills-ref.XXXXXX")"
+    local repo_dir="$SKILLS_REF_WORKDIR/repo"
+    local sdk_dir="$repo_dir/skills-ref"
+
+    echo "📦 Installing pinned skills-ref library at $SKILLS_REF_SHA..."
+    echo ""
+
+    git clone --filter=blob:none --no-checkout "$SKILLS_REF_REPO" "$repo_dir"
+    git -C "$repo_dir" fetch --depth 1 origin "$SKILLS_REF_SHA"
+    git -C "$repo_dir" checkout --detach "$SKILLS_REF_SHA"
+
+    if command -v uv &> /dev/null; then
+        echo "Using uv to install..."
+        (cd "$sdk_dir" && uv sync)
+    else
+        echo "Using pip to install..."
+        (
+            cd "$sdk_dir"
+            python3 -m venv .venv
+            source .venv/bin/activate
+            pip install -e .
+        )
+    fi
+    echo ""
+
+    SKILLS_REF_BIN="$sdk_dir/.venv/bin/skills-ref"
+}
 
 echo "🔍 Validating Skills Using Official skills-ref Library"
 echo "========================================================"
 echo "Reference: https://github.com/agentskills/agentskills"
 echo ""
 
-# Check if skills-ref is already installed
-if [ ! -d "$SKILLS_REF_DIR/.venv" ]; then
-    echo "📦 Installing skills-ref library..."
-    echo ""
-
-    if [ ! -d "$SKILLS_REF_DIR" ]; then
-        cd /tmp
-        git clone https://github.com/agentskills/agentskills.git
-    fi
-
-    cd "$SKILLS_REF_DIR"
-
-    if command -v uv &> /dev/null; then
-        echo "Using uv to install..."
-        uv sync
-    else
-        echo "Using pip to install..."
-        python3 -m venv .venv
-        source .venv/bin/activate
-        pip install -e .
-    fi
-    echo ""
-fi
-
-# Activate the virtual environment
-source "$SKILLS_REF_DIR/.venv/bin/activate"
-
-# Return to the original directory
-cd "$(dirname "$0")"
+resolve_skill_paths
+bootstrap_skills_ref
 
 # Track results
 PASSED=0
@@ -50,12 +103,11 @@ echo "Running validation..."
 echo ""
 
 # Validate each skill
-for skill_dir in "$SKILLS_DIR"/*/; do
+for skill_dir in "${SKILL_PATHS[@]}"; do
     skill_name=$(basename "$skill_dir")
     printf "  %-30s" "$skill_name"
 
-    output=$(skills-ref validate "$skill_dir" 2>&1)
-    if echo "$output" | grep -q "Valid skill"; then
+    if output=$("$SKILLS_REF_BIN" validate "$skill_dir" 2>&1); then
         echo "✓"
         ((PASSED++))
     else

--- a/validate-skills.sh
+++ b/validate-skills.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -uo pipefail
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -8,9 +10,29 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 SKILLS_DIR="skills"
+TARGET_PATH="${1:-$SKILLS_DIR}"
 ISSUES=0
 WARNINGS=0
 PASSED=0
+
+shopt -s nullglob
+SKILL_PATHS=()
+
+if [[ -f "$TARGET_PATH" && "$(basename "$TARGET_PATH")" == "SKILL.md" ]]; then
+    SKILL_PATHS=("$(dirname "$TARGET_PATH")/")
+elif [[ -d "$TARGET_PATH" && -f "$TARGET_PATH/SKILL.md" ]]; then
+    SKILL_PATHS=("${TARGET_PATH%/}/")
+elif [[ -d "$TARGET_PATH" ]]; then
+    SKILL_PATHS=("${TARGET_PATH%/}"/*/)
+else
+    echo -e "${RED}Invalid path:${NC} $TARGET_PATH"
+    exit 1
+fi
+
+if [[ ${#SKILL_PATHS[@]} -eq 0 ]]; then
+    echo -e "${RED}No skills found at:${NC} $TARGET_PATH"
+    exit 1
+fi
 
 echo "🔍 Auditing Skills Against Agent Skills Specification"
 echo "======================================================"
@@ -26,7 +48,7 @@ echo ""
 # SKILL.md: under 500 lines
 # Optional dirs: references/, scripts/, assets/
 
-for skill_dir in "$SKILLS_DIR"/*/; do
+for skill_dir in "${SKILL_PATHS[@]}"; do
     skill_name=$(basename "$skill_dir")
     skill_file="$skill_dir/SKILL.md"
     skill_errors=()
@@ -41,7 +63,20 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     fi
 
     # Extract frontmatter
-    frontmatter=$(sed -n '/^---$/,/^---$/p' "$skill_file" | head -n -1 | tail -n +2)
+    frontmatter=$(awk '
+        BEGIN { in_frontmatter = 0; found_start = 0 }
+        /^---[[:space:]]*$/ {
+            if (!found_start) {
+                found_start = 1
+                in_frontmatter = 1
+                next
+            }
+            if (in_frontmatter) {
+                exit
+            }
+        }
+        in_frontmatter { print }
+    ' "$skill_file")
 
     # Validate frontmatter exists
     if [[ -z "$frontmatter" ]]; then
@@ -52,7 +87,7 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     fi
 
     # ===== NAME VALIDATION =====
-    name_in_file=$(echo "$frontmatter" | grep "^name:" | sed 's/^name: //' | tr -d ' ')
+    name_in_file=$(printf '%s\n' "$frontmatter" | sed -n 's/^name:[[:space:]]*//p' | head -n 1 | tr -d ' ')
 
     if [[ -z "$name_in_file" ]]; then
         skill_errors+=("Missing 'name' field in frontmatter")
@@ -66,13 +101,11 @@ for skill_dir in "$SKILLS_DIR"/*/; do
 
     # ===== DESCRIPTION VALIDATION =====
     # Handle both quoted and unquoted descriptions
-    description=$(echo "$frontmatter" | grep "^description:" | head -1)
-    if [[ $description == *'description: "'* ]]; then
-        # Quoted description - extract between quotes
-        description=$(echo "$description" | sed 's/^description: "//' | sed 's/"$//')
-    else
-        # Unquoted description
-        description=$(echo "$description" | sed 's/^description: //')
+    description=$(printf '%s\n' "$frontmatter" | sed -n 's/^description:[[:space:]]*//p' | head -n 1)
+    if [[ $description == \"*\" && $description == *\" ]]; then
+        description="${description:1:-1}"
+    elif [[ $description == \'*\' && $description == *\' ]]; then
+        description="${description:1:-1}"
     fi
 
     if [[ -z "$description" ]]; then
@@ -95,16 +128,16 @@ for skill_dir in "$SKILLS_DIR"/*/; do
     fi
 
     # ===== OPTIONAL FIELDS VALIDATION =====
-    license=$(echo "$frontmatter" | grep "^license:" | sed 's/^license: //' | tr -d ' ')
+    license=$(printf '%s\n' "$frontmatter" | sed -n 's/^license:[[:space:]]*//p' | head -n 1 | tr -d ' ')
     if [[ -n "$license" && "$license" != "MIT" && "$license" != "Apache-2.0" && "$license" != "ISC" ]]; then
         skill_warnings+=("License '$license' is non-standard (default: MIT)")
     fi
 
     # Check metadata structure
-    metadata=$(echo "$frontmatter" | grep -A 10 "^metadata:")
+    metadata=$(printf '%s\n' "$frontmatter" | grep -A 10 "^metadata:" || true)
     if [[ -n "$metadata" ]]; then
         # If metadata exists, check for version placement
-        if echo "$frontmatter" | grep -q "^version:"; then
+        if printf '%s\n' "$frontmatter" | grep -q "^version:"; then
             skill_errors+=("'version' is top-level (should be under 'metadata:')")
         fi
         # Could add more metadata validation here


### PR DESCRIPTION
The high-impact changes are in validate-skills-official.sh (line 1), validate-skills.sh (line 1), sync-skills.yml (line 1), and validate-skill.yml (line 1). The official validator no longer trusts a shared /tmp checkout or mutable branch by default; it now requires either a preinstalled skills-ref or an explicit immutable SKILLS_REF_SHA. CI now pins actions/checkout to a commit SHA and removes the third-party auto-commit / validation actions in favor of local shell steps.

On the CLI side, supermetrics.js (line 11) now uses x-api-key headers instead of query-string auth, instantly.js (line 11) no longer duplicates the API key in request bodies, ga4.js (line 3) supports GA4_MP_API_SECRET / --api-secret-env so you can avoid putting the Measurement Protocol secret on the command line, and zoominfo.js (line 60) masks JWTs unless --show-token is explicitly passed. I also updated the operator guidance in tools/clis/README.md (line 33).

Verified with bash -n on both shell scripts, node --check on the changed JS files, git diff --check, and real runs of ./validate-skills.sh skills/page-cro and ./validate-skills.sh skills/ab-test-setup. I did not run live API calls or the GitHub workflows themselves.

Residual risk remains where upstream vendors only support query-string auth at the API level, which this repo cannot fully eliminate on its own. I documented that limitation in the CLI README.