### PR TITLE
feat: add Zapier SDK integration for 8,000+ app access

### DIFF
--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -61,7 +61,7 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | meta-ads | Ads | ✓ | - | [✓](clis/meta-ads.js) | ✓ | [meta-ads.md](integrations/meta-ads.md) |
 | linkedin-ads | Ads | ✓ | - | [✓](clis/linkedin-ads.js) | - | [linkedin-ads.md](integrations/linkedin-ads.md) |
 | tiktok-ads | Ads | ✓ | - | [✓](clis/tiktok-ads.js) | ✓ | [tiktok-ads.md](integrations/tiktok-ads.md) |
-| zapier | Automation | ✓ | ✓ | [✓](clis/zapier.js) | - | [zapier.md](integrations/zapier.md) |
+| zapier | Automation | ✓ | ✓ | [✓](clis/zapier.js) | ✓ | [zapier.md](integrations/zapier.md) |
 | hotjar | CRO | ✓ | - | [✓](clis/hotjar.js) | - | [hotjar.md](integrations/hotjar.md) |
 | optimizely | A/B Testing | ✓ | - | [✓](clis/optimizely.js) | ✓ | [optimizely.md](integrations/optimizely.md) |
 | calendly | Scheduling | ✓ | - | [✓](clis/calendly.js) | - | [calendly.md](integrations/calendly.md) |
@@ -202,9 +202,9 @@ Workflow automation and integration platforms.
 
 | Tool | Best For | MCP Available |
 |------|----------|:-------------:|
-| **zapier** | No-code integrations | ✓ |
+| **zapier** | No-code integrations + SDK for 8,000+ apps | ✓ |
 
-**Agent recommendation**: Zapier for connecting tools without code.
+**Agent recommendation**: Zapier SDK for agents that need to interact with any app directly. Zaps for always-on automations.
 
 ### CRO & A/B Testing
 
@@ -456,7 +456,7 @@ These tools have Model Context Protocol servers available, enabling direct agent
 - **mailchimp** - Email campaign management
 - **google-ads** - Ad campaign management
 - **resend** - Transactional email sending
-- **zapier** - Workflow automation
+- **zapier** - Workflow automation + SDK for 8,000+ app integrations
 - **zoominfo** - B2B contacts and intent data
 - **clay** - Data enrichment and outbound automation
 - **supermetrics** - Cross-platform marketing data

--- a/tools/integrations/zapier.md
+++ b/tools/integrations/zapier.md
@@ -1,6 +1,6 @@
 # Zapier
 
-Workflow automation platform connecting apps without code.
+Workflow automation platform connecting 8,000+ apps. The Zapier SDK gives AI agents direct access to any app's actions without building OAuth flows or reverse-engineering APIs.
 
 ## Capabilities
 
@@ -8,16 +8,110 @@ Workflow automation platform connecting apps without code.
 |-------------|-----------|-------|
 | API | ✓ | REST API for Zaps, tasks, and webhooks |
 | MCP | ✓ | Available via Zapier MCP server |
-| CLI | - | Not available |
-| SDK | - | API and webhooks only |
+| CLI | ✓ | `@zapier/zapier-sdk-cli` for app discovery and type generation |
+| SDK | ✓ | `@zapier/zapier-sdk` — TypeScript SDK for 8,000+ app integrations |
 
 ## Authentication
+
+### Legacy API (Zaps management)
 
 - **Type**: API Key
 - **Header**: `X-API-Key: {api_key}`
 - **Get key**: Settings > API in Zapier account
 
-## Common Agent Operations
+### SDK Authentication
+
+**Browser-based login (development):**
+```bash
+npx zapier-sdk login
+```
+
+**Server-side (production):**
+- Client Credentials — store as environment variables
+- Direct token — set `ZAPIER_CREDENTIALS` env var
+
+Browser-based login only works locally. Use Client Credentials for any server-side deployment.
+
+## SDK Quick Start
+
+### Install
+
+```bash
+npm install @zapier/zapier-sdk
+npm install -D @zapier/zapier-sdk-cli @types/node typescript
+npm pkg set type=module
+```
+
+### Initialize
+
+```typescript
+import { createZapierSdk } from "@zapier/zapier-sdk";
+const zapier = createZapierSdk();
+```
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `npx zapier-sdk login` | Authenticate (dev only) |
+| `npx zapier-sdk list-apps --search "query"` | Search available apps |
+| `npx zapier-sdk list-actions APP_KEY` | List actions for an app |
+| `npx zapier-sdk add [app-key]` | Generate TypeScript types |
+
+### SDK Methods
+
+| Method | Purpose |
+|--------|---------|
+| `zapier.listConnections()` | List authenticated app connections |
+| `zapier.findFirstConnection()` | Find a specific connection |
+| `zapier.runAction()` | Execute an action on a connected app |
+| `zapier.apps.slack()` | App proxy pattern for clean syntax |
+| `zapier.fetch()` | Custom authenticated API calls |
+
+### Example: Send a Slack Message
+
+```typescript
+import { createZapierSdk } from "@zapier/zapier-sdk";
+
+const zapier = createZapierSdk();
+const slack = await zapier.apps.slack();
+
+await slack.sendChannelMessage({
+  channel: "#marketing",
+  message: "Campaign launched!"
+});
+```
+
+### Example: Create a HubSpot Contact
+
+```typescript
+const hubspot = await zapier.apps.hubspot();
+
+await hubspot.createContact({
+  email: "lead@example.com",
+  firstName: "Jane",
+  lastName: "Doe"
+});
+```
+
+### Pagination
+
+Use `.items()` for large datasets:
+
+```typescript
+const contacts = await hubspot.listContacts({ maxItems: 100 });
+for await (const contact of contacts.items()) {
+  console.log(contact.email);
+}
+```
+
+### Governance Note
+
+Direct API calls via `zapier.fetch()` are not subject to org app/action restriction policies. Use pre-built actions where possible if your org has governance requirements.
+
+---
+
+## Zaps API (Legacy)
 
 ### List Zaps
 
@@ -82,30 +176,29 @@ POST https://hooks.zapier.com/hooks/catch/{account_id}/{hook_id}/
 
 ## Common Marketing Automations
 
-### Lead capture to CRM
-```
-Typeform → Zapier → HubSpot
+### With SDK (recommended for agents)
+
+```typescript
+// Lead capture to CRM
+const hubspot = await zapier.apps.hubspot();
+await hubspot.createContact({ email, firstName, lastName });
+
+// New customer notification
+const slack = await zapier.apps.slack();
+await slack.sendChannelMessage({ channel: "#revenue", message: `New customer: ${email}` });
+
+// Add to email sequence
+const customerio = await zapier.apps.customerio();
+await customerio.createOrUpdatePerson({ email, plan: "pro" });
 ```
 
-### New customer notifications
-```
-Stripe (new customer) → Zapier → Slack
-```
+### With Zaps (no-code)
 
-### Email sequence triggers
-```
-Form submission → Zapier → Customer.io
-```
-
-### Social proof automation
-```
-New review → Zapier → Twitter/Slack
-```
-
-### Referral tracking
-```
-New referral → Zapier → Spreadsheet + Slack
-```
+- Typeform → Zapier → HubSpot (lead capture)
+- Stripe → Zapier → Slack (new customer alerts)
+- Form submission → Zapier → Customer.io (email sequences)
+- New review → Zapier → Slack (social proof)
+- New referral → Zapier → Spreadsheet + Slack (referral tracking)
 
 ## Webhook Payload Structure
 
@@ -123,24 +216,24 @@ When sending to Zapier, structure data as flat JSON:
 
 ## Key Concepts
 
-- **Zap** - Automated workflow
+- **Zap** - Automated workflow (no-code)
+- **SDK** - Programmatic access to 8,000+ app integrations
 - **Trigger** - Event that starts a Zap
-- **Action** - Task performed by Zap
+- **Action** - Task performed by Zap or SDK
 - **Task** - Single action execution
-- **Filter** - Conditional logic
-- **Path** - Branching logic
+- **Connection** - Authenticated link to an app (shared between Zaps and SDK)
 
 ## When to Use
 
-- Connecting marketing tools without code
-- Automating lead routing
-- Syncing data between platforms
-- Triggering notifications
-- Building marketing workflows
+- **SDK**: When an AI agent needs to interact with any app directly — send messages, create records, sync data
+- **Zaps**: When you need always-on automation without code
+- **Webhooks**: When triggering workflows from your own app
+- **API**: When managing Zaps programmatically
 
 ## Rate Limits
 
-- 100 requests per minute
+- API: 100 requests per minute
+- SDK: Rate limits per connected app
 - Task limits by plan tier
 
 ## Relevant Skills
@@ -148,3 +241,4 @@ When sending to Zapier, structure data as flat JSON:
 - email-sequence
 - analytics-tracking
 - referral-program
+- revops


### PR DESCRIPTION
## Summary
- Adds Zapier SDK (`@zapier/zapier-sdk`) documentation to the Zapier integration guide
- SDK gives AI agents direct TypeScript access to 8,000+ app integrations (Slack, HubSpot, Salesforce, etc.) without building OAuth flows
- Includes install, auth, CLI commands, SDK methods, marketing automation examples
- Updates REGISTRY.md to mark SDK as available for Zapier
- Restructures existing Zaps API docs under "Legacy" heading

## Test plan
- [ ] Verify integration guide renders correctly
- [ ] Confirm REGISTRY.md SDK column is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)