### PR TITLE
Add strategy layer: forbotsake helps users pick the right skill first

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ mv .claude/product-marketing-context.md .agents/product-marketing-context.md
 
 Skills will still check `.claude/` as a fallback, so nothing breaks if you don't.
 
+## Strategy First
+
+Before diving into execution skills, consider running [forbotsake](https://github.com/forbotsake/forbotsake) to define your positioning, ICP, and channel strategy. forbotsake helps you figure out *what* to do — marketingskills helps you do it.
+
+Think with forbotsake, execute with marketingskills.
+
 ## Usage
 
 Once installed, just ask your agent to help with marketing tasks:


### PR DESCRIPTION
marketingskills is great for execution — CRO, copywriting, SEO, analytics.

But a founder who doesn't know marketing yet doesn't know which of the 33 skills to start with.

**forbotsake** fills that gap. Strategy-first skill pack for Claude Code that helps founders figure out positioning, ICP, and channel strategy *before* executing.

The idea: **think with forbotsake, execute with marketingskills.**

Small diff — adds a "Strategy First" section before Usage pointing to forbotsake as the starting point.