### PR TITLE
fix: add missing sections to community-marketing skill

### DIFF
--- a/skills/community-marketing/SKILL.md
+++ b/skills/community-marketing/SKILL.md
@@ -141,3 +141,23 @@ Depending on what the user needs, produce one of:
 - **Health Audit Report** — Current metrics, diagnosis, top 3 priorities to fix
 
 Always be specific. Generic advice ("be consistent," "provide value") is not useful. Give the user something they can act on today.
+
+---
+
+## Task-Specific Questions
+
+1. What platform are you building on (or considering)?
+2. What stage is the community at? (Pre-launch, early, growing, established)
+3. What's the primary business goal? (Retention, activation, word-of-mouth, support deflection)
+4. Who is the ideal community member and what motivates them?
+5. Do you have existing users or customers to seed from?
+6. How much time can you dedicate to community management weekly?
+
+---
+
+## Related Skills
+
+- **referral-program**: For structured referral and ambassador incentive programs
+- **churn-prevention**: For retention strategies that complement community engagement
+- **social-content**: For content creation across social platforms
+- **customer-research**: For understanding your community members' needs and language


### PR DESCRIPTION
## Summary
- Adds Task-Specific Questions section (6 questions)
- Adds Related Skills section (referrals, churn-prevention, social, customer-research)

Content-only portion of the community-marketing cleanup (rename deferred to v2.0.0).

## Test plan
- [ ] Verify SKILL.md frontmatter is valid
- [ ] Confirm new sections follow skill spec conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)