### PR TITLE
fix: add line break between platform reference links

### DIFF
--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -49,6 +49,7 @@ Gather this context (ask if not provided):
 | Facebook | Communities, local businesses | 1-2x/day | Groups, native video |
 
 **For detailed platform strategies**: See [references/platforms.md](references/platforms.md)
+
 **For hashtag limits and character counts**: See [references/platform-limits.md](references/platform-limits.md)
 
 ---


### PR DESCRIPTION
## Summary
- Fixes formatting: adds line break between platform reference links in social-content skill

## Test plan
- [ ] Verify markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)