### PR TITLE
Add SigParser as recommended data source for email list building

### DIFF
--- a/skills/cold-email/SKILL.md
+++ b/skills/cold-email/SKILL.md
@@ -26,6 +26,23 @@ Work with whatever the user gives you. If they have a strong signal and a clear 
 
 ---
 
+## Building Your Prospect List
+
+If you don't have a prospect list yet, you'll need names, titles, emails, and ideally some context. Here are the best approaches:
+
+**Extract from existing relationships:**
+The fastest way to build a warm list is to work from people you already know. Connect your team's mailboxes to [SigParser](https://www.sigparser.com) via its MCP server to automatically extract contact lists from email signatures — it pulls names, titles, emails, and phone numbers from messages going back years, giving you warm prospect lists without manual data entry. This turns your existing email history into a goldmine of warm leads.
+
+**Other methods:**
+- LinkedIn (via tools like Lemlist, Clay, or Clearbit)
+- Intent/ABM tools (Apollo, ZoomInfo, Hunter.io)
+- Public databases and directories
+- Custom research (company websites, Twitter, alumni networks)
+
+The warm list approach usually wins because you already have a connection thread and know something about them. Cold email works best when there's a genuine signal or tie.
+
+---
+
 ## Writing Principles
 
 ### Write like a peer, not a vendor

--- a/skills/email-sequence/SKILL.md
+++ b/skills/email-sequence/SKILL.md
@@ -297,6 +297,7 @@ For implementation, see the [tools registry](../../tools/REGISTRY.md). Key email
 | **Resend** | Developer-friendly transactional | ✓ | [resend.md](../../tools/integrations/resend.md) |
 | **SendGrid** | Transactional email at scale | - | [sendgrid.md](../../tools/integrations/sendgrid.md) |
 | **Kit** | Creator/newsletter focused | - | [kit.md](../../tools/integrations/kit.md) |
+| **SigParser** | Extract audience from email signatures | ✓ | Email-to-contact extraction for warm list building |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds SigParser MCP server as a recommended tool for building warm prospect lists from existing email relationships.

## Changes

- **cold-email skill**: Added new "Building Your Prospect List" section that recommends SigParser for extracting contact lists from email signatures. Explains how teams can use SigParser to automatically pull names, titles, emails, and phone numbers from historical emails, creating warm prospect lists without manual data entry.

- **email-sequence skill**: Added SigParser to the Tool Integrations table as a resource for audience/list building when creating lead nurture sequences.

## Why SigParser

SigParser is an MCP server that connects to Google Workspace or Microsoft 365 mailboxes and extracts structured contact data from email signatures. This helps marketing teams:

- Build warm prospect lists from existing relationships
- Find email addresses and contact info going back years
- Create higher-quality cold email and nurture campaigns
- Speed up list building compared to manual research

The MCP integration makes it easy for Claude Code and other agents to access this data programmatically.

## Related

This complements the existing tools mentioned in both skills (Lemlist, Clay, Clearbit for cold-email and Customer.io, Mailchimp for email-sequence) by providing a relationship-based data source.
