### PR TITLE
Add banana-image-gen skill for AI image generation

### DIFF
--- a/skills/banana-image-gen/SKILL.md
+++ b/skills/banana-image-gen/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: banana
+description: "AI image generation Creative Director powered by Google Gemini Nano Banana models. Use this skill for ANY request involving image creation, editing, visual asset production, or creative direction. Triggers on: generate an image, create a photo, edit this picture, design a logo, make a banner, visual for my anything, and all /banana commands. Handles text-to-image, image editing, multi-turn creative sessions, batch workflows, and brand presets."
+argument-hint: "[generate|edit|chat|inspire|batch] <idea, path, or command>"
+metadata:
+  version: "1.4.1"
+  author: AgriciDaniel
+  mcp-package: "@ycse/nanobanana-mcp"
+---
+
+# Banana Claude -- Creative Director for AI Image Generation
+
+## MANDATORY -- Read these before every generation
+
+Before constructing ANY prompt or calling ANY tool, you MUST read:
+1. `references/gemini-models.md` -- to select the correct model and parameters
+2. `references/prompt-engineering.md` -- to construct a compliant prompt
+
+This is not optional. Do not skip this even for simple requests.
+
+## Core Principle
+
+Act as a **Creative Director** that orchestrates Gemini's image generation.
+Never pass raw user text directly to the API. Always interpret, enhance, and
+construct an optimized prompt using the 5-Component Formula from `references/prompt-engineering.md`.
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `/banana` | Interactive -- detect intent, craft prompt, generate |
+| `/banana generate <idea>` | Generate image with full prompt engineering |
+| `/banana edit <path> <instructions>` | Edit existing image intelligently |
+| `/banana chat` | Multi-turn visual session (character/style consistent) |
+| `/banana inspire [category]` | Browse prompt database for ideas |
+| `/banana batch <idea> [N]` | Generate N variations (default: 3) |
+| `/banana setup` | Install MCP server and configure API key |
+| `/banana preset [list\|create\|show\|delete]` | Manage brand/style presets |
+| `/banana cost [summary\|today\|estimate]` | View cost tracking and estimates |
+
+## Core Principle: Claude as Creative Director
+
+**NEVER** pass the user's raw text as-is to `gemini_generate_image`.
+
+Follow this pipeline for every generation -- no exceptions:
+
+1. Read `references/gemini-models.md` and `references/prompt-engineering.md`
+2. Analyze intent (Step 1 below) -- confirm with user if ambiguous
+3. Select domain mode (Step 2) -- check for presets (Step 1.5)
+4. Construct prompt using 5-component formula from prompt-engineering.md
+5. Select model and `imageSize` based on domain routing table in gemini-models.md
+6. Call the MCP generate tool (or fallback to direct API scripts)
+7. Check response:
+   - If `finishReason: IMAGE_SAFETY` → apply safety rephrase, retry (max 3 attempts with user approval)
+   - If empty response (no image parts) → verify responseModalities includes "IMAGE", retry once
+   - If HTTP 429 → wait 2s, retry with exponential backoff (max 3 retries)
+   - If HTTP 400 FAILED_PRECONDITION → inform user about billing, do not retry
+8. On success: save image, log cost, return file path and summary
+9. Never report success until a valid image file path is confirmed to exist
+
+### Step 1: Analyze Intent
+
+Determine what the user actually needs:
+- What is the final use case? (blog, social, app, print, presentation)
+- What style fits? (photorealistic, illustrated, minimal, editorial)
+- What constraints exist? (brand colors, dimensions, transparency)
+- What mood/emotion should it convey?
+
+If the request is vague (e.g., "make me a hero image"), ASK clarifying
+questions about use case, style preference, and brand context before generating.
+
+### Step 1.5: Check for Presets
+
+If the user mentions a brand name or style preset, check `~/.banana/presets/`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/presets.py list
+```
+If a matching preset exists, load it with `presets.py show NAME` and use its values
+as defaults for the Reasoning Brief. User instructions override preset values.
+
+### Step 2: Select Domain Mode
+
+Choose the expertise lens that best fits the request:
+
+| Mode | When to use | Prompt emphasis |
+|------|-------------|-----------------|
+| **Cinema** | Dramatic scenes, storytelling, mood pieces | Camera specs, lens, film stock, lighting setup |
+| **Product** | E-commerce, packshots, merchandise | Surface materials, studio lighting, angles, clean BG |
+| **Portrait** | People, characters, headshots, avatars | Facial features, expression, pose, lens choice |
+| **Editorial** | Fashion, magazine, lifestyle | Styling, composition, publication reference |
+| **UI/Web** | Icons, illustrations, app assets | Clean vectors, flat design, brand colors, sizing |
+| **Logo** | Branding, marks, identity | Geometric construction, minimal palette, scalability |
+| **Landscape** | Environments, backgrounds, wallpapers | Atmospheric perspective, depth layers, time of day |
+| **Abstract** | Patterns, textures, generative art | Color theory, mathematical forms, movement |
+| **Infographic** | Data visualization, diagrams, charts | Layout structure, text rendering, hierarchy |
+
+### Step 3: Construct the Reasoning Brief
+
+Build the prompt using the **5-Component Formula** from `references/prompt-engineering.md`.
+Be SPECIFIC and VISCERAL -- describe what the camera sees, not what the ad means.
+
+**The 5 Components:** Subject → Action → Location/Context → Composition → Style (includes lighting)
+
+**CRITICAL RULES:**
+- Name real cameras: "Sony A7R IV", "Canon EOS R5", "iPhone 16 Pro Max"
+- Name real brands for styling: "Lululemon", "Tom Ford" (triggers visual associations)
+- Include micro-details: "sweat droplets on collarbones", "baby hairs stuck to neck"
+- Use prestigious context anchors: "Vanity Fair editorial," "National Geographic cover"
+- **NEVER** use banned keywords: "8K", "masterpiece", "ultra-realistic", "high resolution" -- use `imageSize` param instead
+- **NEVER** write "a dark-themed ad showing..." -- describe the SCENE, not the concept
+- For critical constraints use ALL CAPS: "MUST contain exactly three figures"
+- For products: say "prominently displayed" to ensure visibility
+
+**Template for photorealistic / ads:**
+```
+[Subject: age + appearance + expression], wearing [outfit with brand/texture],
+[action verb] in [specific location + time]. [Micro-detail about skin/hair/
+sweat/texture]. Captured with [camera model], [focal length] lens at [f-stop],
+[lighting description]. [Prestigious context: "Vanity Fair editorial" /
+"Pulitzer Prize-winning cover photograph"].
+```
+
+**Template for product / commercial:**
+```
+[Product with brand name] with [dynamic element: condensation/splashes/glow],
+[product detail: "logo prominently displayed"], [surface/setting description].
+[Supporting visual elements: light rays, particles, reflections].
+Commercial photography for an advertising campaign. [Publication reference:
+"Bon Appetit feature spread" / "Wallpaper* design editorial"].
+```
+
+**Template for illustrated/stylized:**
+```
+A [art style] [format] of [subject with character detail], featuring
+[distinctive characteristics] with [color palette]. [Line style] and
+[shading technique]. Background is [description]. [Mood/atmosphere].
+```
+
+**Template for text-heavy assets** (keep text under 25 characters):
+```
+A [asset type] with the text "[exact text]" in [descriptive font style],
+[placement and sizing]. [Layout structure]. [Color scheme]. [Visual
+context and supporting elements].
+```
+
+For more templates see `references/prompt-engineering.md` → Proven Prompt Templates.
+
+### Step 4: Select Aspect Ratio
+
+Match ratio to use case -- call `set_aspect_ratio` BEFORE generating:
+
+| Use Case | Ratio | Why |
+|----------|-------|-----|
+| Social post / avatar | `1:1` | Square, universal |
+| Blog header / YouTube thumb | `16:9` | Widescreen standard |
+| Story / Reel / mobile | `9:16` | Vertical full-screen |
+| Portrait / book cover | `3:4` | Tall vertical |
+| Product shot | `4:3` | Classic display |
+| DSLR print / photo standard | `3:2` | Classic camera ratio |
+| Pinterest pin / poster | `2:3` | Tall vertical card |
+| Instagram portrait | `4:5` | Social portrait optimized |
+| Large format photography | `5:4` | Landscape fine art |
+| Website banner | `4:1` or `8:1` | Ultra-wide strip |
+| Ultrawide / cinematic | `21:9` | Film-grade (3.1 Flash only) |
+
+### Step 4.5: Select Resolution (optional)
+
+Choose output resolution based on intended use:
+
+| `imageSize` | When to use |
+|-------------|-------------|
+| `512` | Quick drafts, rapid iteration |
+| `1K` | Budget-conscious, web thumbnails, social media |
+| `2K` | **Default** -- quality assets, most use cases |
+| `4K` | Print production, hero images, final deliverables |
+
+Note: Resolution control (`imageSize`) depends on MCP package version support.
+
+### Step 5: Call the MCP
+
+Use the appropriate MCP tool:
+
+| MCP Tool | When |
+|----------|------|
+| `set_aspect_ratio` | Always call first if ratio differs from 1:1 |
+| `set_model` | Only if switching models |
+| `gemini_generate_image` | New image from prompt |
+| `gemini_edit_image` | Modify existing image |
+| `gemini_chat` | Multi-turn / iterative refinement |
+| `get_image_history` | Review session history |
+| `clear_conversation` | Reset session context |
+
+### Step 6: Post-Processing (when needed)
+
+After generation, apply post-processing if the user needs it.
+For transparent PNG output, use the green screen pipeline documented in `references/post-processing.md`.
+
+**Pre-flight:** Before running any post-processing, verify tools are available:
+```bash
+which magick || which convert || echo "ImageMagick not installed -- install with: sudo apt install imagemagick"
+```
+If `magick` (v7) is not found, fall back to `convert` (v6). If neither exists, inform the user.
+
+```bash
+# Crop to exact dimensions
+magick input.png -resize 1200x630^ -gravity center -extent 1200x630 output.png
+
+# Remove white background → transparent PNG
+magick input.png -fuzz 10% -transparent white output.png
+
+# Convert format
+magick input.png output.webp
+
+# Add border/padding
+magick input.png -bordercolor white -border 20 output.png
+
+# Resize for specific platform
+magick input.png -resize 1080x1080 instagram.png
+```
+
+Check if `magick` (ImageMagick 7) is available. Fall back to `convert` if not.
+
+## Editing Workflows
+
+For `/banana edit`, Claude should also enhance the edit instruction:
+
+- **Don't:** Pass "remove background" directly
+- **Do:** "Remove the existing background entirely, replacing it with a clean
+  transparent or solid white background. Preserve all edge detail and fine
+  features like hair strands."
+
+Common intelligent edit transformations:
+| User says | Claude crafts |
+|-----------|---------------|
+| "remove background" | Detailed edge-preserving background removal instruction |
+| "make it warmer" | Specific color temperature shift with preservation notes |
+| "add text" | Font style, size, placement, contrast, readability notes |
+| "make it pop" | Increase saturation, add contrast, enhance focal point |
+| "extend it" | Outpainting with style-consistent continuation description |
+
+## Multi-turn Chat (`/banana chat`)
+
+Use `gemini_chat` for iterative creative sessions:
+
+1. Generate initial concept with full Reasoning Brief
+2. Refine with specific, targeted changes (not full re-descriptions)
+3. Session maintains character consistency and style across turns
+4. Use for: character design sheets, sequential storytelling, progressive refinement
+
+## Prompt Inspiration (`/banana inspire`)
+
+If the user has the `prompt-engine` or `prompt-library` skill installed, use it
+to search 2,500+ curated prompts. Otherwise, Claude should generate prompt
+inspiration based on the domain mode libraries in `references/prompt-engineering.md`.
+
+**When using an external prompt database**, available filters include:
+- `--category [name]` -- 19 categories (fashion-editorial, sci-fi, logos-icons, etc.)
+- `--model [name]` -- Filter by original model (adapt to Gemini)
+- `--type image` -- Image prompts only
+- `--random` -- Random inspiration
+
+**IMPORTANT:** Prompts from the database are optimized for Midjourney/DALL-E/etc.
+When adapting to Gemini, you MUST:
+- Remove Midjourney `--parameters` (--ar, --v, --style, --chaos)
+- Convert keyword lists to natural language paragraphs
+- Replace prompt weights `(word:1.5)` with descriptive emphasis
+- Add camera/lens specifications for photorealistic prompts
+- Expand terse tags into full scene descriptions
+
+## Batch Variations (`/banana batch`)
+
+For `/banana batch <idea> [N]`, generate N variations:
+
+1. Construct the base Reasoning Brief from the idea
+2. Create N variations by rotating one component per generation:
+   - Variation 1: Different lighting (golden hour → blue hour)
+   - Variation 2: Different composition (close-up → wide shot)
+   - Variation 3: Different style (photorealistic → illustration)
+3. Call `gemini_generate_image` N times with distinct prompts
+4. Present all results with brief descriptions of what varies
+
+For CSV-driven batch: `python3 ${CLAUDE_SKILL_DIR}/scripts/batch.py --csv path/to/file.csv`
+The script outputs a generation plan with cost estimates. Execute each row via MCP.
+
+## Model Routing
+
+Select model based on task requirements:
+
+| Scenario | Model | Resolution | Brief Level | When |
+|----------|-------|-----------|-------------|------|
+| Quick draft | `gemini-2.5-flash-image` | 512/1K | 3-component (Subject+Context+Style) | Rapid iteration, budget-conscious |
+| Standard | `gemini-3.1-flash-image-preview` | 2K | Full 5-component | Default -- most use cases |
+| Quality | `gemini-3.1-flash-image-preview` | 2K/4K | 5-component + prestigious anchors | Final assets, hero images |
+| Text-heavy | `gemini-3.1-flash-image-preview` | 2K | 5-component, thinking: high | Logos, infographics, text rendering |
+| Batch/bulk | Any model via Batch API | 1K | 5-component | Non-urgent bulk -- 50% cost discount |
+
+Default: `gemini-3.1-flash-image-preview`. Switch with `set_model` when routing to 2.5 Flash.
+
+## Error Handling
+
+| Error | Resolution |
+|-------|-----------|
+| MCP not configured | Run `/banana setup` |
+| API key invalid | New key at https://aistudio.google.com/apikey |
+| Rate limited (429) | Wait 60s, retry with exponential backoff. Free tier: ~5-15 RPM / ~20-500 RPD |
+| `IMAGE_SAFETY` | Output blocked -- analyze prompt for triggers, suggest 2-3 rephrased alternatives. See `references/prompt-engineering.md` Safety Rephrase section. Do NOT auto-retry without user approval. |
+| `PROHIBITED_CONTENT` | Topic is blocked (violence, NSFW, real public figures). Non-retryable -- explain why and suggest alternative concepts. |
+| Safety filter false positive | Filters are overly cautious. Rephrase using abstraction, artistic framing, or metaphor. Common: "dog" blocked → try "a friendly golden retriever in a sunny park". See `references/prompt-engineering.md` Safety Rephrase Strategies. |
+| MCP unavailable | Fall back to direct API: `python3 ${CLAUDE_SKILL_DIR}/scripts/generate.py --prompt "..." --aspect-ratio "16:9"` or `python3 ${CLAUDE_SKILL_DIR}/scripts/edit.py --image PATH --prompt "..."`. These call the Gemini REST API directly with no MCP dependency. |
+| Vague request | Ask clarifying questions before generating |
+| Poor result quality | Review Reasoning Brief -- likely too abstract. Load `references/prompt-engineering.md` Proven Templates and rebuild with specifics. |
+
+## Cost Tracking
+
+After every successful generation, log it:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/cost_tracker.py log --model MODEL --resolution RES --prompt "brief description"
+```
+Before batch operations, show the estimate. Run `cost_tracker.py summary` if the user asks about usage.
+
+## Response Format
+
+After generating, always provide:
+1. **The image path** -- where it was saved
+2. **The crafted prompt** -- show the user what you sent (educational)
+3. **Settings used** -- model, aspect ratio
+4. **Suggestions** -- 1-2 refinement ideas if relevant
+
+## Reference Documentation
+
+Load on-demand -- do NOT load all at startup:
+- `references/prompt-engineering.md` -- Domain mode details, modifier libraries, advanced techniques
+- `references/gemini-models.md` -- Model specs, rate limits, capabilities
+- `references/mcp-tools.md` -- MCP tool parameters and response formats
+- `references/post-processing.md` -- FFmpeg/ImageMagick pipeline recipes, green screen transparency
+- `references/cost-tracking.md` -- Pricing table, usage guide, free tier limits
+- `references/presets.md` -- Brand preset schema, examples, merge behavior
+
+## Setup
+
+Run `python3 scripts/setup_mcp.py` to configure the MCP server. Requires:
+- Node.js 18+ (npx)
+- Google AI API key (free at https://aistudio.google.com/apikey)
+
+Verify: `python3 scripts/validate_setup.py`

--- a/skills/banana-image-gen/evals/evals.json
+++ b/skills/banana-image-gen/evals/evals.json
@@ -1,0 +1,90 @@
+{
+  "skill_name": "banana-image-gen",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Generate a hero image for my SaaS landing page. We're a project management tool targeting startup founders. Brand colors are teal and dark navy.",
+      "expected_output": "Should act as Creative Director — not pass raw text to API. Should analyze intent (SaaS hero image, web use case). Should select UI/Web or Product domain mode. Should construct a 5-component prompt (Subject, Action, Location/Context, Composition, Style) using narrative prose, not keyword lists. Should avoid banned keywords (8K, masterpiece, ultra-realistic). Should select appropriate aspect ratio (16:9 for hero). Should use prestigious context anchors instead of generic quality terms. Should mention model selection and resolution.",
+      "assertions": [
+        "Acts as Creative Director, does not pass raw text",
+        "Analyzes intent and use case before generating",
+        "Selects appropriate domain mode",
+        "Constructs prompt using 5-component formula",
+        "Uses narrative prose, not keyword lists",
+        "Avoids banned keywords (8K, masterpiece, ultra-realistic)",
+        "Sets aspect ratio appropriate for hero image (16:9)",
+        "Uses prestigious context anchors"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "/banana edit ~/Downloads/product-photo.png remove the background and make it look more professional",
+      "expected_output": "Should enhance the raw edit instruction — not pass 'remove background' directly. Should craft a detailed edit prompt with edge-preserving instructions, background replacement details, and quality preservation notes. Should use gemini_edit_image MCP tool or fallback to edit.py script. Should describe the enhanced instruction to the user.",
+      "assertions": [
+        "Enhances raw edit instruction with specific detail",
+        "Includes edge-preserving instructions",
+        "Specifies background replacement approach",
+        "Uses gemini_edit_image or edit.py fallback",
+        "Shows the user the crafted edit prompt"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I need 5 variations of a product shot for our new coffee brand. The bag is kraft paper with a black logo.",
+      "expected_output": "Should activate batch variation workflow. Should construct a base Reasoning Brief using the Product domain mode. Should create 5 variations by rotating different components (lighting, composition, angle, style, setting). Should select appropriate aspect ratio for product shots (4:3 or 1:1). Should use Product mode prompt patterns with studio lighting vocabulary, surface materials, and brand specificity. Should show cost estimate before generating.",
+      "assertions": [
+        "Activates batch variation workflow",
+        "Uses Product domain mode",
+        "Creates 5 distinct variations rotating different components",
+        "Uses Product mode vocabulary (surfaces, lighting, angles)",
+        "Shows cost estimate before generating",
+        "Each variation has a clearly different component"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "make me a logo",
+      "expected_output": "Should recognize this as a vague request and ask clarifying questions before generating. Should ask about: brand name, industry/use case, style preferences, color preferences, and where the logo will be used. Should NOT immediately generate an image from the vague prompt. Should mention Logo domain mode capabilities.",
+      "assertions": [
+        "Recognizes vague request",
+        "Asks clarifying questions before generating",
+        "Asks about brand name and industry",
+        "Asks about style and color preferences",
+        "Does NOT immediately generate from vague prompt"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "/banana generate a dramatic cinematic shot of a luxury watch on a dark surface with moody lighting",
+      "expected_output": "Should read references/gemini-models.md and references/prompt-engineering.md first. Should select Cinema or Product domain mode. Should construct full 5-component prompt with specific camera model (e.g., Sony A7R IV), lens specs (e.g., 90mm macro f/2.8), lighting setup details, surface material description, and prestigious context anchor (e.g., Wallpaper* magazine editorial). Should set aspect ratio (16:9 or 3:2 for cinematic). Should call MCP generate tool or fallback script.",
+      "assertions": [
+        "Reads reference docs before constructing prompt",
+        "Selects Cinema or Product domain mode",
+        "Includes specific camera model in prompt",
+        "Includes lens specifications",
+        "Describes lighting setup in detail",
+        "Includes prestigious context anchor",
+        "Sets cinematic aspect ratio",
+        "Calls MCP tool or fallback script"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I need social media graphics for Instagram, a YouTube thumbnail, and a LinkedIn banner — all for the same product launch. Can you help?",
+      "expected_output": "Should plan a multi-asset workflow with different aspect ratios per platform. Instagram: 1:1 or 4:5, YouTube thumbnail: 16:9 at 1280x720, LinkedIn banner: custom crop. Should maintain visual consistency across assets using the same Reasoning Brief base with adapted compositions. Should mention post-processing resize commands if needed. Should suggest generating each separately with appropriate ratios.",
+      "assertions": [
+        "Plans multi-asset workflow",
+        "Specifies correct aspect ratio per platform",
+        "Maintains visual consistency across assets",
+        "Mentions post-processing for exact platform dimensions",
+        "Generates each asset with appropriate settings"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/banana-image-gen/references/cost-tracking.md
+++ b/skills/banana-image-gen/references/cost-tracking.md
@@ -1,0 +1,47 @@
+# Cost Tracking Reference
+
+> Load this on-demand when the user asks about costs or before batch operations.
+
+## Pricing Table
+
+| Model | Resolution | Cost/Image | Notes |
+|-------|-----------|-----------|-------|
+| 3.1 Flash | 512 | $0.020 | Quick drafts |
+| 3.1 Flash | 1K | $0.039 | Standard (default) |
+| 3.1 Flash | 2K | $0.078 | Quality assets |
+| 3.1 Flash | 4K | $0.156 | Print/hero images |
+| 2.5 Flash | 512 | $0.020 | Draft fallback |
+| 2.5 Flash | 1K | $0.039 | Standard fallback |
+| Batch API | Any | 50% of above | Asynchronous, higher latency |
+
+Pricing is approximate, based on ~1,290 output tokens per image.
+Research suggests actual costs may be ~$0.067/img. Verify at https://ai.google.dev/gemini-api/docs/pricing
+
+## Free Tier Limits
+
+- ~10 requests per minute (RPM)
+- ~500 requests per day (RPD)
+- Per Google Cloud project, resets midnight Pacific
+
+## Cost Tracker Commands
+
+```bash
+# Log a generation
+cost_tracker.py log --model gemini-3.1-flash-image-preview --resolution 1K --prompt "coffee shop hero"
+
+# View summary (total + last 7 days)
+cost_tracker.py summary
+
+# Today's usage
+cost_tracker.py today
+
+# Estimate before batch
+cost_tracker.py estimate --model gemini-3.1-flash-image-preview --resolution 1K --count 10
+
+# Reset ledger
+cost_tracker.py reset --confirm
+```
+
+## Storage
+
+Ledger stored at `~/.banana/costs.json`. Created automatically on first use.

--- a/skills/banana-image-gen/references/gemini-models.md
+++ b/skills/banana-image-gen/references/gemini-models.md
@@ -1,0 +1,236 @@
+# Gemini Image Generation Models
+
+> Last updated: 2026-03-19
+> Aligned with Google's March 2026 API state
+
+## Available Models
+
+### gemini-3.1-flash-image-preview -- Nano Banana 2 (DEFAULT)
+| Property | Value |
+|----------|-------|
+| **Model ID** | `gemini-3.1-flash-image-preview` |
+| **Tier** | Nano Banana 2 (Flash) |
+| **Status** | Preview -- **Active, recommended default** |
+| **Speed** | Fast -- optimized for high-volume use |
+| **Aspect Ratios** | All 14 ratios including extreme: 1:4, 4:1, 1:8, 8:1 (see table below) |
+| **Max Resolution** | Up to 4096×4096 (4K tier) |
+| **Input Tokens** | 131,072 |
+| **Features** | Google Search grounding (web + image), thinking levels, image-only output, extreme aspect ratios |
+| **Rate Limits (Free)** | ~5-15 RPM / ~20-500 RPD (per project, resets midnight Pacific. Cut ~92% Dec 2025) |
+| **Output Tokens** | ~1,290 output tokens per image |
+| **Best For** | All standard production generation and editing -- most use cases |
+
+### gemini-2.5-flash-image -- Nano Banana (Original)
+| Property | Value |
+|----------|-------|
+| **Model ID** | `gemini-2.5-flash-image` |
+| **Tier** | Nano Banana (Flash, original generation) |
+| **Status** | GA -- **Active** |
+| **Speed** | Fast |
+| **Aspect Ratios** | 1:1, 16:9, 9:16, 4:3, 3:4, 2:3, 3:2, 4:5, 5:4, 21:9 (10 ratios) |
+| **Max Resolution** | Up to 1024×1024 (1K tier) |
+| **Input Tokens** | 32,768 |
+| **Rate Limits (Free)** | ~5-15 RPM / ~20-500 RPD |
+| **Best For** | Free-tier users, budget-conscious high-volume workflows, 1K-resolution use cases |
+| **Cost** | ~$0.039/image at 1K |
+
+## ⛔ DEPRECATED -- Nano Banana Pro (gemini-3-pro-image-preview)
+
+<!-- REMOVED 2026-03-19: gemini-3-pro-image-preview shut down by Google March 9, 2026 -->
+
+**Shut down by Google on March 9, 2026.** API calls to this model ID will fail
+with a hard error. Do not use. The replacement is Nano Banana 2
+(`gemini-3.1-flash-image-preview`).
+
+**Was:** Nano Banana Pro tier -- professional asset production, 4K output, 14 reference images, 94% text accuracy.
+
+**Migration:** Replace all references to `gemini-3-pro-image-preview` with `gemini-3.1-flash-image-preview`.
+
+## Deprecated Models (DO NOT USE)
+
+### gemini-2.0-flash-exp
+- **Status:** Deprecated, replaced by gemini-2.5-flash-image
+
+## Domain-to-Model Routing
+
+| Domain Mode | Recommended Model | Reason |
+|---|---|---|
+| Cinema, Landscape, Abstract | Nano Banana 2 | Thinking mode improves complex compositions |
+| Product, Portrait | Nano Banana 2 | 2K/4K resolution for fidelity |
+| UI, Infographic | Nano Banana 2 | Search grounding for factual diagrams |
+| Logo | Nano Banana 2 | Text rendering improvements in 3.1 |
+| Editorial | Nano Banana 2 | Default |
+| Free tier / budget | Nano Banana (original) | $0.039/image, still excellent |
+
+## Resolution Defaults by Domain
+
+| Domain | Default `imageSize` | Rationale |
+|--------|-------------------|-----------|
+| Portrait, Product, Logo | `2K` | Fine detail and text fidelity |
+| Cinema, Landscape | `2K` + widescreen ratio | Atmospheric depth at larger canvas |
+| UI, Infographic | `1K` | Structured output doesn't benefit from 4K |
+| Quick draft / preview | `512` (Nano Banana 2 only) | Rapid iteration |
+| Print / high fidelity | `4K` | Maximum resolution for physical output |
+
+## Aspect Ratios
+
+All 14 supported ratios. Availability varies by model:
+
+| Ratio | Orientation | Use Cases | NB2 (3.1 Flash) | NB (2.5 Flash) |
+|-------|-------------|-----------|:----------------:|:--------------:|
+| `1:1` | Square | Social posts, avatars, thumbnails | ✅ | ✅ |
+| `16:9` | Landscape | Blog headers, YouTube thumbnails, presentations | ✅ | ✅ |
+| `9:16` | Portrait | Stories, Reels, TikTok, mobile | ✅ | ✅ |
+| `4:3` | Landscape | Product shots, classic display | ✅ | ✅ |
+| `3:4` | Portrait | Book covers, portrait framing | ✅ | ✅ |
+| `2:3` | Portrait | Pinterest pins, posters | ✅ | ✅ |
+| `3:2` | Landscape | DSLR standard, photo prints | ✅ | ✅ |
+| `4:5` | Portrait | Instagram portrait, social | ✅ | ✅ |
+| `5:4` | Landscape | Large format photography | ✅ | ✅ |
+| `21:9` | Ultra-wide | Cinematic, film-grade, ultra-wide monitors | ✅ | ✅ |
+| `1:4` | Tall strip | Vertical banners, side panels | ✅ | ❌ |
+| `4:1` | Wide strip | Website banners, headers | ✅ | ❌ |
+| `1:8` | Extreme tall | Narrow vertical strips | ✅ | ❌ |
+| `8:1` | Extreme wide | Ultra-wide banners | ✅ | ❌ |
+
+## Resolution Tiers
+
+Control output resolution with the `imageSize` parameter. Note the **UPPERCASE** requirement -- lowercase values are silently rejected.
+
+| `imageSize` Value | Pixel Range | Model Availability | Use Case |
+|-------------------|-------------|-------------------|----------|
+| `512` | Up to 512×512 | Nano Banana 2 only | Drafts, quick iteration, low bandwidth |
+| `1K` | Up to 1024×1024 | All models | Standard web use, social media |
+| `2K` | Up to 2048×2048 | Nano Banana 2 only | Quality assets, detailed work |
+| `4K` | Up to 4096×4096 | Nano Banana 2 only | Print production, hero images, final assets |
+
+**Notes:**
+- Actual pixel dimensions depend on aspect ratio (e.g., 4K at 16:9 = 4096×2304)
+- Higher resolutions consume more tokens and cost more
+- The API default is `1K` if `imageSize` is omitted. The banana skill defaults to `2K` -- always pass `imageSize` explicitly
+- `imageSize` value MUST be uppercase -- `"2k"` will be silently ignored
+
+## API Configuration
+
+### Endpoint
+```
+https://generativelanguage.googleapis.com/v1beta/models/{model-id}:generateContent
+```
+
+### Required Parameters
+```json
+{
+  "contents": [{"parts": [{"text": "your prompt here"}]}],
+  "generationConfig": {
+    "responseModalities": ["TEXT", "IMAGE"],
+    "imageConfig": {
+      "aspectRatio": "16:9",
+      "imageSize": "2K"
+    }
+  }
+}
+```
+
+### Image-Only Output Mode
+Force the model to return only an image (no text response):
+```json
+{
+  "generationConfig": {
+    "responseModalities": ["IMAGE"]
+  }
+}
+```
+
+### Thinking Level
+Control how much the model "thinks" before generating. Higher levels improve complex compositions but increase latency:
+```json
+{
+  "generationConfig": {
+    "thinkingConfig": {
+      "thinkingLevel": "medium"
+    }
+  }
+}
+```
+Levels: `minimal`, `low`, `medium`, `high`
+
+### Google Search Grounding
+Ground generation in real-world visual references. Supports web and image search (Nano Banana 2):
+```json
+{
+  "tools": [{"googleSearch": {}}]
+}
+```
+**Prompt pattern:** `[Search/source request] + [Analytical task] + [Visual translation]`
+
+Example: "Search for the latest SpaceX Starship design, analyze its proportions and markings, then generate a photorealistic image of it at sunset on the launch pad."
+
+### Multi-Image Input
+Up to 14 reference images can be provided:
+- **10 object references** -- for style, composition, or visual matching
+- **4 character references** -- assign distinct names to preserve features across generations
+
+Useful for character consistency, style transfer, and brand-aligned generation.
+
+## Rate Limits by Tier
+
+| Tier | RPM | RPD | Notes |
+|------|-----|-----|-------|
+| Free | ~5-15 | ~20-500 | Per project, resets midnight Pacific. Cut ~92% Dec 2025. |
+| Tier 1 (billing enabled) | 150-300 | 1,500-10,000 | Production workloads |
+| Tier 2 ($250+ spend) | 1,000+ | Unlimited | High-volume |
+| Enterprise | Custom | Custom | Contact Google |
+
+## Pricing
+
+| Model | Resolution | Cost per Image | Notes |
+|-------|-----------|---------------|-------|
+| NB2 (3.1 Flash) | 1K | ~$0.067 | Standard |
+| NB2 (3.1 Flash) | 2K | ~$0.134 | 2x standard |
+| NB2 (3.1 Flash) | 4K | ~$0.268 | 4x standard |
+| NB (2.5 Flash) | 1K | ~$0.039 | Previous gen, budget option |
+| Batch API | Any | 50% discount | Asynchronous, higher latency |
+
+Pricing is approximate and based on ~1,290 output tokens per image.
+
+## Image Output Specs
+
+| Property | Value |
+|----------|-------|
+| **Format** | PNG |
+| **Max Resolution** | Up to 4096×4096 (4K tier, Nano Banana 2) |
+| **Color Space** | sRGB |
+| **Text Rendering** | Supported -- excellent under 25 characters |
+| **Style Control** | Via prompt engineering |
+
+## Safety Filters
+
+Gemini uses a two-layer safety architecture:
+
+1. **Input filters** -- block prompts containing prohibited content before generation
+2. **Output filters** -- analyze generated images and block unsafe results
+
+| `finishReason` | Meaning | Retryable? |
+|----------------|---------|:----------:|
+| `STOP` | Successful generation | N/A |
+| `IMAGE_SAFETY` | Output blocked by safety filter | Rephrase prompt |
+| `PROHIBITED_CONTENT` | Content policy violation | No -- topic is blocked |
+| `SAFETY` | General safety block | Rephrase prompt |
+| `RECITATION` | Detected copyrighted content | Rephrase prompt |
+
+**Known issue:** Filters are known to be overly cautious -- benign prompts may be blocked. Iterate with rephrased wording if this happens.
+
+## Content Credentials
+
+- **SynthID watermarks** are always embedded in generated images (invisible, machine-readable)
+- **C2PA metadata** is included on paid outputs (verifiable provenance chain)
+
+## Key Limitations
+- No video generation (image only)
+- No transparent backgrounds (PNG but always with background -- use green screen workaround)
+- Text rendering quality varies -- keep text under 25 characters for best results
+- Safety filters may block some prompts (violence, NSFW, public figures) -- known to be overly cautious
+- Session context resets between Claude Code conversations
+- `imageSize` values MUST be uppercase -- lowercase fails silently
+- Gemini generates ONE image per API call -- no batch parameter exists
+- No negative prompt parameter -- use semantic reframing instead

--- a/skills/banana-image-gen/references/mcp-tools.md
+++ b/skills/banana-image-gen/references/mcp-tools.md
@@ -1,0 +1,145 @@
+# MCP Tools Reference -- @ycse/nanobanana-mcp
+
+> Package: `@ycse/nanobanana-mcp`
+> GitHub: https://github.com/YCSE/nanobanana-mcp
+
+## Tools
+
+### gemini_generate_image
+Generate an image from a text prompt.
+
+**Parameters:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `prompt` | string | Yes | Text description of the image to generate |
+
+**Returns:** Image data + file path (saved to `~/Documents/nanobanana_generated/`)
+
+**Example usage in Claude Code:**
+```
+User: "Generate a sunset over mountains in watercolor style"
+→ Claude calls gemini_generate_image with prompt
+→ Returns image path and description
+```
+
+### gemini_edit_image
+Edit an existing image with text instructions.
+
+**Parameters:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `imagePath` | string | Yes | Path to the image file to edit |
+| `prompt` | string | Yes | Edit instructions |
+
+**Returns:** Modified image data + file path
+
+**Example:**
+```
+User: "Remove the background from ~/Documents/photo.png"
+→ Claude calls gemini_edit_image with path and instruction
+```
+
+### gemini_chat
+Multi-turn visual conversation maintaining session context.
+
+**Parameters:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `message` | string | Yes | Chat message (can reference previous images) |
+
+**Returns:** Text response + optional image
+
+**Key feature:** Session consistency -- maintains style, characters, and context across turns. Great for iterative refinement.
+
+### set_aspect_ratio
+Configure the aspect ratio for subsequent image generations.
+
+**Parameters:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ratio` | string | Yes | Aspect ratio (e.g., "16:9", "1:1", "9:16") |
+
+**Supported ratios:** 1:1, 16:9, 9:16, 4:3, 3:4, 2:3, 3:2, 4:5, 5:4, 1:4, 4:1, 1:8, 8:1, 21:9
+
+### set_model
+Switch the active Gemini model.
+
+**Parameters:**
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `model` | string | Yes | Model identifier |
+
+**Available models:**
+- `gemini-3.1-flash-image-preview` (default, recommended -- Nano Banana 2)
+- `gemini-2.5-flash-image` (stable fallback -- Nano Banana original)
+<!-- REMOVED 2026-03-19: gemini-3-pro-image-preview shut down by Google March 9, 2026. Do not use. -->
+
+### get_image_history
+Retrieve list of images generated in the current session.
+
+**Parameters:** None
+
+**Returns:** Array of image entries with paths and prompts
+
+### clear_conversation
+Reset session context and conversation history.
+
+**Parameters:** None
+
+**Returns:** Confirmation of reset
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_AI_API_KEY` | Yes | API key from https://aistudio.google.com/apikey |
+| `NANOBANANA_MODEL` | No | Override default model (default: `gemini-3.1-flash-image-preview`) |
+
+## Output Directory
+All generated images are saved to: `~/Documents/nanobanana_generated/`
+
+Images are named with timestamps for easy identification.
+
+## Feature Availability via MCP
+
+Some newer Gemini API features depend on the MCP package version of `@ycse/nanobanana-mcp`. Check the package version to confirm support:
+
+| Feature | API Status | MCP Support |
+|---------|-----------|-------------|
+| `imageSize` (resolution control) | Available | Depends on package version |
+| Thinking level (`thinkingConfig`) | Available | Depends on package version |
+| Search grounding (`googleSearch`) | Available | Depends on package version |
+| Image-only output (`responseModalities: ["IMAGE"]`) | Available | Depends on package version |
+| Multi-image input (up to 14 refs) | Available | Via `gemini_chat` with image paths |
+| All 14 aspect ratios | Available | Via `set_aspect_ratio` |
+
+If a feature is not yet supported by the MCP package, you can still use it via direct API calls with the fallback scripts (`scripts/generate.py` and `scripts/edit.py`).
+
+## ImageConfig Parameter Reference
+
+| Parameter | Type | Valid values | Default | Critical notes |
+|---|---|---|---|---|
+| `aspect_ratio` | string | "1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9", "1:4"*, "4:1"*, "1:8"*, "8:1"* | "1:1" | * = Nano Banana 2 only |
+| `image_size` | string | "512"*, "1K", "2K"*, "4K"* | "1K" | MUST be uppercase. "2k" silently fails. * = Nano Banana 2 only |
+| `person_generation` | string | "ALLOW_ALL", "ALLOW_ADULT", "ALLOW_NONE" | Varies | ALLOW_ALL restricted in EU/UK |
+
+## ❌ Parameters That Do NOT Exist for Gemini Image Models
+
+These are common copy-paste errors from Imagen or other model documentation.
+Passing them will not cause errors -- they will be silently ignored.
+
+- `numberOfImages` / `n` / `sampleCount` -- Gemini generates ONE image per call. These are Imagen-only. There is no batch parameter.
+- `negativePrompt` -- See prompt-engineering.md for the correct approach (semantic reframing).
+- `output_mime_type` -- Vertex AI only, not available in Gemini API.
+- `candidate_count` -- Only 1 supported for image models.
+- `seed` -- Not supported for reproducible generation.
+
+## Error Response Taxonomy
+
+| Error type | Cause | Correct response |
+|---|---|---|
+| HTTP 429 | Rate limit | Exponential backoff. Free tier: ~5-15 RPM. |
+| HTTP 400 FAILED_PRECONDITION | Billing not enabled | User must enable billing in Google AI Studio |
+| `finishReason: "IMAGE_SAFETY"` | Content policy block | Apply safety rephrase from prompt-engineering.md, retry once |
+| Empty `parts` in response | Wrong `response_modalities` | Must include "IMAGE" in responseModalities |
+| `thought_signature` missing | Multi-turn editing on Gemini 3 | Preserve this field from previous response for edit continuity |

--- a/skills/banana-image-gen/references/post-processing.md
+++ b/skills/banana-image-gen/references/post-processing.md
@@ -1,0 +1,192 @@
+# Post-Processing Pipeline Reference
+
+> Load this on-demand when the user needs image manipulation after generation.
+
+## Prerequisites
+
+Check availability before using:
+```bash
+which magick    # ImageMagick 7 (preferred)
+which convert   # ImageMagick 6 (fallback)
+which ffmpeg    # For video/animation
+```
+
+Install ImageMagick if not present: `sudo apt install imagemagick` (Debian/Ubuntu) or `brew install imagemagick` (macOS).
+
+## Common Operations
+
+### Resize for Platforms
+
+```bash
+# Instagram post (1080x1080)
+magick input.png -resize 1080x1080^ -gravity center -extent 1080x1080 instagram.png
+
+# Twitter/X header (1500x500)
+magick input.png -resize 1500x500^ -gravity center -extent 1500x500 twitter-header.png
+
+# YouTube thumbnail (1280x720)
+magick input.png -resize 1280x720^ -gravity center -extent 1280x720 youtube-thumb.png
+
+# LinkedIn banner (1584x396)
+magick input.png -resize 1584x396^ -gravity center -extent 1584x396 linkedin-banner.png
+
+# Favicon (multi-size ICO)
+magick input.png -resize 32x32 favicon.ico
+```
+
+### Background Removal (Transparency)
+
+```bash
+# Remove solid white background
+magick input.png -fuzz 10% -transparent white output.png
+
+# Remove solid color background (specify color)
+magick input.png -fuzz 15% -transparent "#F0F0F0" output.png
+
+# Clean edges after transparency (anti-alias)
+magick input.png -fuzz 10% -transparent white -channel A -blur 0x1 -level 50%,100% output.png
+
+# Auto-crop transparent padding
+magick input.png -trim +repage output.png
+```
+
+### Format Conversion
+
+```bash
+# PNG to WebP (web-optimized, smaller file)
+magick input.png -quality 85 output.webp
+
+# PNG to JPEG (with white background for transparency)
+magick input.png -background white -flatten -quality 90 output.jpg
+
+# PNG to AVIF (modern, smallest size)
+magick input.png -quality 80 output.avif
+
+# SVG trace (for logos -- requires potrace)
+potrace input.pbm -s -o output.svg
+```
+
+### Color Adjustments
+
+```bash
+# Increase contrast
+magick input.png -contrast-stretch 2%x1% output.png
+
+# Warm color temperature
+magick input.png -modulate 100,110,105 output.png
+
+# Cool color temperature
+magick input.png -modulate 100,90,95 output.png
+
+# Desaturate (muted colors)
+magick input.png -modulate 100,70,100 output.png
+
+# Convert to grayscale
+magick input.png -colorspace Gray output.png
+
+# Sepia tone
+magick input.png -sepia-tone 80% output.png
+```
+
+### Compositing
+
+```bash
+# Overlay watermark (bottom-right, 20% opacity)
+magick base.png watermark.png -gravity southeast -geometry +20+20 \
+  -compose dissolve -define compose:args=20 -composite output.png
+
+# Side-by-side comparison
+magick input1.png input2.png +append comparison.png
+
+# Vertical stack
+magick input1.png input2.png -append stack.png
+
+# Add padding/border
+magick input.png -bordercolor white -border 40 output.png
+
+# Add rounded corners
+magick input.png \( +clone -alpha extract -draw \
+  "roundrectangle 0,0,%[fx:w-1],%[fx:h-1],20,20" \) \
+  -alpha off -compose CopyOpacity -composite rounded.png
+```
+
+### Batch Processing
+
+```bash
+# Resize all PNGs in directory
+for f in ~/Documents/nanobanana_generated/*.png; do
+  magick "$f" -resize 800x800 "${f%.png}_thumb.png"
+done
+
+# Convert all to WebP
+for f in ~/Documents/nanobanana_generated/*.png; do
+  magick "$f" -quality 85 "${f%.png}.webp"
+done
+```
+
+## Animation (GIF/Video from Multiple Frames)
+
+```bash
+# Create GIF from multiple images
+magick -delay 100 frame1.png frame2.png frame3.png animation.gif
+
+# Create MP4 from image sequence
+ffmpeg -framerate 1 -pattern_type glob -i '*.png' \
+  -c:v libx264 -pix_fmt yuv420p slideshow.mp4
+```
+
+## Note on 4K Output
+
+With Gemini 3.1 Flash's `imageSize: "4K"` option (up to 4096×4096), many traditional
+upscaling post-processing steps are no longer necessary. If your target platform accepts
+images at or below 4K resolution, generate at native 4K instead of generating at 1K
+and upscaling. This produces better detail and avoids upscaling artifacts.
+
+## Green Screen Transparency Pipeline
+
+Gemini cannot generate transparent backgrounds. Use this workaround:
+
+### 1. Generate with green screen prompt
+
+Append to any prompt:
+```
+on a solid bright green (#00FF00) chroma key background
+with a thin white outline separating the subject from the background
+```
+
+### 2. Remove green screen (ImageMagick)
+
+```bash
+magick input.png -fuzz 20% -transparent "#00FF00" output.png
+```
+
+### 3. Clean edges + trim (ImageMagick)
+
+```bash
+magick output.png -channel A -blur 0x1 -level 50%,100% -trim +repage final.png
+```
+
+### 4. Alternative (FFmpeg, better for batch)
+
+```bash
+ffmpeg -i input.png -vf "colorkey=0x00FF00:0.3:0.1,despill=type=green" -pix_fmt rgba output.png
+```
+
+### Tips
+- `-fuzz 20%` handles slight color variations at edges; increase to 25% for softer edges
+- The white outline in the prompt helps prevent color spill on subject edges
+- For batch processing, the FFmpeg approach is faster and handles despill automatically
+- Always verify edges after conversion -- may need manual touchup for hair/fur
+
+## Quality Assessment
+
+```bash
+# Get image dimensions and info
+magick identify -verbose input.png | head -20
+
+# Check file size
+ls -lh input.png
+
+# Get exact pixel dimensions
+magick identify -format "%wx%h" input.png
+```

--- a/skills/banana-image-gen/references/presets.md
+++ b/skills/banana-image-gen/references/presets.md
@@ -1,0 +1,69 @@
+# Brand/Style Presets Reference
+
+> Load this on-demand when the user asks about presets or brand consistency.
+
+## Preset Schema
+
+Each preset is stored as `~/.banana/presets/NAME.json`:
+
+```json
+{
+  "name": "tech-saas",
+  "description": "Clean tech SaaS brand",
+  "colors": ["#2563EB", "#1E40AF", "#F8FAFC"],
+  "style": "clean minimal tech illustration, flat vectors, soft shadows",
+  "typography": "bold geometric sans-serif",
+  "lighting": "bright diffused studio, no harsh shadows",
+  "mood": "professional, trustworthy, modern",
+  "default_ratio": "16:9",
+  "default_resolution": "2K"
+}
+```
+
+## Example Presets
+
+### tech-saas
+- **Colors:** #2563EB, #1E40AF, #F8FAFC (blue + white)
+- **Style:** Clean minimal tech illustration, flat vectors, soft shadows
+- **Typography:** Bold geometric sans-serif
+- **Mood:** Professional, trustworthy, modern
+
+### luxury-brand
+- **Colors:** #1A1A1A, #C9A96E, #FAFAF5 (black + gold + cream)
+- **Style:** Elegant high-end photography, rich textures, deep contrast
+- **Typography:** Thin elegant serif, generous letter-spacing
+- **Mood:** Exclusive, sophisticated, aspirational
+
+### editorial-magazine
+- **Colors:** #000000, #FFFFFF, #FF3B30 (black + white + accent red)
+- **Style:** Bold editorial photography, strong geometric composition
+- **Typography:** Condensed all-caps sans-serif headlines
+- **Mood:** Bold, provocative, contemporary
+
+## How Presets Merge into Reasoning Brief
+
+When a preset is active, Claude uses its values as defaults for the Reasoning Brief:
+1. **Colors** → inform palette descriptions in Context and Style components
+2. **Style** → becomes the base for the Style component
+3. **Typography** → used for any text rendering
+4. **Lighting** → becomes the base for the Lighting component
+5. **Mood** → influences Action and Context components
+
+User instructions always override preset values. If a user says "make it dark"
+but the preset has bright lighting, follow the user's instruction.
+
+## Managing Presets
+
+```bash
+# List presets
+presets.py list
+
+# Show details
+presets.py show tech-saas
+
+# Create interactively (Claude fills in details from conversation)
+presets.py create NAME --colors "#hex,#hex" --style "..." --mood "..."
+
+# Delete
+presets.py delete NAME --confirm
+```

--- a/skills/banana-image-gen/references/prompt-engineering.md
+++ b/skills/banana-image-gen/references/prompt-engineering.md
@@ -1,0 +1,481 @@
+# Prompt Engineering Reference -- Banana Claude
+
+> Load this on-demand when constructing complex prompts or when the user
+> asks about prompt techniques. Do NOT load at startup.
+>
+> Aligned with Google's March 2026 "Ultimate Prompting Guide" for Gemini image generation.
+
+## The 5-Component Prompt Formula
+
+> Based on Google's officially validated prompt structure for Gemini image models.
+> Write as natural narrative paragraphs -- NEVER as comma-separated keyword lists.
+
+### Component 1 -- SUBJECT
+Who or what is the primary focus. Be specific about physical characteristics,
+material, species, age, expression. Never write just "a person" or "a product."
+
+**Good:** "A weathered Japanese ceramicist in his 70s, deep sun-etched
+wrinkles mapping decades of kiln work, calloused hands cradling a
+freshly thrown tea bowl with an irregular, organic rim"
+
+**Bad:** "old man, ceramic, bowl"
+
+### Component 2 -- ACTION
+What the subject is doing, or the primary visual state. Use strong present-
+tense verbs. "floats weightlessly," "holds a glowing lantern," "sits perfectly
+still." If no action, describe pose or arrangement.
+
+**Good:** "leaning forward with intense concentration, gently smoothing
+the rim with a wet thumb, a thin trail of slip running down his wrist"
+
+**Bad:** "making pottery"
+
+### Component 3 -- LOCATION / CONTEXT
+Where the scene takes place. Include environmental details, time of day,
+atmospheric conditions. "inside the cupola module of the International Space
+Station," "on a rain-slicked Tokyo alley at 2am."
+
+**Good:** "inside a traditional wood-fired anagama kiln workshop,
+stacked shelves of drying pots visible in the soft background, late
+afternoon light filtering through rice paper screens"
+
+**Bad:** "workshop, afternoon"
+
+### Component 4 -- COMPOSITION
+Camera perspective, framing, and spatial relationship. "medium shot centered
+against the window," "extreme low-angle looking up," "bird's-eye view from
+30 meters," "tight close-up on hands."
+
+**Good:** "intimate close-up shot from slightly below eye level,
+shallow depth of field isolating the hands and bowl against the
+soft bokeh of the workshop behind"
+
+**Bad:** "close up"
+
+### Component 5 -- STYLE (includes lighting)
+The visual register, aesthetic, medium, and lighting combined. Reference real
+cameras, film stock, photographers, publications, or art movements. Lighting
+lives here as a sub-element, not a separate component.
+
+**Good:** "shot on a Fujifilm X-T4 with warm color science and natural
+bokeh, warm directional light from a single high window camera-left
+creating gentle Rembrandt lighting on the face with deep warm shadows.
+Reminiscent of Dorothea Lange's documentary portraiture"
+
+**Bad:** "photorealistic, 8K, masterpiece" (see Banned Keywords below)
+
+## Domain Mode Modifier Libraries
+
+### Cinema Mode
+**Camera specs:** RED V-Raptor, ARRI Alexa 65, Sony Venice 2, Blackmagic URSA
+**Lenses:** Cooke S7/i, Zeiss Supreme Prime, Atlas Orion anamorphic
+**Film stocks:** Kodak Vision3 500T (tungsten), Kodak Vision3 250D (daylight), Fuji Eterna Vivid
+**Lighting setups:** three-point, chiaroscuro, Rembrandt, split, butterfly, rim/backlight
+**Shot types:** establishing wide, medium close-up, extreme close-up, Dutch angle, overhead crane, Steadicam tracking
+**Color grading:** teal and orange, desaturated cold, warm vintage, high-contrast noir
+
+### Product Mode
+**Surfaces:** polished marble, brushed concrete, raw linen, acrylic riser, gradient sweep
+**Lighting:** softbox diffused, hard key with fill card, rim separation, tent lighting, light painting
+**Angles:** 45-degree hero, flat lay, three-quarter, straight-on, worm's-eye
+**Style refs:** Apple product photography, Aesop minimal, Bang & Olufsen clean, luxury cosmetics
+
+### Portrait Mode
+**Focal lengths:** 85mm (classic), 105mm (compression), 135mm (telephoto), 50mm (environmental)
+**Apertures:** f/1.4 (dreamy bokeh), f/2.8 (subject-sharp), f/5.6 (environmental context)
+**Pose language:** candid mid-gesture, direct-to-camera confrontational, profile silhouette, over-shoulder glance
+**Skin/texture:** freckles visible, pores at macro distance, catch light in eyes, subsurface scattering
+
+### Editorial/Fashion Mode
+**Publication refs:** Vogue Italia, Harper's Bazaar, GQ, National Geographic, Kinfolk
+**Styling notes:** layered textures, statement accessories, monochromatic palette, contrast patterns
+**Locations:** marble staircase, rooftop at golden hour, industrial loft, desert dunes, neon-lit alley
+**Poses:** power stance, relaxed editorial lean, movement blur, fabric in wind
+
+### UI/Web Mode
+**Styles:** flat vector, isometric 3D, line art, glassmorphism, neumorphism, material design
+**Colors:** specify exact hex or descriptive palette (e.g., "cool blues #2563EB to #1E40AF")
+**Sizing:** design at 2x for retina, specify exact pixel dimensions needed
+**Backgrounds:** transparent (request solid white then post-process), gradient, solid color
+
+### Logo Mode
+**Construction:** geometric primitives, golden ratio, grid-based, negative space
+**Typography:** bold sans-serif, elegant serif, custom lettermark, monogram
+**Colors:** max 2-3 colors, works in monochrome, high contrast
+**Output:** request on solid white background, post-process to transparent
+
+### Landscape Mode
+**Depth layers:** foreground interest, midground subject, background atmosphere
+**Atmospherics:** fog, mist, haze, volumetric light rays, dust particles
+**Time of day:** blue hour (pre-dawn), golden hour, magic hour (post-sunset), midnight blue
+**Weather:** dramatic storm clouds, clearing after rain, snow-covered, sun-dappled
+
+### Infographic Mode
+**Layout:** modular sections, clear visual hierarchy, bento grid, flow top-to-bottom
+**Text:** use quotes for exact text, descriptive font style, specify size hierarchy
+**Data viz:** bar charts, pie charts, flow diagrams, timelines, comparison tables
+**Colors:** high-contrast, accessible palette, consistent brand colors
+
+### Abstract Mode
+**Geometry:** fractals, voronoi tessellation, spirals, fibonacci, organic flow, crystalline
+**Textures:** marble veining, fluid dynamics, smoke wisps, ink diffusion, watercolor bleed
+**Color palettes:** analogous harmony, complementary clash, monochromatic gradient, neon-on-black
+**Styles:** generative art, data visualization art, glitch, procedural, macro photography of materials
+
+## Advanced Techniques
+
+### Character Consistency (Multi-turn)
+Use `gemini_chat` and maintain descriptive anchors:
+- First turn: Generate character with exhaustive physical description
+- Following turns: Reference "the same character" + repeat 2-3 key identifiers
+- Key identifiers: hair color/style, distinctive clothing, facial feature
+
+**Multi-image reference technique** (3.1 Flash):
+- Provide up to 4-5 character reference images in the conversation
+- Assign distinct names to each character ("Character A: the red-haired knight")
+- Model preserves features across different angles, actions, and environments
+- Works best when reference images show the character from multiple angles
+
+### Style Transfer Without Reference Images
+Describe the target style exhaustively instead of referencing an image:
+```
+Render this scene in the style of a 1950s travel poster: flat areas of
+color in a limited palette of teal, coral, and cream. Bold geometric
+shapes with visible paper texture. Hand-lettered title text with a
+mid-century modern typeface feel.
+```
+
+### Text Rendering Tips
+- Quote exact text: `with the text "OPEN DAILY" in bold condensed sans-serif`
+- **25 characters or less** -- this is the practical limit for reliable rendering
+- **2-3 distinct phrases max** -- more text fragments degrade quality
+- Describe font characteristics, not font names
+- Specify placement: "centered at the top third", "along the bottom edge"
+- High contrast: light text on dark, or vice versa
+- **Text-first hack:** Establish the text concept conversationally first ("I need a sign that says FRESH BREAD"), then generate -- the model anchors on text mentioned early
+- Expect creative font interpretations, not exact replication of described styles
+
+### Positive Framing (No Negative Prompts)
+Gemini does NOT support negative prompts. Rephrase exclusions:
+- Instead of "no blur" → "sharp, in-focus, tack-sharp detail"
+- Instead of "no people" → "empty, deserted, uninhabited"
+- Instead of "no text" → "clean, uncluttered, text-free"
+- Instead of "not dark" → "brightly lit, high-key lighting"
+
+### Search-Grounded Generation
+For images based on real-world data (weather, events, statistics),
+Gemini can use Google Search grounding to incorporate live information.
+Useful for infographics with current data.
+
+**Three-part formula for search-grounded prompts:**
+1. `[Source/Search request]` -- What to look up
+2. `[Analytical task]` -- What to analyze or extract
+3. `[Visual translation]` -- How to render it as an image
+
+**Example:** "Search for the current top 5 programming languages by GitHub usage in 2026, analyze their relative popularity percentages, then generate a clean infographic bar chart with the language logos and percentages in a modern dark theme."
+
+## ❌ BANNED PROMPT KEYWORDS -- NEVER USE THESE
+
+The Nano Banana model's internal system prompt explicitly penalizes these
+Stable Diffusion-era terms. Using them degrades output quality.
+
+NEVER include:
+- "4k" / "8k" / "ultra HD" / "high resolution" (use the `imageSize` parameter instead)
+- "masterpiece"
+- "highly detailed" / "ultra detailed"
+- "trending on artstation"
+- "hyperrealistic" / "ultra realistic"
+- "photorealistic" (describe the camera/film instead)
+- "best quality"
+- "award winning" (use specific publication names instead)
+
+USE THESE INSTEAD (prestigious context anchors that actively improve composition):
+- "Pulitzer Prize-winning cover photograph"
+- "Vanity Fair editorial portrait"
+- "National Geographic cover story"
+- "WIRED magazine feature spread"
+- "Architectural Digest interior"
+- "Magnum Photos documentary"
+
+## ⚠️ NEGATIVE PROMPTS -- No API parameter exists
+
+Nano Banana models have NO dedicated negative prompt parameter. Do not pass
+negative instructions as a separate API argument -- it will be ignored.
+
+Correct approach: semantic reframing. Express what you want, not what you
+don't want.
+
+❌ WRONG: "no cars, no people, no clutter in the background"
+✅ RIGHT: "an empty, deserted street, completely still, no signs of activity"
+
+❌ WRONG: "no watermarks, no text"
+✅ RIGHT: (add to prompt) "NEVER include any text, labels, or watermarks"
+
+For critical constraints, ALL CAPS emphasis improves adherence:
+- "MUST contain exactly three figures"
+- "NEVER include any visible horizon line"
+- "ONLY show the product, nothing else in frame"
+
+## Prompt Length Guide
+
+| Use case | Target length | Notes |
+|---|---|---|
+| Quick draft / concept | 20–60 words (1–2 sentences) | Good for ideation |
+| Standard generation | 100–200 words (3–5 sentences) | Production default |
+| Complex professional | 200–300 words | Full 5-component treatment |
+| Maximum specification | Up to 2,600 tokens | JSON/Markdown structured format supported |
+
+Nano Banana 2 accepts up to 131,072 input tokens. Do not artificially truncate
+a prompt to hit a word count target -- quality and specificity matter more.
+
+## Text Rendering in Images
+
+Nano Banana 2 has excellent text rendering. Rules:
+1. Enclose desired text in quotation marks in the prompt: "LAUNCH DAY"
+2. Specify font characteristics explicitly: "bold white sans-serif," "Century Gothic"
+3. Specify placement: "centered at the bottom third," "upper left corner"
+4. For complex layouts, describe text placement before requesting the image
+
+Example: Place the text "Happy Birthday, Sarah" in a warm gold serif font
+centered in the lower third of the image.
+
+Known limitation: Small text (<16px equivalent) and complex multilingual text
+may require iterative refinement.
+
+## Prompt Adaptation Rules
+
+When adapting prompts from the claude-prompts database (Midjourney/DALL-E/etc.)
+to Gemini's natural language format:
+
+| Source Syntax | Gemini Equivalent |
+|---------------|-------------------|
+| `--ar 16:9` | Call `set_aspect_ratio("16:9")` separately |
+| `--v 6`, `--style raw` | Remove -- Gemini has no version/style flags |
+| `--chaos 50` | Describe variety: "unexpected, surreal composition" |
+| `--no trees` | Positive framing: "open clearing with no vegetation" |
+| `(word:1.5)` weight | Descriptive emphasis: "prominently featuring [word]" |
+| `8K, masterpiece, ultra-detailed` | Remove ALL of these -- they are banned. Use prestigious context anchors instead (see Banned Keywords section) |
+| Comma-separated tags | Expand into descriptive narrative paragraphs |
+| `shot on Hasselblad` | Keep -- camera specs work well in Gemini |
+
+## Common Prompt Mistakes
+
+1. **Keyword stuffing** -- stacking generic quality terms ("8K, masterpiece, best quality, ultra-realistic") actively degrades output. Use prestigious context anchors instead (see Banned Keywords section)
+2. **Tag lists** -- Gemini wants prose, not "red car, sunset, mountain, cinematic"
+3. **Missing lighting** -- The single biggest quality differentiator
+4. **No composition direction** -- Results in generic centered framing
+5. **Vague style** -- "make it look cool" vs specific art direction
+6. **Ignoring aspect ratio** -- Always set before generating
+7. **Overlong prompts** -- Diminishing returns past ~200 words; be precise, not verbose
+8. **Text longer than ~25 characters** -- Rendering degrades rapidly past this limit
+9. **Burying key details at the end** -- In long prompts, details placed last may be deprioritized; put critical specifics (exact text, key constraints) in the first third of the prompt
+10. **Not iterating with follow-up prompts** -- Use `gemini_chat` for progressive refinement instead of trying to get everything right in one generation
+
+## Proven Prompt Templates
+
+> Extracted from 2,500+ tested prompts. These patterns consistently produce
+> high-quality results. Use them as starting points and adapt to the request.
+
+### The Winning Formula (Weight Distribution)
+
+| Component | Weight | What to include |
+|-----------|--------|-----------------|
+| **Subject** | 30% | Age, skin tone, hair color/style, eye color, body type, expression |
+| **Action** | 10% | Movement, pose, gesture, interaction, state of being |
+| **Context** | 15% | Location + time of day + weather + context details |
+| **Composition** | 10% | Shot type, camera angle, framing, focal length, f-stop |
+| **Lighting** | 10% | Quality, direction, color temperature, shadows |
+| **Style** | 25% | Art medium, brand names, textures, camera model, color grading |
+
+### Instagram Ad / Social Media
+
+**Pattern:** `[Subject with age/appearance] + [outfit with brand/texture] + [action verb] + [setting] + [camera spec] + [lighting] + [platform aesthetic]`
+
+**Example (Product Placement):**
+```
+Hyper-realistic gym selfie of athletic 24yo influencer with glowing olive
+skin, wearing crinkle-textured athleisure set in mauve. iPhone 16 Pro Max
+front-facing portrait mode capturing sweat droplets on collarbones, hazel
+eyes enhanced by gym LED lighting. Mirror reflection shows perfect form,
+golden morning light through floor-to-ceiling windows. Frayed chestnut
+ponytail with baby hairs, visible skin texture with natural erythema from
+workout. Vanity Fair wellness editorial aesthetic.
+```
+
+**Example (Lifestyle Ad):**
+```
+A 24-year-old blonde fitness model in a high-energy sports drink
+advertisement. Mid-run on a beach, wearing a vibrant orange sports bra
+and black shorts, playful smile and sparkling blue eyes exuding vitality.
+Bottle of the drink held in hand, waves crashing in background. Shot on
+Nikon D850 with 70-200mm f/2.8 lens, natural light, fast shutter speed
+capturing motion. Visible skin texture, water droplets, product label
+clearly visible. National Geographic fitness feature aesthetic.
+```
+
+**Example (Luxury Lifestyle):**
+```
+Gorgeous Instagram model wearing a designer silk gown, luxury rooftop
+restaurant, golden hour lighting, champagne in hand, luxurious aspirational
+lifestyle. Captured with Sony A7R IV, 85mm f/1.4 lens, shallow depth of
+field, warm color grading.
+```
+
+### Product / Commercial Photography
+
+**Pattern:** `[Product with brand/detail] + [dynamic elements] + [surface/setting] + "commercial photography for advertising campaign" + [lighting] + [prestigious publication reference]`
+
+**Example (Beverage):**
+```
+Gatorade bottle with condensation dripping down the sides, surrounded by
+lightning bolts and a burst of vibrant blue and orange light rays. The
+Gatorade logo is prominently displayed on the bottle, with splashes of
+water frozen in mid-air. Commercial food photography for an advertising
+campaign, vibrant complementary colors. Bon Appetit magazine cover aesthetic.
+```
+
+**Example (Food):**
+```
+In and Out burger with layers of fresh lettuce, melted cheese, and pretzel
+bun, placed on a white surface with the In and Out logo subtly glowing in
+the background. Falling french fries and golden light, warm scene.
+Commercial food photography for an advertising campaign, vibrant
+complementary colors. Shot in the style of a Bon Appetit feature spread.
+```
+
+### Fashion / Editorial
+
+**Pattern:** `[Subject with ethnicity/age/features] + [outfit with texture/brand/cut] + [location] + [pose/action] + [camera + lens] + [lighting quality]`
+
+**Example (Street Style):**
+```
+A 24-year-old female AI influencer posing confidently in an urban cityscape
+during golden hour. Flawless sun-kissed skin, long wavy brown hair, deep
+green eyes. Wearing a chic streetwear outfit -- oversized beige blazer,
+white top, high-waisted jeans. Captured with Sony A7R IV at 85mm f/1.4,
+shallow depth of field with warm golden bokeh.
+```
+
+**Example (High Fashion):**
+```
+Stunning 24-year-old woman, long platinum blonde hair, radiant skin,
+piercing blue eyes, dressed in a chic pastel blazer with a modern
+minimalist aesthetic, soft sunlight glow, high-end fashion appeal.
+Shot on Canon EOS R5, 85mm f/1.2 lens.
+```
+
+**Example (Avant-Garde):**
+```
+A blonde fitness model transformed into a runway-ready fashion icon,
+wearing a bold avant-garde outfit: cropped leather jacket with neon pink
+accents, paired with high-waisted athletic shorts and knee-high boots.
+Captured mid-stride on a minimalist white runway, playful twinkle in her
+eye, dramatic studio lighting from above.
+```
+
+### SaaS / Tech Marketing
+
+**Pattern:** `[UI mockup or abstract visual] + "on [dark/light] background" + [specific colors with hex] + [typography description] + "clean, premium SaaS aesthetic" + [glassmorphism/gradient/glow effects]`
+
+**Example (Dashboard Hero):**
+```
+A floating glassmorphism UI card on a deep charcoal background showing a
+content analytics dashboard with a rising line graph in teal (#14B8A6),
+bar charts in coral (#F97316), and a circular progress indicator at 94%.
+Subtle grid lines, frosted glass effect with 20% opacity, teal glow
+bleeding from the card edges. Clean premium SaaS aesthetic, no text
+smaller than headline size.
+```
+
+**Example (Feature Highlight):**
+```
+An isometric 3D illustration of interconnected data nodes on a dark navy
+background. Each node is a glowing teal sphere connected by thin luminous
+lines, forming a constellation pattern. One central node pulses brighter
+with radiating rings. Modern tech illustration style with subtle depth
+of field, volumetric lighting from below.
+```
+
+**Example (Comparison/Before-After):**
+```
+Split-screen image: left side shows a cluttered, dim workspace with
+scattered papers, red error indicators, and a frustrated expression
+conveyed through a cracked coffee mug and tangled cables. Right side
+shows a clean, organized dashboard interface glowing in teal and white
+on a dark background, with smooth flowing lines and checkmarks. A sharp
+vertical dividing line separates chaos from clarity.
+```
+
+### Logo / Branding
+
+**Pattern:** `[Product/bottle/item] + "with [brand element] prominently displayed" + [dynamic visual elements] + "commercial photography" + [lighting style] + [prestigious publication reference]`
+
+**Example:**
+```
+A sleek matte black bottle with a minimal white logo mark centered on the
+label, surrounded by swirling gradient ribbons of teal and coral light.
+The bottle sits on a reflective dark surface, sharp studio rim lighting
+separating it from the background. Product photography for luxury
+branding, dramatic contrast. Wallpaper* magazine design editorial.
+```
+
+### Key Tactics That Make Prompts Work
+
+1. **Name real cameras** -- "Sony A7R IV", "Canon EOS R5", "iPhone 16 Pro Max" anchor realism
+2. **Specify exact lens** -- "85mm f/1.4" gives the model precise depth-of-field information
+3. **Use age + ethnicity + features** -- "24yo with olive skin, hazel eyes" beats "a person"
+4. **Name brands for styling** -- "Lululemon mat", "Tom Ford suit" triggers specific visual associations
+5. **Include micro-details** -- "sweat droplets on collarbones", "baby hairs stuck to neck"
+6. **Add platform context** -- "Instagram aesthetic", "commercial photography for advertising"
+7. **Describe textures** -- "crinkle-textured", "metallic silver", "frosted glass"
+8. **Use action verbs** -- "mid-run", "posing confidently", "captured mid-stride"
+9. **Use prestigious context anchors** -- "Pulitzer Prize-winning photograph," "Vanity Fair editorial," "National Geographic cover" actively improve quality. NEVER use "ultra-realistic," "8K," "masterpiece" -- these are banned (see Banned Keywords)
+10. **For products, say "prominently displayed"** -- ensures the product/logo isn't hidden
+
+### Anti-Patterns (What NOT to Do)
+
+- **"A dark-themed Instagram ad showing..."** -- too meta, describes the concept not the image
+- **"A sleek SaaS dashboard visualization..."** -- abstract, no visual anchors
+- **"Modern, clean, professional..."** -- vague adjectives that mean nothing to the model
+- **"A bold call to action with..."** -- describes marketing intent, not visual content
+- **Describing what the viewer should feel** -- instead, describe what creates that feeling
+
+## Safety Filter Rephrase Strategies
+
+Gemini's safety filters (Layer 2: server-side output filter) cannot be disabled.
+When a prompt is blocked, the only path forward is rephrasing.
+
+### Common Trigger Categories
+
+| Category | Triggers on | Rephrase approach |
+|----------|------------|-------------------|
+| Violence/weapons | Combat, blood, injuries, firearms | Use metaphor or aftermath: "battle-worn" → "weathered veteran" |
+| Medical/gore | Surgery, wounds, anatomical detail | Abstract or clinical: "open wound" → "medical illustration" |
+| Real public figures | Named celebrities, politicians | Use archetypes: "Elon Musk" → "a tech entrepreneur in a minimalist office" |
+| Children + risk | Minors in any ambiguous context | Add safety context: specify educational, family, or playful framing |
+| NSFW/suggestive | Revealing clothing, intimate poses | Use artistic framing: "fashion editorial, fully clothed, editorial pose" |
+
+### Rephrase Patterns
+
+1. **Abstraction** -- Replace specific dangerous elements with abstract concepts
+2. **Artistic framing** -- Frame content as art, editorial, or documentary
+3. **Metaphor** -- Use symbolic language instead of literal descriptions
+4. **Positive emphasis** -- Describe what IS present, not what's dangerous
+5. **Context shift** -- Move from threatening to educational/professional context
+
+### Example Rephrases
+
+| Blocked prompt | Successful rephrase |
+|----------------|---------------------|
+| "a soldier in combat firing a rifle" | "a determined soldier standing guard at dawn, rifle slung over shoulder, morning mist over the outpost" |
+| "a scary horror monster" | "a fantastical creature from a dark fairy tale, intricate organic textures, bioluminescent accents, concept art style" |
+| "dog in a fight" | "a friendly golden retriever playing energetically in a sunny park, action shot, joyful expression" |
+| "medical surgery scene" | "a clean modern operating room viewed from the observation gallery, soft blue surgical lights, professional documentary style" |
+| "celebrity portrait of [name]" | "a distinguished middle-aged man in a tailored navy suit, warm studio lighting, editorial portrait style" |
+
+### Key Principle
+
+Layer 2 (output filter) analyzes the generated image, not just the prompt.
+Even well-phrased prompts can be blocked if the model's interpretation triggers
+the output filter. When this happens, try shifting the visual concept further
+from the trigger rather than just changing words.

--- a/skills/banana-image-gen/scripts/batch.py
+++ b/skills/banana-image-gen/scripts/batch.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Banana Claude -- CSV Batch Workflow
+
+Parse a CSV file of image generation requests and output a structured plan.
+Claude then executes each row via MCP.
+
+Usage:
+    batch.py --csv path/to/file.csv
+
+CSV columns:
+    prompt (required), ratio, resolution, model, preset (all optional)
+
+Example CSV:
+    prompt,ratio,resolution
+    "coffee shop hero image",16:9,2K
+    "team photo placeholder",1:1,1K
+    "product shot on marble",4:3,2K
+"""
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+# Inline pricing for estimates
+PRICING = {
+    "gemini-3.1-flash-image-preview": {"512": 0.020, "1K": 0.039, "2K": 0.078, "4K": 0.156},
+    "gemini-2.5-flash-image": {"512": 0.020, "1K": 0.039},
+}
+DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
+DEFAULT_RESOLUTION = "1K"
+DEFAULT_RATIO = "1:1"
+
+
+def estimate_cost(model, resolution):
+    """Estimate cost for a single image."""
+    model_pricing = PRICING.get(model, PRICING[DEFAULT_MODEL])
+    return model_pricing.get(resolution, model_pricing.get("1K", 0.039))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse CSV batch and output generation plan")
+    parser.add_argument("--csv", required=True, help="Path to CSV file")
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv).resolve()
+    if not csv_path.exists():
+        print(json.dumps({"error": True, "message": f"CSV not found: {csv_path}"}))
+        sys.exit(1)
+
+    rows = []
+    errors = []
+
+    try:
+        with open(csv_path, "r", newline="") as f:
+            reader = csv.DictReader(f)
+            if not reader.fieldnames or "prompt" not in reader.fieldnames:
+                print(json.dumps({"error": True, "message": "CSV must have a 'prompt' column header"}))
+                sys.exit(1)
+            for i, row in enumerate(reader, start=2):  # Line 2+ (1 is header)
+                prompt = row.get("prompt", "").strip()
+                if not prompt:
+                    errors.append(f"Row {i}: missing prompt")
+                    continue
+
+                rows.append({
+                    "row": i,
+                    "prompt": prompt,
+                    "ratio": row.get("ratio", "").strip() or DEFAULT_RATIO,
+                    "resolution": row.get("resolution", "").strip() or DEFAULT_RESOLUTION,
+                    "model": row.get("model", "").strip() or DEFAULT_MODEL,
+                    "preset": row.get("preset", "").strip() or None,
+                })
+    except (csv.Error, UnicodeDecodeError) as e:
+        print(json.dumps({"error": True, "message": f"Failed to parse CSV: {e}"}))
+        sys.exit(1)
+
+    if errors:
+        print("Validation errors:")
+        for e in errors:
+            print(f"  - {e}")
+        if not rows:
+            sys.exit(1)
+        print()
+
+    # Cost estimate
+    total_cost = sum(estimate_cost(r["model"], r["resolution"]) for r in rows)
+
+    # Output structured JSON for Claude to consume
+    print(json.dumps({"rows": rows, "total_count": len(rows),
+                       "estimated_cost": round(total_cost, 3),
+                       "errors": errors}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/cost_tracker.py
+++ b/skills/banana-image-gen/scripts/cost_tracker.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Cost Tracker
+
+Track image generation costs, view summaries, and estimate batch costs.
+
+Usage:
+    cost_tracker.py log --model MODEL --resolution RES --prompt "summary"
+    cost_tracker.py summary
+    cost_tracker.py today
+    cost_tracker.py estimate --model MODEL --resolution RES --count N
+    cost_tracker.py reset --confirm
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LEDGER_PATH = Path.home() / ".banana" / "costs.json"
+
+# Cost per image in USD (approximate, based on ~1,290 output tokens)
+PRICING = {
+    "gemini-3.1-flash-image-preview": {
+        "512": 0.020,
+        "1K": 0.039,
+        "2K": 0.078,
+        "4K": 0.156,
+    },
+    "gemini-2.5-flash-image": {
+        "512": 0.020,
+        "1K": 0.039,
+    },
+}
+
+# Batch API gets 50% discount
+BATCH_DISCOUNT = 0.5
+
+
+def _load_ledger():
+    """Load the cost ledger from disk."""
+    if not LEDGER_PATH.exists():
+        return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
+    with open(LEDGER_PATH, "r") as f:
+        return json.load(f)
+
+
+def _save_ledger(ledger):
+    """Save the cost ledger to disk."""
+    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(LEDGER_PATH, "w") as f:
+        json.dump(ledger, f, indent=2)
+
+
+def _lookup_cost(model, resolution, batch=False):
+    """Look up cost for a model+resolution combination."""
+    model_pricing = PRICING.get(model)
+    if not model_pricing:
+        # Try partial match
+        for key in PRICING:
+            if key in model or model in key:
+                model_pricing = PRICING[key]
+                break
+    if not model_pricing:
+        print(f"Warning: Unknown model '{model}', using 3.1 Flash pricing", file=sys.stderr)
+        model_pricing = PRICING["gemini-3.1-flash-image-preview"]
+
+    valid_resolutions = {"512", "1K", "2K", "4K"}
+    if resolution not in valid_resolutions:
+        print(f"Warning: Unknown resolution '{resolution}', using 1K pricing", file=sys.stderr)
+    cost = model_pricing.get(resolution, model_pricing.get("1K", 0.039))
+    if batch:
+        cost *= BATCH_DISCOUNT
+    return cost
+
+
+def cmd_log(args):
+    """Log a generation to the ledger."""
+    ledger = _load_ledger()
+    cost = _lookup_cost(args.model, args.resolution, getattr(args, "batch", False))
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+
+    entry = {
+        "ts": now,
+        "model": args.model,
+        "res": args.resolution,
+        "cost": cost,
+        "prompt": args.prompt[:100],
+    }
+
+    ledger["entries"].append(entry)
+    ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
+    ledger["total_images"] += 1
+
+    if today not in ledger["daily"]:
+        ledger["daily"][today] = {"count": 0, "cost": 0.0}
+    ledger["daily"][today]["count"] += 1
+    ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
+
+    _save_ledger(ledger)
+    print(json.dumps({"logged": True, "cost": cost, "total_cost": ledger["total_cost"],
+                       "total_images": ledger["total_images"]}))
+
+
+def cmd_summary(args):
+    """Show cost summary."""
+    ledger = _load_ledger()
+    print(f"Total images: {ledger['total_images']}")
+    print(f"Total cost:   ${ledger['total_cost']:.3f}")
+    print()
+
+    daily = ledger.get("daily", {})
+    if daily:
+        # Show last 7 days
+        sorted_days = sorted(daily.keys(), reverse=True)[:7]
+        print("Last 7 days:")
+        for day in sorted_days:
+            d = daily[day]
+            print(f"  {day}: {d['count']} images, ${d['cost']:.3f}")
+    else:
+        print("No usage recorded yet.")
+
+
+def cmd_today(args):
+    """Show today's usage."""
+    ledger = _load_ledger()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    daily = ledger.get("daily", {}).get(today, {"count": 0, "cost": 0.0})
+    print(f"Today ({today}): {daily['count']} images, ${daily['cost']:.3f}")
+
+
+def cmd_estimate(args):
+    """Estimate cost for a batch."""
+    cost_per = _lookup_cost(args.model, args.resolution, getattr(args, "batch", False))
+    total = round(cost_per * args.count, 3)
+    print(f"Model:      {args.model}")
+    print(f"Resolution: {args.resolution}")
+    print(f"Count:      {args.count}")
+    print(f"Cost/image: ${cost_per:.3f}")
+    print(f"Total est:  ${total:.3f}")
+    if not getattr(args, "batch", False):
+        batch_total = round(cost_per * BATCH_DISCOUNT * args.count, 3)
+        print(f"Batch est:  ${batch_total:.3f} (50% discount)")
+
+
+def cmd_reset(args):
+    """Reset the ledger."""
+    if not args.confirm:
+        print("Error: Pass --confirm to reset the cost ledger.", file=sys.stderr)
+        sys.exit(1)
+    _save_ledger({"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}})
+    print("Cost ledger reset.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Banana Claude Cost Tracker")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # log
+    p_log = sub.add_parser("log", help="Log a generation")
+    p_log.add_argument("--model", required=True, help="Model ID")
+    p_log.add_argument("--resolution", required=True, help="Resolution (512, 1K, 2K, 4K)")
+    p_log.add_argument("--prompt", required=True, help="Brief prompt description")
+    p_log.add_argument("--batch", action="store_true", help="Batch API (50%% discount)")
+
+    # summary
+    sub.add_parser("summary", help="Show cost summary")
+
+    # today
+    sub.add_parser("today", help="Show today's usage")
+
+    # estimate
+    p_est = sub.add_parser("estimate", help="Estimate batch cost")
+    p_est.add_argument("--model", required=True, help="Model ID")
+    p_est.add_argument("--resolution", required=True, help="Resolution (512, 1K, 2K, 4K)")
+    p_est.add_argument("--count", required=True, type=int, help="Number of images")
+    p_est.add_argument("--batch", action="store_true", help="Use batch pricing (50%% discount)")
+
+    # reset
+    p_reset = sub.add_parser("reset", help="Reset cost ledger")
+    p_reset.add_argument("--confirm", action="store_true", help="Confirm reset")
+
+    args = parser.parse_args()
+    cmds = {"log": cmd_log, "summary": cmd_summary, "today": cmd_today,
+            "estimate": cmd_estimate, "reset": cmd_reset}
+    cmds[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/edit.py
+++ b/skills/banana-image-gen/scripts/edit.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Direct API Fallback: Image Editing
+
+Edit images via Gemini REST API when MCP is unavailable.
+Uses only Python stdlib (no pip dependencies).
+
+Usage:
+    edit.py --image path/to/image.png --prompt "remove the background"
+            [--model MODEL] [--api-key KEY]
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
+OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+
+
+def edit_image(image_path, prompt, model, api_key):
+    """Call Gemini API to edit an image."""
+    image_path = Path(image_path).resolve()
+    if not image_path.exists():
+        print(json.dumps({"error": True, "message": f"Image not found: {image_path}"}))
+        sys.exit(1)
+
+    # Read and encode image
+    with open(image_path, "rb") as f:
+        image_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+    # Determine MIME type
+    suffix = image_path.suffix.lower()
+    mime_types = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                  ".webp": "image/webp", ".gif": "image/gif"}
+    mime_type = mime_types.get(suffix, "image/png")
+
+    url = f"{API_BASE}/{model}:generateContent?key={api_key}"
+
+    body = {
+        "contents": [
+            {
+                "parts": [
+                    {"text": prompt},
+                    {"inlineData": {"mimeType": mime_type, "data": image_b64}},
+                ]
+            }
+        ],
+        "generationConfig": {
+            "responseModalities": ["TEXT", "IMAGE"],
+        },
+    }
+
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    max_retries = 3
+    result = None
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                result = json.loads(resp.read().decode("utf-8"))
+            break  # Success
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            if e.code == 429 and attempt < max_retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(json.dumps({"retry": True, "attempt": attempt + 1, "wait_seconds": wait, "reason": "rate_limited"}), file=sys.stderr)
+                time.sleep(wait)
+                req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+                continue
+            if e.code == 400 and "FAILED_PRECONDITION" in error_body:
+                print(json.dumps({"error": True, "status": 400, "message": "Billing not enabled. Enable billing at https://aistudio.google.com/apikey"}))
+                sys.exit(1)
+            print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": str(e.reason)}))
+            sys.exit(1)
+
+    if result is None:
+        print(json.dumps({"error": True, "message": "Max retries exceeded"}))
+        sys.exit(1)
+
+    # Extract image from response
+    candidates = result.get("candidates", [])
+    if not candidates:
+        finish_reason = result.get("promptFeedback", {}).get("blockReason", "UNKNOWN")
+        print(json.dumps({"error": True, "message": f"No candidates returned. Reason: {finish_reason}"}))
+        sys.exit(1)
+
+    parts = candidates[0].get("content", {}).get("parts", [])
+    image_data = None
+    text_response = ""
+
+    for part in parts:
+        if "inlineData" in part:
+            image_data = part["inlineData"]["data"]
+        elif "text" in part:
+            text_response = part["text"]
+
+    if not image_data:
+        finish_reason = candidates[0].get("finishReason", "UNKNOWN")
+        print(json.dumps({"error": True, "message": f"No image in response. finishReason: {finish_reason}"}))
+        sys.exit(1)
+
+    # Save image
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    filename = f"banana_edit_{timestamp}.png"
+    output_path = (OUTPUT_DIR / filename).resolve()
+
+    with open(output_path, "wb") as f:
+        f.write(base64.b64decode(image_data))
+
+    return {
+        "path": str(output_path),
+        "model": model,
+        "source": str(image_path),
+        "text": text_response,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Edit images via Gemini REST API")
+    parser.add_argument("--image", required=True, help="Path to input image")
+    parser.add_argument("--prompt", required=True, help="Edit instruction")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Model ID (default: {DEFAULT_MODEL})")
+    parser.add_argument("--api-key", default=None, help="Google AI API key (or set GOOGLE_AI_API_KEY env)")
+
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.environ.get("GOOGLE_AI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": True, "message": "No API key. Set GOOGLE_AI_API_KEY env or pass --api-key"}))
+        sys.exit(1)
+
+    result = edit_image(
+        image_path=args.image,
+        prompt=args.prompt,
+        model=args.model,
+        api_key=api_key,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/generate.py
+++ b/skills/banana-image-gen/scripts/generate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Direct API Fallback: Image Generation
+
+Generate images via Gemini REST API when MCP is unavailable.
+Uses only Python stdlib (no pip dependencies).
+
+Usage:
+    generate.py --prompt "a cat in space" [--aspect-ratio 16:9] [--resolution 1K]
+                [--model MODEL] [--api-key KEY] [--thinking LEVEL] [--image-only]
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
+DEFAULT_RESOLUTION = "2K"  # Must be uppercase -- lowercase values are silently rejected by the API
+DEFAULT_RATIO = "1:1"
+OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+
+VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "2:3", "3:2",
+                "4:5", "5:4", "1:4", "4:1", "1:8", "8:1", "21:9"}
+VALID_RESOLUTIONS = {"512", "1K", "2K", "4K"}
+
+
+def generate_image(prompt, model, aspect_ratio, resolution, api_key,
+                   thinking_level=None, image_only=False):
+    """Call Gemini API to generate an image."""
+    url = f"{API_BASE}/{model}:generateContent?key={api_key}"
+
+    modalities = ["IMAGE"] if image_only else ["TEXT", "IMAGE"]
+    body = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {
+            "responseModalities": modalities,
+            "imageConfig": {
+                "aspectRatio": aspect_ratio,
+                "imageSize": resolution,
+            },
+        },
+    }
+
+    if thinking_level:
+        body["generationConfig"]["thinkingConfig"] = {"thinkingLevel": thinking_level}
+
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    max_retries = 3
+    result = None
+    for attempt in range(max_retries):
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                result = json.loads(resp.read().decode("utf-8"))
+            break  # Success
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8") if e.fp else ""
+            if e.code == 429 and attempt < max_retries - 1:
+                wait = 2 ** (attempt + 1)
+                print(json.dumps({"retry": True, "attempt": attempt + 1, "wait_seconds": wait, "reason": "rate_limited"}), file=sys.stderr)
+                time.sleep(wait)
+                # Rebuild request for retry
+                req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+                continue
+            if e.code == 400 and "FAILED_PRECONDITION" in error_body:
+                print(json.dumps({"error": True, "status": 400, "message": "Billing not enabled. Enable billing at https://aistudio.google.com/apikey"}))
+                sys.exit(1)
+            print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+            sys.exit(1)
+        except urllib.error.URLError as e:
+            print(json.dumps({"error": True, "message": str(e.reason)}))
+            sys.exit(1)
+
+    if result is None:
+        print(json.dumps({"error": True, "message": "Max retries exceeded"}))
+        sys.exit(1)
+
+    # Extract image from response
+    candidates = result.get("candidates", [])
+    if not candidates:
+        finish_reason = result.get("promptFeedback", {}).get("blockReason", "UNKNOWN")
+        print(json.dumps({"error": True, "message": f"No candidates returned. Reason: {finish_reason}"}))
+        sys.exit(1)
+
+    parts = candidates[0].get("content", {}).get("parts", [])
+    image_data = None
+    text_response = ""
+
+    for part in parts:
+        if "inlineData" in part:
+            image_data = part["inlineData"]["data"]
+        elif "text" in part:
+            text_response = part["text"]
+
+    if not image_data:
+        finish_reason = candidates[0].get("finishReason", "UNKNOWN")
+        print(json.dumps({"error": True, "message": f"No image in response. finishReason: {finish_reason}"}))
+        sys.exit(1)
+
+    # Save image
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    filename = f"banana_{timestamp}.png"
+    output_path = (OUTPUT_DIR / filename).resolve()
+
+    with open(output_path, "wb") as f:
+        f.write(base64.b64decode(image_data))
+
+    return {
+        "path": str(output_path),
+        "model": model,
+        "aspect_ratio": aspect_ratio,
+        "resolution": resolution,
+        "text": text_response,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate images via Gemini REST API")
+    parser.add_argument("--prompt", required=True, help="Image generation prompt")
+    parser.add_argument("--aspect-ratio", default=DEFAULT_RATIO, help=f"Aspect ratio (default: {DEFAULT_RATIO})")
+    parser.add_argument("--resolution", default=DEFAULT_RESOLUTION, help=f"Resolution: 512, 1K, 2K, 4K (default: {DEFAULT_RESOLUTION})")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help=f"Model ID (default: {DEFAULT_MODEL})")
+    parser.add_argument("--api-key", default=None, help="Google AI API key (or set GOOGLE_AI_API_KEY env)")
+    parser.add_argument("--thinking", default=None, choices=["minimal", "low", "medium", "high"], help="Thinking level")
+    parser.add_argument("--image-only", action="store_true", help="Return image only (no text)")
+
+    args = parser.parse_args()
+
+    if args.aspect_ratio not in VALID_RATIOS:
+        print(json.dumps({"error": True, "message": f"Invalid aspect ratio '{args.aspect_ratio}'. Valid: {sorted(VALID_RATIOS)}"}))
+        sys.exit(1)
+
+    if args.resolution not in VALID_RESOLUTIONS:
+        print(json.dumps({"error": True, "message": f"Invalid resolution '{args.resolution}'. Valid: {sorted(VALID_RESOLUTIONS)}"}))
+        sys.exit(1)
+
+    api_key = args.api_key or os.environ.get("GOOGLE_AI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": True, "message": "No API key. Set GOOGLE_AI_API_KEY env or pass --api-key"}))
+        sys.exit(1)
+
+    result = generate_image(
+        prompt=args.prompt,
+        model=args.model,
+        aspect_ratio=args.aspect_ratio,
+        resolution=args.resolution,
+        api_key=api_key,
+        thinking_level=args.thinking,
+        image_only=args.image_only,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/presets.py
+++ b/skills/banana-image-gen/scripts/presets.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Banana Claude -- Brand/Style Presets
+
+Manage reusable brand and style presets for consistent image generation.
+
+Usage:
+    presets.py list
+    presets.py show NAME
+    presets.py create NAME --colors "#hex,#hex" --style "..." [options]
+    presets.py delete NAME --confirm
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+PRESETS_DIR = Path.home() / ".banana" / "presets"
+
+
+def _ensure_dir():
+    """Ensure presets directory exists."""
+    PRESETS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _sanitize_name(name):
+    """Sanitize preset name to prevent path traversal."""
+    # Strip path separators and keep only safe characters
+    safe = re.sub(r'[^a-zA-Z0-9_\-]', '', name)
+    if not safe:
+        print("Error: Preset name must contain only letters, numbers, hyphens, and underscores.", file=sys.stderr)
+        sys.exit(1)
+    return safe
+
+
+def _preset_path(name):
+    """Get path for a preset file."""
+    safe_name = _sanitize_name(name)
+    return PRESETS_DIR / f"{safe_name}.json"
+
+
+def _load_preset(name):
+    """Load a preset by name."""
+    path = _preset_path(name)
+    if not path.exists():
+        print(f"Error: Preset '{name}' not found.", file=sys.stderr)
+        sys.exit(1)
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def cmd_list(args):
+    """List available presets."""
+    _ensure_dir()
+    presets = sorted(PRESETS_DIR.glob("*.json"))
+    if not presets:
+        print("No presets found. Create one with: presets.py create NAME --style \"...\"")
+        return
+    print(f"Available presets ({len(presets)}):\n")
+    for p in presets:
+        try:
+            with open(p, "r") as f:
+                data = json.load(f)
+            desc = data.get("description", "No description")
+            print(f"  {p.stem:20s} -- {desc}")
+        except (json.JSONDecodeError, KeyError):
+            print(f"  {p.stem:20s} -- (invalid preset file)")
+
+
+def cmd_show(args):
+    """Show full preset details."""
+    preset = _load_preset(args.name)
+    print(json.dumps(preset, indent=2))
+
+
+def cmd_create(args):
+    """Create a new preset."""
+    _ensure_dir()
+    path = _preset_path(args.name)
+    if path.exists():
+        print(f"Error: Preset '{args.name}' already exists. Use a different name.", file=sys.stderr)
+        sys.exit(1)
+
+    colors = [c.strip() for c in args.colors.split(",")] if args.colors else []
+
+    preset = {
+        "name": args.name,
+        "description": args.description or f"Custom preset: {args.name}",
+        "colors": colors,
+        "style": args.style or "",
+        "typography": args.typography or "",
+        "lighting": args.lighting or "",
+        "mood": args.mood or "",
+        "default_ratio": args.ratio or "16:9",
+        "default_resolution": args.resolution or "2K",
+    }
+
+    with open(path, "w") as f:
+        json.dump(preset, f, indent=2)
+
+    print(f"Preset '{args.name}' created at {path}")
+    print(json.dumps(preset, indent=2))
+
+
+def cmd_delete(args):
+    """Delete a preset."""
+    if not args.confirm:
+        print("Error: Pass --confirm to delete the preset.", file=sys.stderr)
+        sys.exit(1)
+    path = _preset_path(args.name)
+    if not path.exists():
+        print(f"Error: Preset '{args.name}' not found.", file=sys.stderr)
+        sys.exit(1)
+    path.unlink()
+    print(f"Preset '{args.name}' deleted.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Banana Claude Brand/Style Presets")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # list
+    sub.add_parser("list", help="List available presets")
+
+    # show
+    p_show = sub.add_parser("show", help="Show preset details")
+    p_show.add_argument("name", help="Preset name")
+
+    # create
+    p_create = sub.add_parser("create", help="Create a new preset")
+    p_create.add_argument("name", help="Preset name (e.g., tech-saas, luxury-brand)")
+    p_create.add_argument("--colors", default="", help="Comma-separated hex colors")
+    p_create.add_argument("--style", default="", help="Visual style description")
+    p_create.add_argument("--typography", default="", help="Typography description")
+    p_create.add_argument("--lighting", default="", help="Lighting description")
+    p_create.add_argument("--mood", default="", help="Mood/emotion description")
+    p_create.add_argument("--description", default="", help="Brief preset description")
+    p_create.add_argument("--ratio", default="16:9", help="Default aspect ratio")
+    p_create.add_argument("--resolution", default="2K", help="Default resolution")
+    p_create.add_argument("--force", action="store_true", help="Overwrite existing preset")
+
+    # delete
+    p_delete = sub.add_parser("delete", help="Delete a preset")
+    p_delete.add_argument("name", help="Preset name")
+    p_delete.add_argument("--confirm", action="store_true", help="Confirm deletion")
+
+    args = parser.parse_args()
+    cmds = {"list": cmd_list, "show": cmd_show, "create": cmd_create, "delete": cmd_delete}
+    cmds[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/setup_mcp.py
+++ b/skills/banana-image-gen/scripts/setup_mcp.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Setup script for Banana Claude MCP server in Claude Code.
+
+Configures @ycse/nanobanana-mcp in Claude Code's settings.json
+with the user's Google AI API key.
+
+Usage:
+    python3 setup_mcp.py                    # Interactive (prompts for key)
+    python3 setup_mcp.py --key YOUR_KEY     # Non-interactive
+    python3 setup_mcp.py --check            # Verify existing setup
+    python3 setup_mcp.py --remove           # Remove MCP config
+    python3 setup_mcp.py --help             # Show usage
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+MCP_NAME = "nanobanana-mcp"
+MCP_PACKAGE = "@ycse/nanobanana-mcp"
+DEFAULT_MODEL = "gemini-3.1-flash-image-preview"
+
+
+def load_settings() -> dict:
+    """Load Claude Code settings.json."""
+    if not SETTINGS_PATH.exists():
+        return {}
+    with open(SETTINGS_PATH, "r") as f:
+        return json.load(f)
+
+
+def save_settings(settings: dict) -> None:
+    """Save Claude Code settings.json."""
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(SETTINGS_PATH, "w") as f:
+        json.dump(settings, f, indent=2)
+    print(f"Settings saved to {SETTINGS_PATH}")
+
+
+def check_setup() -> bool:
+    """Check if MCP is already configured."""
+    settings = load_settings()
+    servers = settings.get("mcpServers", {})
+    if MCP_NAME in servers:
+        env = servers[MCP_NAME].get("env", {})
+        key = env.get("GOOGLE_AI_API_KEY", "")
+        masked = key[:8] + "..." + key[-4:] if len(key) > 12 else "(not set)"
+        print(f"MCP server '{MCP_NAME}' is configured.")
+        print(f"  Package: {MCP_PACKAGE}")
+        print(f"  API Key: {masked}")
+        print(f"  Model:   {env.get('NANOBANANA_MODEL', DEFAULT_MODEL)}")
+        return True
+    print(f"MCP server '{MCP_NAME}' is NOT configured.")
+    return False
+
+
+def remove_mcp() -> None:
+    """Remove MCP configuration."""
+    settings = load_settings()
+    servers = settings.get("mcpServers", {})
+    if MCP_NAME in servers:
+        del servers[MCP_NAME]
+        settings["mcpServers"] = servers
+        save_settings(settings)
+        print(f"Removed '{MCP_NAME}' from Claude Code settings.")
+    else:
+        print(f"'{MCP_NAME}' not found in settings.")
+
+
+def setup_mcp(api_key: str) -> None:
+    """Configure MCP server in Claude Code settings."""
+    if not api_key or not api_key.strip():
+        print("Error: API key cannot be empty.")
+        sys.exit(1)
+
+    api_key = api_key.strip()
+    settings = load_settings()
+
+    if "mcpServers" not in settings:
+        settings["mcpServers"] = {}
+
+    settings["mcpServers"][MCP_NAME] = {
+        "command": "npx",
+        "args": ["-y", MCP_PACKAGE],
+        "env": {
+            "GOOGLE_AI_API_KEY": api_key,
+            "NANOBANANA_MODEL": DEFAULT_MODEL,
+        },
+    }
+
+    save_settings(settings)
+    print(f"\nMCP server '{MCP_NAME}' configured successfully!")
+    print(f"  Package: {MCP_PACKAGE}")
+    print(f"  Model:   {DEFAULT_MODEL}")
+    print(f"\nRestart Claude Code for changes to take effect.")
+    print(f"Generated images will be saved to: ~/Documents/nanobanana_generated/")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    if "--help" in args or "-h" in args:
+        print("Usage: python3 setup_mcp.py [OPTIONS]")
+        print()
+        print("Options:")
+        print("  --key KEY        Provide API key non-interactively")
+        print("  --check          Verify existing setup")
+        print("  --remove         Remove MCP configuration")
+        print("  --help, -h       Show this help message")
+        print()
+        print("Get a free API key at: https://aistudio.google.com/apikey")
+        sys.exit(0)
+
+    if "--check" in args:
+        check_setup()
+        return
+
+    if "--remove" in args:
+        remove_mcp()
+        return
+
+    # Get API key
+    api_key = None
+    for i, arg in enumerate(args):
+        if arg == "--key" and i + 1 < len(args):
+            api_key = args[i + 1]
+            break
+
+    if not api_key:
+        # Check environment
+        api_key = os.environ.get("GOOGLE_AI_API_KEY")
+
+    if not api_key:
+        print("Banana Claude -- MCP Setup")
+        print("=" * 40)
+        print(f"\nGet your free API key at: https://aistudio.google.com/apikey")
+        print()
+        try:
+            api_key = input("Enter your Google AI API key: ")
+        except (EOFError, KeyboardInterrupt):
+            print("\nError: No input received. Provide a key with --key or set GOOGLE_AI_API_KEY env var.")
+            sys.exit(1)
+
+    setup_mcp(api_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/banana-image-gen/scripts/validate_setup.py
+++ b/skills/banana-image-gen/scripts/validate_setup.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Validate that the Banana Claude MCP server is properly configured.
+
+Checks:
+1. Claude Code settings.json has the MCP entry
+2. API key is present
+3. Node.js/npx is available
+4. Output directory exists or can be created
+
+Usage:
+    python3 validate_setup.py
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+MCP_NAME = "nanobanana-mcp"
+OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+
+
+def check(label: str, passed: bool, detail: str = "") -> bool:
+    status = "PASS" if passed else "FAIL"
+    msg = f"  [{status}] {label}"
+    if detail:
+        msg += f" -- {detail}"
+    print(msg)
+    return passed
+
+
+def main() -> int:
+    print("Banana Claude -- Setup Validation")
+    print("=" * 40)
+    results = []
+
+    # 1. Settings file exists
+    results.append(check(
+        "Claude Code settings.json exists",
+        SETTINGS_PATH.exists(),
+        str(SETTINGS_PATH),
+    ))
+
+    if not SETTINGS_PATH.exists():
+        print("\nCannot continue without settings.json.")
+        return 1
+
+    # 2. Load and parse settings
+    try:
+        with open(SETTINGS_PATH) as f:
+            settings = json.load(f)
+        results.append(check("settings.json is valid JSON", True))
+    except json.JSONDecodeError as e:
+        results.append(check("settings.json is valid JSON", False, str(e)))
+        return 1
+
+    # 3. MCP entry exists
+    servers = settings.get("mcpServers", {})
+    has_mcp = MCP_NAME in servers
+    results.append(check(f"MCP server '{MCP_NAME}' configured", has_mcp))
+
+    if has_mcp:
+        mcp = servers[MCP_NAME]
+
+        # 4. Command is npx
+        results.append(check(
+            "Command is 'npx'",
+            mcp.get("command") == "npx",
+            mcp.get("command", "(missing)"),
+        ))
+
+        # 5. Package is correct
+        args = mcp.get("args", [])
+        has_pkg = "@ycse/nanobanana-mcp" in args
+        results.append(check(
+            "Package is @ycse/nanobanana-mcp",
+            has_pkg,
+            str(args),
+        ))
+
+        # 6. API key present
+        env = mcp.get("env", {})
+        key = env.get("GOOGLE_AI_API_KEY", "")
+        results.append(check(
+            "GOOGLE_AI_API_KEY is set",
+            bool(key),
+            f"{key[:8]}...{key[-4:]}" if len(key) > 12 else "(empty or short)",
+        ))
+
+        # 7. Model configured
+        model = env.get("NANOBANANA_MODEL", "")
+        results.append(check(
+            "NANOBANANA_MODEL is set",
+            bool(model),
+            model or "(not set, will use package default)",
+        ))
+
+    # 8. Node.js/npx available
+    has_npx = shutil.which("npx") is not None
+    results.append(check(
+        "npx is available in PATH",
+        has_npx,
+        shutil.which("npx") or "not found",
+    ))
+
+    # 9. Output directory
+    if OUTPUT_DIR.exists():
+        results.append(check("Output directory exists", True, str(OUTPUT_DIR)))
+    else:
+        try:
+            OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+            results.append(check("Output directory created", True, str(OUTPUT_DIR)))
+        except OSError as e:
+            results.append(check("Output directory writable", False, str(e)))
+
+    # Summary
+    passed = sum(1 for r in results if r)
+    total = len(results)
+    print(f"\n{'=' * 40}")
+    print(f"Results: {passed}/{total} checks passed")
+
+    if passed == total:
+        print("Status: Ready to generate images!")
+        return 0
+    else:
+        print("Status: Some checks failed. Fix the issues above.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/clone-website/SKILL.md
+++ b/skills/clone-website/SKILL.md
@@ -1,0 +1,473 @@
+---
+name: clone-website
+description: Reverse-engineer and clone one or more websites in one shot — extracts assets, CSS, and content section-by-section and proactively dispatches parallel builder agents in worktrees as it goes. Use this whenever the user wants to clone, replicate, rebuild, reverse-engineer, or copy any website. Also triggers on phrases like "make a copy of this site", "rebuild this page", "pixel-perfect clone". Provide one or more target URLs as arguments.
+argument-hint: "<url1> [<url2> ...]"
+user-invocable: true
+---
+
+# Clone Website
+
+You are about to reverse-engineer and rebuild **$ARGUMENTS** as pixel-perfect clones.
+
+When multiple URLs are provided, process them independently and in parallel where possible, while keeping each site's extraction artifacts isolated in dedicated folders (for example, `docs/research/<hostname>/`).
+
+This is not a two-phase process (inspect then build). You are a **foreman walking the job site** — as you inspect each section of the page, you write a detailed specification to a file, then hand that file to a specialist builder agent with everything they need. Extraction and construction happen in parallel, but extraction is meticulous and produces auditable artifacts.
+
+## Scope Defaults
+
+The target is whatever page `$ARGUMENTS` resolves to. Clone exactly what's visible at that URL. Unless the user specifies otherwise, use these defaults:
+
+- **Fidelity level:** Pixel-perfect — exact match in colors, spacing, typography, animations
+- **In scope:** Visual layout and styling, component structure and interactions, responsive design, mock data for demo purposes
+- **Out of scope:** Real backend / database, authentication, real-time features, SEO optimization, accessibility audit
+- **Customization:** None — pure emulation
+
+If the user provides additional instructions (specific fidelity level, customizations, extra context), honor those over the defaults.
+
+## Pre-Flight
+
+1. **Browser automation is required.** Check for available browser MCP tools (Chrome MCP, Playwright MCP, Browserbase MCP, Puppeteer MCP, etc.). Use whichever is available — if multiple exist, prefer Chrome MCP. If none are detected, ask the user which browser tool they have and how to connect it. This skill cannot work without browser automation.
+2. Parse `$ARGUMENTS` as one or more URLs. Normalize and validate each URL; if any are invalid, ask the user to correct them before proceeding. For each valid URL, verify it is accessible via your browser MCP tool.
+3. Verify the base project builds: `npm run build`. The Next.js + shadcn/ui + Tailwind v4 scaffold should already be in place. If not, tell the user to set it up first.
+4. Create the output directories if they don't exist: `docs/research/`, `docs/research/components/`, `docs/design-references/`, `scripts/`. For multiple clones, also prepare per-site folders like `docs/research/<hostname>/` and `docs/design-references/<hostname>/`.
+5. When working with multiple sites in one command, optionally confirm whether to run them in parallel (recommended, if resources allow) or sequentially to avoid overload.
+
+## Guiding Principles
+
+These are the truths that separate a successful clone from a "close enough" mess. Internalize them — they should inform every decision you make.
+
+### 1. Completeness Beats Speed
+
+Every builder agent must receive **everything** it needs to do its job perfectly: screenshot, exact CSS values, downloaded assets with local paths, real text content, component structure. If a builder has to guess anything — a color, a font size, a padding value — you have failed at extraction. Take the extra minute to extract one more property rather than shipping an incomplete brief.
+
+### 2. Small Tasks, Perfect Results
+
+When an agent gets "build the entire features section," it glosses over details — it approximates spacing, guesses font sizes, and produces something "close enough" but clearly wrong. When it gets a single focused component with exact CSS values, it nails it every time.
+
+Look at each section and judge its complexity. A simple banner with a heading and a button? One agent. A complex section with 3 different card variants, each with unique hover states and internal layouts? One agent per card variant plus one for the section wrapper. When in doubt, make it smaller.
+
+**Complexity budget rule:** If a builder prompt exceeds ~150 lines of spec content, the section is too complex for one agent. Break it into smaller pieces. This is a mechanical check — don't override it with "but it's all related."
+
+### 3. Real Content, Real Assets
+
+Extract the actual text, images, videos, and SVGs from the live site. This is a clone, not a mockup. Use `element.textContent`, download every `<img>` and `<video>`, extract inline `<svg>` elements as React components. The only time you generate content is when something is clearly server-generated and unique per session.
+
+**Layered assets matter.** A section that looks like one image is often multiple layers — a background watercolor/gradient, a foreground UI mockup PNG, an overlay icon. Inspect each container's full DOM tree and enumerate ALL `<img>` elements and background images within it, including absolutely-positioned overlays. Missing an overlay image makes the clone look empty even if the background is correct.
+
+### 4. Foundation First
+
+Nothing can be built until the foundation exists: global CSS with the target site's design tokens (colors, fonts, spacing), TypeScript types for the content structures, and global assets (fonts, favicons). This is sequential and non-negotiable. Everything after this can be parallel.
+
+### 5. Extract How It Looks AND How It Behaves
+
+A website is not a screenshot — it's a living thing. Elements move, change, appear, and disappear in response to scrolling, hovering, clicking, resizing, and time. If you only extract the static CSS of each element, your clone will look right in a screenshot but feel dead when someone actually uses it.
+
+For every element, extract its **appearance** (exact computed CSS via `getComputedStyle()`) AND its **behavior** (what changes, what triggers the change, and how the transition happens). Not "it looks like 16px" — extract the actual computed value. Not "the nav changes on scroll" — document the exact trigger (scroll position, IntersectionObserver threshold, viewport intersection), the before and after states (both sets of CSS values), and the transition (duration, easing, CSS transition vs. JS-driven vs. CSS `animation-timeline`).
+
+Examples of behaviors to watch for — these are illustrative, not exhaustive. The page may do things not on this list, and you must catch those too:
+- A navbar that shrinks, changes background, or gains a shadow after scrolling past a threshold
+- Elements that animate into view when they enter the viewport (fade-up, slide-in, stagger delays)
+- Sections that snap into place on scroll (`scroll-snap-type`)
+- Parallax layers that move at different rates than the scroll
+- Hover states that animate (not just change — the transition duration and easing matter)
+- Dropdowns, modals, accordions with enter/exit animations
+- Scroll-driven progress indicators or opacity transitions
+- Auto-playing carousels or cycling content
+- Dark-to-light (or any theme) transitions between page sections
+- **Tabbed/pill content that cycles** — buttons that switch visible card sets with transitions
+- **Scroll-driven tab/accordion switching** — sidebars where the active item auto-changes as content scrolls past (IntersectionObserver, NOT click handlers)
+- **Smooth scroll libraries** (Lenis, Locomotive Scroll) — check for `.lenis` class or scroll container wrappers
+
+### 6. Identify the Interaction Model Before Building
+
+This is the single most expensive mistake in cloning: building a click-based UI when the original is scroll-driven, or vice versa. Before writing any builder prompt for an interactive section, you must definitively answer: **Is this section driven by clicks, scrolls, hovers, time, or some combination?**
+
+How to determine this:
+1. **Don't click first.** Scroll through the section slowly and observe if things change on their own as you scroll.
+2. If they do, it's scroll-driven. Extract the mechanism: `IntersectionObserver`, `scroll-snap`, `position: sticky`, `animation-timeline`, or JS scroll listeners.
+3. If nothing changes on scroll, THEN click/hover to test for click/hover-driven interactivity.
+4. Document the interaction model explicitly in the component spec: "INTERACTION MODEL: scroll-driven with IntersectionObserver" or "INTERACTION MODEL: click-to-switch with opacity transition."
+
+A section with a sticky sidebar and scrolling content panels is fundamentally different from a tabbed interface where clicking switches content. Getting this wrong means a complete rewrite, not a CSS tweak.
+
+### 7. Extract Every State, Not Just the Default
+
+Many components have multiple visual states — a tab bar shows different cards per tab, a header looks different at scroll position 0 vs 100, a card has hover effects. You must extract ALL states, not just whatever is visible on page load.
+
+For tabbed/stateful content:
+- Click each tab/button via browser MCP
+- Extract the content, images, and card data for EACH state
+- Record which content belongs to which state
+- Note the transition animation between states (opacity, slide, fade, etc.)
+
+For scroll-dependent elements:
+- Capture computed styles at scroll position 0 (initial state)
+- Scroll past the trigger threshold and capture computed styles again (scrolled state)
+- Diff the two to identify exactly which CSS properties change
+- Record the transition CSS (duration, easing, properties)
+- Record the exact trigger threshold (scroll position in px, or viewport intersection ratio)
+
+### 8. Spec Files Are the Source of Truth
+
+Every component gets a specification file in `docs/research/components/` BEFORE any builder is dispatched. This file is the contract between your extraction work and the builder agent. The builder receives the spec file contents inline in its prompt — the file also persists as an auditable artifact that the user (or you) can review if something looks wrong.
+
+The spec file is not optional. It is not a nice-to-have. If you dispatch a builder without first writing a spec file, you are shipping incomplete instructions based on whatever you can remember from a browser MCP session, and the builder will guess to fill gaps.
+
+### 9. Build Must Always Compile
+
+Every builder agent must verify `npx tsc --noEmit` passes before finishing. After merging worktrees, you verify `npm run build` passes. A broken build is never acceptable, even temporarily.
+
+## Phase 1: Reconnaissance
+
+Navigate to the target URL with browser MCP.
+
+### Screenshots
+- Take **full-page screenshots** at desktop (1440px) and mobile (390px) viewports
+- Save to `docs/design-references/` with descriptive names
+- These are your master reference — builders will receive section-specific crops/screenshots later
+
+### Global Extraction
+Extract these from the page before doing anything else:
+
+**Fonts** — Inspect `<link>` tags for Google Fonts or self-hosted fonts. Check computed `font-family` on key elements (headings, body, code, labels). Document every family, weight, and style actually used. Configure them in `src/app/layout.tsx` using `next/font/google` or `next/font/local`.
+
+**Colors** — Extract the site's color palette from computed styles across the page. Update `src/app/globals.css` with the target's actual colors in the `:root` and `.dark` CSS variable blocks. Map them to shadcn's token names (background, foreground, primary, muted, etc.) where they fit. Add custom properties for colors that don't map to shadcn tokens.
+
+**Favicons & Meta** — Download favicons, apple-touch-icons, OG images, webmanifest to `public/seo/`. Update `layout.tsx` metadata.
+
+**Global UI patterns** — Identify any site-wide CSS or JS: custom scrollbar hiding, scroll-snap on the page container, global keyframe animations, backdrop filters, gradients used as overlays, **smooth scroll libraries** (Lenis, Locomotive Scroll — check for `.lenis`, `.locomotive-scroll`, or custom scroll container classes). Add these to `globals.css` and note any libraries that need to be installed.
+
+### Mandatory Interaction Sweep
+
+This is a dedicated pass AFTER screenshots and BEFORE anything else. Its purpose is to discover every behavior on the page — many of which are invisible in a static screenshot.
+
+**Scroll sweep:** Scroll the page slowly from top to bottom via browser MCP. At each section, pause and observe:
+- Does the header change appearance? Record the scroll position where it triggers.
+- Do elements animate into view? Record which ones and the animation type.
+- Does a sidebar or tab indicator auto-switch as you scroll? Record the mechanism.
+- Are there scroll-snap points? Record which containers.
+- Is there a smooth scroll library active? Check for non-native scroll behavior.
+
+**Click sweep:** Click every element that looks interactive:
+- Every button, tab, pill, link, card
+- Record what happens: does content change? Does a modal open? Does a dropdown appear?
+- For tabs/pills: click EACH ONE and record the content that appears for each state
+
+**Hover sweep:** Hover over every element that might have hover states:
+- Buttons, cards, links, images, nav items
+- Record what changes: color, scale, shadow, underline, opacity
+
+**Responsive sweep:** Test at 3 viewport widths via browser MCP:
+- Desktop: 1440px
+- Tablet: 768px
+- Mobile: 390px
+- At each width, note which sections change layout (column → stack, sidebar disappears, etc.) and at approximately which breakpoint the change occurs.
+
+Save all findings to `docs/research/BEHAVIORS.md`. This is your behavior bible — reference it when writing every component spec.
+
+### Page Topology
+Map out every distinct section of the page from top to bottom. Give each a working name. Document:
+- Their visual order
+- Which are fixed/sticky overlays vs. flow content
+- The overall page layout (scroll container, column structure, z-index layers)
+- Dependencies between sections (e.g., a floating nav that overlays everything)
+- **The interaction model** of each section (static, click-driven, scroll-driven, time-driven)
+
+Save this as `docs/research/PAGE_TOPOLOGY.md` — it becomes your assembly blueprint.
+
+## Phase 2: Foundation Build
+
+This is sequential. Do it yourself (not delegated to an agent) since it touches many files:
+
+1. **Update fonts** in `layout.tsx` to match the target site's actual fonts
+2. **Update globals.css** with the target's color tokens, spacing values, keyframe animations, utility classes, and any **global scroll behaviors** (Lenis, smooth scroll CSS, scroll-snap on body)
+3. **Create TypeScript interfaces** in `src/types/` for the content structures you've observed
+4. **Extract SVG icons** — find all inline `<svg>` elements on the page, deduplicate them, and save as named React components in `src/components/icons.tsx`. Name them by visual function (e.g., `SearchIcon`, `ArrowRightIcon`, `LogoIcon`).
+5. **Download global assets** — write and run a Node.js script (`scripts/download-assets.mjs`) that downloads all images, videos, and other binary assets from the page to `public/`. Preserve meaningful directory structure.
+6. Verify: `npm run build` passes
+
+### Asset Discovery Script Pattern
+
+Use browser MCP to enumerate all assets on the page:
+
+```javascript
+// Run this via browser MCP to discover all assets
+JSON.stringify({
+  images: [...document.querySelectorAll('img')].map(img => ({
+    src: img.src || img.currentSrc,
+    alt: img.alt,
+    width: img.naturalWidth,
+    height: img.naturalHeight,
+    // Include parent info to detect layered compositions
+    parentClasses: img.parentElement?.className,
+    siblings: img.parentElement ? [...img.parentElement.querySelectorAll('img')].length : 0,
+    position: getComputedStyle(img).position,
+    zIndex: getComputedStyle(img).zIndex
+  })),
+  videos: [...document.querySelectorAll('video')].map(v => ({
+    src: v.src || v.querySelector('source')?.src,
+    poster: v.poster,
+    autoplay: v.autoplay,
+    loop: v.loop,
+    muted: v.muted
+  })),
+  backgroundImages: [...document.querySelectorAll('*')].filter(el => {
+    const bg = getComputedStyle(el).backgroundImage;
+    return bg && bg !== 'none';
+  }).map(el => ({
+    url: getComputedStyle(el).backgroundImage,
+    element: el.tagName + '.' + el.className?.split(' ')[0]
+  })),
+  svgCount: document.querySelectorAll('svg').length,
+  fonts: [...new Set([...document.querySelectorAll('*')].slice(0, 200).map(el => getComputedStyle(el).fontFamily))],
+  favicons: [...document.querySelectorAll('link[rel*="icon"]')].map(l => ({ href: l.href, sizes: l.sizes?.toString() }))
+});
+```
+
+Then write a download script that fetches everything to `public/`. Use batched parallel downloads (4 at a time) with proper error handling.
+
+## Phase 3: Component Specification & Dispatch
+
+This is the core loop. For each section in your page topology (top to bottom), you do THREE things: **extract**, **write the spec file**, then **dispatch builders**.
+
+### Step 1: Extract
+
+For each section, use browser MCP to extract everything:
+
+1. **Screenshot** the section in isolation (scroll to it, screenshot the viewport). Save to `docs/design-references/`.
+
+2. **Extract CSS** for every element in the section. Use the extraction script below — don't hand-measure individual properties. Run it once per component container and capture the full output:
+
+```javascript
+// Per-component extraction — run via browser MCP
+// Replace SELECTOR with the actual CSS selector for the component
+(function(selector) {
+  const el = document.querySelector(selector);
+  if (!el) return JSON.stringify({ error: 'Element not found: ' + selector });
+  const props = [
+    'fontSize','fontWeight','fontFamily','lineHeight','letterSpacing','color',
+    'textTransform','textDecoration','backgroundColor','background',
+    'padding','paddingTop','paddingRight','paddingBottom','paddingLeft',
+    'margin','marginTop','marginRight','marginBottom','marginLeft',
+    'width','height','maxWidth','minWidth','maxHeight','minHeight',
+    'display','flexDirection','justifyContent','alignItems','gap',
+    'gridTemplateColumns','gridTemplateRows',
+    'borderRadius','border','borderTop','borderBottom','borderLeft','borderRight',
+    'boxShadow','overflow','overflowX','overflowY',
+    'position','top','right','bottom','left','zIndex',
+    'opacity','transform','transition','cursor',
+    'objectFit','objectPosition','mixBlendMode','filter','backdropFilter',
+    'whiteSpace','textOverflow','WebkitLineClamp'
+  ];
+  function extractStyles(element) {
+    const cs = getComputedStyle(element);
+    const styles = {};
+    props.forEach(p => { const v = cs[p]; if (v && v !== 'none' && v !== 'normal' && v !== 'auto' && v !== '0px' && v !== 'rgba(0, 0, 0, 0)') styles[p] = v; });
+    return styles;
+  }
+  function walk(element, depth) {
+    if (depth > 4) return null;
+    const children = [...element.children];
+    return {
+      tag: element.tagName.toLowerCase(),
+      classes: element.className?.toString().split(' ').slice(0, 5).join(' '),
+      text: element.childNodes.length === 1 && element.childNodes[0].nodeType === 3 ? element.textContent.trim().slice(0, 200) : null,
+      styles: extractStyles(element),
+      images: element.tagName === 'IMG' ? { src: element.src, alt: element.alt, naturalWidth: element.naturalWidth, naturalHeight: element.naturalHeight } : null,
+      childCount: children.length,
+      children: children.slice(0, 20).map(c => walk(c, depth + 1)).filter(Boolean)
+    };
+  }
+  return JSON.stringify(walk(el, 0), null, 2);
+})('SELECTOR');
+```
+
+3. **Extract multi-state styles** — for any element with multiple states (scroll-triggered, hover, active tab), capture BOTH states:
+
+```javascript
+// State A: capture styles at current state (e.g., scroll position 0)
+// Then trigger the state change (scroll, click, hover via browser MCP)
+// State B: re-run the extraction script on the same element
+// The diff between A and B IS the behavior specification
+```
+
+Record the diff explicitly: "Property X changes from VALUE_A to VALUE_B, triggered by TRIGGER, with transition: TRANSITION_CSS."
+
+4. **Extract real content** — all text, alt attributes, aria labels, placeholder text. Use `element.textContent` for each text node. For tabbed/stateful content, **click each tab and extract content per state**.
+
+5. **Identify assets** this section uses — which downloaded images/videos from `public/`, which icon components from `icons.tsx`. Check for **layered images** (multiple `<img>` or background-images stacked in the same container).
+
+6. **Assess complexity** — how many distinct sub-components does this section contain? A distinct sub-component is an element with its own unique styling, structure, and behavior (e.g., a card, a nav item, a search panel).
+
+### Step 2: Write the Component Spec File
+
+For each section (or sub-component, if you're breaking it up), create a spec file in `docs/research/components/`. This is NOT optional — every builder must have a corresponding spec file.
+
+**File path:** `docs/research/components/<component-name>.spec.md`
+
+**Template:**
+
+```markdown
+# <ComponentName> Specification
+
+## Overview
+- **Target file:** `src/components/<ComponentName>.tsx`
+- **Screenshot:** `docs/design-references/<screenshot-name>.png`
+- **Interaction model:** <static | click-driven | scroll-driven | time-driven>
+
+## DOM Structure
+<Describe the element hierarchy — what contains what>
+
+## Computed Styles (exact values from getComputedStyle)
+
+### Container
+- display: ...
+- padding: ...
+- maxWidth: ...
+- (every relevant property with exact values)
+
+### <Child element 1>
+- fontSize: ...
+- color: ...
+- (every relevant property)
+
+### <Child element N>
+...
+
+## States & Behaviors
+
+### <Behavior name, e.g., "Scroll-triggered floating mode">
+- **Trigger:** <exact mechanism — scroll position 50px, IntersectionObserver rootMargin "-30% 0px", click on .tab-button, hover>
+- **State A (before):** maxWidth: 100vw, boxShadow: none, borderRadius: 0
+- **State B (after):** maxWidth: 1200px, boxShadow: 0 4px 20px rgba(0,0,0,0.1), borderRadius: 16px
+- **Transition:** transition: all 0.3s ease
+- **Implementation approach:** <CSS transition + scroll listener | IntersectionObserver | CSS animation-timeline | etc.>
+
+### Hover states
+- **<Element>:** <property>: <before> → <after>, transition: <value>
+
+## Per-State Content (if applicable)
+
+### State: "Featured"
+- Title: "..."
+- Subtitle: "..."
+- Cards: [{ title, description, image, link }, ...]
+
+### State: "Productivity"
+- Title: "..."
+- Cards: [...]
+
+## Assets
+- Background image: `public/images/<file>.webp`
+- Overlay image: `public/images/<file>.png`
+- Icons used: <ArrowIcon>, <SearchIcon> from icons.tsx
+
+## Text Content (verbatim)
+<All text content, copy-pasted from the live site>
+
+## Responsive Behavior
+- **Desktop (1440px):** <layout description>
+- **Tablet (768px):** <what changes — e.g., "maintains 2-column, gap reduces to 16px">
+- **Mobile (390px):** <what changes — e.g., "stacks to single column, images full-width">
+- **Breakpoint:** layout switches at ~<N>px
+```
+
+Fill every section. If a section doesn't apply (e.g., no states for a static footer), write "N/A" — but think twice before marking States & Behaviors as N/A. Even a footer might have hover states on links.
+
+### Step 3: Dispatch Builders
+
+Based on complexity, dispatch builder agent(s) in worktree(s):
+
+**Simple section** (1-2 sub-components): One builder agent gets the entire section.
+
+**Complex section** (3+ distinct sub-components): Break it up. One agent per sub-component, plus one agent for the section wrapper that imports them. Sub-component builders go first since the wrapper depends on them.
+
+**What every builder agent receives:**
+- The full contents of its component spec file (inline in the prompt — don't say "go read the spec file")
+- Path to the section screenshot in `docs/design-references/`
+- Which shared components to import (`icons.tsx`, `cn()`, shadcn primitives)
+- The target file path (e.g., `src/components/HeroSection.tsx`)
+- Instruction to verify with `npx tsc --noEmit` before finishing
+- For responsive behavior: the specific breakpoint values and what changes
+
+**Don't wait.** As soon as you've dispatched the builder(s) for one section, move to extracting the next section. Builders work in parallel in their worktrees while you continue extraction.
+
+### Step 4: Merge
+
+As builder agents complete their work:
+- Merge their worktree branches into main
+- You have full context on what each agent built, so resolve any conflicts intelligently
+- After each merge, verify the build still passes: `npm run build`
+- If a merge introduces type errors, fix them immediately
+
+The extract → spec → dispatch → merge cycle continues until all sections are built.
+
+## Phase 4: Page Assembly
+
+After all sections are built and merged, wire everything together in `src/app/page.tsx`:
+
+- Import all section components
+- Implement the page-level layout from your topology doc (scroll containers, column structures, sticky positioning, z-index layering)
+- Connect real content to component props
+- Implement page-level behaviors: scroll snap, scroll-driven animations, dark-to-light transitions, intersection observers, smooth scroll (Lenis etc.)
+- Verify: `npm run build` passes clean
+
+## Phase 5: Visual QA Diff
+
+After assembly, do NOT declare the clone complete. Take side-by-side comparison screenshots:
+
+1. Open the original site and your clone side-by-side (or take screenshots at the same viewport widths)
+2. Compare section by section, top to bottom, at desktop (1440px)
+3. Compare again at mobile (390px)
+4. For each discrepancy found:
+   - Check the component spec file — was the value extracted correctly?
+   - If the spec was wrong: re-extract from browser MCP, update the spec, fix the component
+   - If the spec was right but the builder got it wrong: fix the component to match the spec
+5. Test all interactive behaviors: scroll through the page, click every button/tab, hover over interactive elements
+6. Verify smooth scroll feels right, header transitions work, tab switching works, animations play
+
+Only after this visual QA pass is the clone complete.
+
+## Pre-Dispatch Checklist
+
+Before dispatching ANY builder agent, verify you can check every box. If you can't, go back and extract more.
+
+- [ ] Spec file written to `docs/research/components/<name>.spec.md` with ALL sections filled
+- [ ] Every CSS value in the spec is from `getComputedStyle()`, not estimated
+- [ ] Interaction model is identified and documented (static / click / scroll / time)
+- [ ] For stateful components: every state's content and styles are captured
+- [ ] For scroll-driven components: trigger threshold, before/after styles, and transition are recorded
+- [ ] For hover states: before/after values and transition timing are recorded
+- [ ] All images in the section are identified (including overlays and layered compositions)
+- [ ] Responsive behavior is documented for at least desktop and mobile
+- [ ] Text content is verbatim from the site, not paraphrased
+- [ ] The builder prompt is under ~150 lines of spec; if over, the section needs to be split
+
+## What NOT to Do
+
+These are lessons from previous failed clones — each one cost hours of rework:
+
+- **Don't build click-based tabs when the original is scroll-driven (or vice versa).** Determine the interaction model FIRST by scrolling before clicking. This is the #1 most expensive mistake — it requires a complete rewrite, not a CSS fix.
+- **Don't extract only the default state.** If there are tabs showing "Featured" on load, click Productivity, Creative, Lifestyle and extract each one's cards/content. If the header changes on scroll, capture styles at position 0 AND position 100+.
+- **Don't miss overlay/layered images.** A background watercolor + foreground UI mockup = 2 images. Check every container's DOM tree for multiple `<img>` elements and positioned overlays.
+- **Don't build mockup components for content that's actually videos/animations.** Check if a section uses `<video>`, Lottie, or canvas before building elaborate HTML mockups of what the video shows.
+- **Don't approximate CSS classes.** "It looks like `text-lg`" is wrong if the computed value is `18px` and `text-lg` is `18px/28px` but the actual line-height is `24px`. Extract exact values.
+- **Don't build everything in one monolithic commit.** The whole point of this pipeline is incremental progress with verified builds at each step.
+- **Don't reference docs from builder prompts.** Each builder gets the CSS spec inline in its prompt — never "see DESIGN_TOKENS.md for colors." The builder should have zero need to read external docs.
+- **Don't skip asset extraction.** Without real images, videos, and fonts, the clone will always look fake regardless of how perfect the CSS is.
+- **Don't give a builder agent too much scope.** If you're writing a builder prompt and it's getting long because the section is complex, that's a signal to break it into smaller tasks.
+- **Don't bundle unrelated sections into one agent.** A CTA section and a footer are different components with different designs — don't hand them both to one agent and hope for the best.
+- **Don't skip responsive extraction.** If you only inspect at desktop width, the clone will break at tablet and mobile. Test at 1440, 768, and 390 during extraction.
+- **Don't forget smooth scroll libraries.** Check for Lenis (`.lenis` class), Locomotive Scroll, or similar. Default browser scrolling feels noticeably different and the user will spot it immediately.
+- **Don't dispatch builders without a spec file.** The spec file forces exhaustive extraction and creates an auditable artifact. Skipping it means the builder gets whatever you can fit in a prompt from memory.
+
+## Completion
+
+When done, report:
+- Total sections built
+- Total components created
+- Total spec files written (should match components)
+- Total assets downloaded (images, videos, SVGs, fonts)
+- Build status (`npm run build` result)
+- Visual QA results (any remaining discrepancies)
+- Any known gaps or limitations

--- a/skills/clone-website/evals/evals.json
+++ b/skills/clone-website/evals/evals.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "clone-website",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "/clone-website https://example.com",
+      "expected_output": "Should start Phase 1 Reconnaissance: take full-page screenshots at 1440px, 768px, and 390px breakpoints. Should extract design tokens (fonts, colors, spacing). Should perform interaction sweep (scroll, hover, click). Should map page topology into sections before building anything. Should NOT skip to building components without completing recon.",
+      "assertions": [
+        "Takes screenshots at multiple breakpoints",
+        "Extracts design tokens (fonts, colors)",
+        "Performs interaction sweep",
+        "Maps page into sections/components",
+        "Does not skip reconnaissance phase"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "/clone-website https://example.com https://example.com/pricing",
+      "expected_output": "Should handle multiple URLs in one invocation. Should perform recon on each page separately. Should identify shared components across pages (navbar, footer). Should build shared components once and reuse. Should create separate page routes for each URL.",
+      "assertions": [
+        "Accepts multiple URLs",
+        "Performs recon on each page",
+        "Identifies shared components",
+        "Creates separate routes per page"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Clone this website and make it pixel-perfect: https://example.com",
+      "expected_output": "Should trigger the clone-website skill from natural language. Should extract exact CSS values using getComputedStyle(), not estimates. Should write component spec files to docs/research/components/ before dispatching builders. Should dispatch parallel builder agents in git worktrees. Should run Visual QA diff comparing original vs clone at the end.",
+      "assertions": [
+        "Triggers from natural language request",
+        "Uses getComputedStyle() for exact values",
+        "Writes spec files before building",
+        "Dispatches parallel builder agents",
+        "Runs visual QA comparison"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/clone-website/references/INSPECTION_GUIDE.md
+++ b/skills/clone-website/references/INSPECTION_GUIDE.md
@@ -1,0 +1,80 @@
+# Website Inspection Guide
+
+## How to Reverse-Engineer Any Website
+
+This guide outlines what to capture when inspecting a target website via Chrome MCP or browser DevTools.
+
+## Phase 1: Visual Audit
+
+### Screenshots to Capture
+- [ ] Every distinct page — desktop, tablet, mobile
+- [ ] Dark mode variants (if applicable)
+- [ ] Light mode variants (if applicable)
+- [ ] Key interaction states (hover, active, open menus, modals)
+- [ ] Loading/skeleton states
+- [ ] Empty states
+- [ ] Error states
+
+### Design Tokens to Extract
+- [ ] **Colors** — background, text (primary/secondary/muted), accent, border, hover, error, success, warning
+- [ ] **Typography** — font family, sizes (h1-h6, body, caption, label), weights, line heights, letter spacing
+- [ ] **Spacing** — padding/margin patterns (look for a scale: 4px, 8px, 12px, 16px, 24px, 32px, etc.)
+- [ ] **Border radius** — buttons, cards, avatars, inputs
+- [ ] **Shadows/elevation** — card shadows, dropdown shadows, modal overlay
+- [ ] **Breakpoints** — when does the layout shift? (inspect with DevTools responsive mode)
+- [ ] **Icons** — which icon library? custom SVGs? sizes?
+- [ ] **Avatars** — sizes, shapes, fallback behavior
+- [ ] **Buttons** — all variants (primary, secondary, ghost, icon-only, danger)
+- [ ] **Inputs** — text fields, textareas, selects, checkboxes, toggles
+
+## Phase 2: Component Inventory
+
+For each distinct UI component, document:
+1. **Name** — what would you call this component?
+2. **Structure** — what HTML elements / child components does it contain?
+3. **Variants** — does it have different sizes, colors, or states?
+4. **States** — default, hover, active, disabled, loading, error, empty
+5. **Responsive behavior** — how does it change at different breakpoints?
+6. **Interactions** — click, hover, focus, keyboard navigation
+7. **Animations** — transitions, entrance/exit animations, micro-interactions
+
+### Common Components to Look For
+- Navigation (top bar, sidebar, bottom bar)
+- Cards / list items
+- Buttons and links
+- Forms and inputs
+- Modals and dialogs
+- Dropdowns and menus
+- Tabs and segmented controls
+- Avatars and user badges
+- Loading skeletons
+- Toast notifications
+- Tooltips and popovers
+
+## Phase 3: Layout Architecture
+
+- [ ] **Grid system** — CSS Grid? Flexbox? Fixed widths?
+- [ ] **Column layout** — how many columns at each breakpoint?
+- [ ] **Max-width** — main content area max-width
+- [ ] **Sticky elements** — header, sidebar, floating buttons
+- [ ] **Z-index layers** — navigation, modals, tooltips, overlays
+- [ ] **Scroll behavior** — infinite scroll, pagination, virtual scrolling
+
+## Phase 4: Technical Stack Analysis
+
+- [ ] **Framework** — React? Vue? Angular? Check `__NEXT_DATA__`, `__NUXT__`, `ng-version`
+- [ ] **CSS approach** — Tailwind (utility classes), CSS Modules, Styled Components, Emotion, vanilla CSS
+- [ ] **State management** — Redux (check DevTools), React Query, Zustand, Pinia
+- [ ] **API patterns** — REST, GraphQL (check network tab for `/graphql` requests)
+- [ ] **Font loading** — Google Fonts, self-hosted, system fonts
+- [ ] **Image strategy** — CDN, lazy loading, srcset, WebP/AVIF
+- [ ] **Animation library** — Framer Motion, GSAP, CSS transitions only
+
+## Phase 5: Documentation Output
+
+After inspection, create these files in `docs/research/`:
+1. `DESIGN_TOKENS.md` — All extracted colors, typography, spacing
+2. `COMPONENT_INVENTORY.md` — Every component with structure notes
+3. `LAYOUT_ARCHITECTURE.md` — Page layouts, grid system, responsive behavior
+4. `INTERACTION_PATTERNS.md` — Animations, transitions, hover states
+5. `TECH_STACK_ANALYSIS.md` — What the site uses and our chosen equivalents

--- a/skills/notebooklm/AUTHENTICATION.md
+++ b/skills/notebooklm/AUTHENTICATION.md
@@ -1,0 +1,154 @@
+# Authentication Architecture
+
+## Overview
+
+This skill uses a **hybrid authentication approach** that combines the best of both worlds:
+
+1. **Persistent Browser Profile** (`user_data_dir`) for consistent browser fingerprinting
+2. **Manual Cookie Injection** from `state.json` for reliable session cookie persistence
+
+## Why This Approach?
+
+### The Problem
+
+Playwright/Patchright has a known bug ([#36139](https://github.com/microsoft/playwright/issues/36139)) where **session cookies** (cookies without an `Expires` attribute) do not persist correctly when using `launch_persistent_context()` with `user_data_dir`.
+
+**What happens:**
+- ✅ Persistent cookies (with `Expires` date) → Saved correctly to browser profile
+- ❌ Session cookies (without `Expires`) → **Lost after browser restarts**
+
+**Impact:**
+- Some Google auth cookies are session cookies
+- Users experience random authentication failures
+- "Works on my machine" syndrome (depends on which cookies Google uses)
+
+### TypeScript vs Python
+
+The **MCP Server** (TypeScript) can work around this by passing `storage_state` as a parameter:
+
+```typescript
+// TypeScript - works!
+const context = await chromium.launchPersistentContext(userDataDir, {
+  storageState: "state.json",  // ← Loads cookies including session cookies
+  channel: "chrome"
+});
+```
+
+But **Python's Playwright API doesn't support this** ([#14949](https://github.com/microsoft/playwright/issues/14949)):
+
+```python
+# Python - NOT SUPPORTED!
+context = playwright.chromium.launch_persistent_context(
+    user_data_dir=profile_dir,
+    storage_state="state.json",  # ← Parameter not available in Python!
+    channel="chrome"
+)
+```
+
+## Our Solution: Hybrid Approach
+
+We use a **two-phase authentication system**:
+
+### Phase 1: Setup (`auth_manager.py setup`)
+
+1. Launch persistent context with `user_data_dir`
+2. User logs in manually
+3. **Save state to TWO places:**
+   - Browser profile directory (automatic, for fingerprint + persistent cookies)
+   - `state.json` file (explicit save, for session cookies)
+
+```python
+context = playwright.chromium.launch_persistent_context(
+    user_data_dir="browser_profile/",
+    channel="chrome"
+)
+# User logs in...
+context.storage_state(path="state.json")  # Save all cookies
+```
+
+### Phase 2: Runtime (`ask_question.py`)
+
+1. Launch persistent context with `user_data_dir` (loads fingerprint + persistent cookies)
+2. **Manually inject cookies** from `state.json` (adds session cookies)
+
+```python
+# Step 1: Launch with browser profile
+context = playwright.chromium.launch_persistent_context(
+    user_data_dir="browser_profile/",
+    channel="chrome"
+)
+
+# Step 2: Manually inject cookies from state.json
+with open("state.json", 'r') as f:
+    state = json.load(f)
+    context.add_cookies(state['cookies'])  # ← Workaround for session cookies!
+```
+
+## Benefits
+
+| Feature | Our Approach | Pure `user_data_dir` | Pure `storage_state` |
+|---------|--------------|----------------------|----------------------|
+| **Browser Fingerprint Consistency** | ✅ Same across restarts | ✅ Same | ❌ Changes each time |
+| **Session Cookie Persistence** | ✅ Manual injection | ❌ Lost (bug) | ✅ Native support |
+| **Persistent Cookie Persistence** | ✅ Automatic | ✅ Automatic | ✅ Native support |
+| **Google Trust** | ✅ High (same browser) | ✅ High | ❌ Low (new browser) |
+| **Cross-platform Reliability** | ✅ Chrome required | ⚠️ Chromium issues | ✅ Portable |
+| **Cache Performance** | ✅ Keeps cache | ✅ Keeps cache | ❌ No cache |
+
+## File Structure
+
+```
+~/.claude/skills/notebooklm/data/
+├── auth_info.json              # Metadata about authentication
+├── browser_state/
+│   ├── state.json             # Cookies + localStorage (for manual injection)
+│   └── browser_profile/       # Chrome user profile (for fingerprint + cache)
+│       ├── Default/
+│       │   ├── Cookies        # Persistent cookies only (session cookies missing!)
+│       │   ├── Local Storage/
+│       │   └── Cache/
+│       └── ...
+```
+
+## Why `state.json` is Critical
+
+Even though we use `user_data_dir`, we **still need `state.json`** because:
+
+1. **Session cookies** are not saved to the browser profile (Playwright bug)
+2. **Manual injection** is the only reliable way to load session cookies
+3. **Validation** - we can check if cookies are expired before launching
+
+## Code References
+
+**Setup:** `scripts/auth_manager.py:94-120`
+- Lines 100-113: Launch persistent context with `channel="chrome"`
+- Line 167: Save to `state.json` via `context.storage_state()`
+
+**Runtime:** `scripts/ask_question.py:77-118`
+- Lines 86-99: Launch persistent context
+- Lines 101-118: Manual cookie injection workaround
+
+**Validation:** `scripts/auth_manager.py:236-298`
+- Lines 262-275: Launch persistent context
+- Lines 277-287: Manual cookie injection for validation
+
+## Related Issues
+
+- [microsoft/playwright#36139](https://github.com/microsoft/playwright/issues/36139) - Session cookies not persisting
+- [microsoft/playwright#14949](https://github.com/microsoft/playwright/issues/14949) - Storage state with persistent context
+- [StackOverflow Question](https://stackoverflow.com/questions/79641481/) - Session cookie persistence issue
+
+## Future Improvements
+
+If Playwright adds support for `storage_state` parameter in Python's `launch_persistent_context()`, we can simplify to:
+
+```python
+# Future (when Python API supports it):
+context = playwright.chromium.launch_persistent_context(
+    user_data_dir="browser_profile/",
+    storage_state="state.json",  # ← Would handle everything automatically!
+    channel="chrome"
+)
+```
+
+Until then, our hybrid approach is the most reliable solution.

--- a/skills/notebooklm/SKILL.md
+++ b/skills/notebooklm/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: notebooklm
+description: Use this skill to query your Google NotebookLM notebooks directly from Claude Code for source-grounded, citation-backed answers from Gemini. Browser automation, library management, persistent auth. Drastically reduced hallucinations through document-only responses.
+---
+
+# NotebookLM Research Assistant Skill
+
+Interact with Google NotebookLM to query documentation with Gemini's source-grounded answers. Each question opens a fresh browser session, retrieves the answer exclusively from your uploaded documents, and closes.
+
+## When to Use This Skill
+
+Trigger when user:
+- Mentions NotebookLM explicitly
+- Shares NotebookLM URL (`https://notebooklm.google.com/notebook/...`)
+- Asks to query their notebooks/documentation
+- Wants to add documentation to NotebookLM library
+- Uses phrases like "ask my NotebookLM", "check my docs", "query my notebook"
+
+## ⚠️ CRITICAL: Add Command - Smart Discovery
+
+When user wants to add a notebook without providing details:
+
+**SMART ADD (Recommended)**: Query the notebook first to discover its content:
+```bash
+# Step 1: Query the notebook about its content
+python scripts/run.py ask_question.py --question "What is the content of this notebook? What topics are covered? Provide a complete overview briefly and concisely" --notebook-url "[URL]"
+
+# Step 2: Use the discovered information to add it
+python scripts/run.py notebook_manager.py add --url "[URL]" --name "[Based on content]" --description "[Based on content]" --topics "[Based on content]"
+```
+
+**MANUAL ADD**: If user provides all details:
+- `--url` - The NotebookLM URL
+- `--name` - A descriptive name
+- `--description` - What the notebook contains (REQUIRED!)
+- `--topics` - Comma-separated topics (REQUIRED!)
+
+NEVER guess or use generic descriptions! If details missing, use Smart Add to discover them.
+
+## Critical: Always Use run.py Wrapper
+
+**NEVER call scripts directly. ALWAYS use `python scripts/run.py [script]`:**
+
+```bash
+# ✅ CORRECT - Always use run.py:
+python scripts/run.py auth_manager.py status
+python scripts/run.py notebook_manager.py list
+python scripts/run.py ask_question.py --question "..."
+
+# ❌ WRONG - Never call directly:
+python scripts/auth_manager.py status  # Fails without venv!
+```
+
+The `run.py` wrapper automatically:
+1. Creates `.venv` if needed
+2. Installs all dependencies
+3. Activates environment
+4. Executes script properly
+
+## Core Workflow
+
+### Step 1: Check Authentication Status
+```bash
+python scripts/run.py auth_manager.py status
+```
+
+If not authenticated, proceed to setup.
+
+### Step 2: Authenticate (One-Time Setup)
+```bash
+# Browser MUST be visible for manual Google login
+python scripts/run.py auth_manager.py setup
+```
+
+**Important:**
+- Browser is VISIBLE for authentication
+- Browser window opens automatically
+- User must manually log in to Google
+- Tell user: "A browser window will open for Google login"
+
+### Step 3: Manage Notebook Library
+
+```bash
+# List all notebooks
+python scripts/run.py notebook_manager.py list
+
+# BEFORE ADDING: Ask user for metadata if unknown!
+# "What does this notebook contain?"
+# "What topics should I tag it with?"
+
+# Add notebook to library (ALL parameters are REQUIRED!)
+python scripts/run.py notebook_manager.py add \
+  --url "https://notebooklm.google.com/notebook/..." \
+  --name "Descriptive Name" \
+  --description "What this notebook contains" \  # REQUIRED - ASK USER IF UNKNOWN!
+  --topics "topic1,topic2,topic3"  # REQUIRED - ASK USER IF UNKNOWN!
+
+# Search notebooks by topic
+python scripts/run.py notebook_manager.py search --query "keyword"
+
+# Set active notebook
+python scripts/run.py notebook_manager.py activate --id notebook-id
+
+# Remove notebook
+python scripts/run.py notebook_manager.py remove --id notebook-id
+```
+
+### Quick Workflow
+1. Check library: `python scripts/run.py notebook_manager.py list`
+2. Ask question: `python scripts/run.py ask_question.py --question "..." --notebook-id ID`
+
+### Step 4: Ask Questions
+
+```bash
+# Basic query (uses active notebook if set)
+python scripts/run.py ask_question.py --question "Your question here"
+
+# Query specific notebook
+python scripts/run.py ask_question.py --question "..." --notebook-id notebook-id
+
+# Query with notebook URL directly
+python scripts/run.py ask_question.py --question "..." --notebook-url "https://..."
+
+# Show browser for debugging
+python scripts/run.py ask_question.py --question "..." --show-browser
+```
+
+## Follow-Up Mechanism (CRITICAL)
+
+Every NotebookLM answer ends with: **"EXTREMELY IMPORTANT: Is that ALL you need to know?"**
+
+**Required Claude Behavior:**
+1. **STOP** - Do not immediately respond to user
+2. **ANALYZE** - Compare answer to user's original request
+3. **IDENTIFY GAPS** - Determine if more information needed
+4. **ASK FOLLOW-UP** - If gaps exist, immediately ask:
+   ```bash
+   python scripts/run.py ask_question.py --question "Follow-up with context..."
+   ```
+5. **REPEAT** - Continue until information is complete
+6. **SYNTHESIZE** - Combine all answers before responding to user
+
+## Script Reference
+
+### Authentication Management (`auth_manager.py`)
+```bash
+python scripts/run.py auth_manager.py setup    # Initial setup (browser visible)
+python scripts/run.py auth_manager.py status   # Check authentication
+python scripts/run.py auth_manager.py reauth   # Re-authenticate (browser visible)
+python scripts/run.py auth_manager.py clear    # Clear authentication
+```
+
+### Notebook Management (`notebook_manager.py`)
+```bash
+python scripts/run.py notebook_manager.py add --url URL --name NAME --description DESC --topics TOPICS
+python scripts/run.py notebook_manager.py list
+python scripts/run.py notebook_manager.py search --query QUERY
+python scripts/run.py notebook_manager.py activate --id ID
+python scripts/run.py notebook_manager.py remove --id ID
+python scripts/run.py notebook_manager.py stats
+```
+
+### Question Interface (`ask_question.py`)
+```bash
+python scripts/run.py ask_question.py --question "..." [--notebook-id ID] [--notebook-url URL] [--show-browser]
+```
+
+### Data Cleanup (`cleanup_manager.py`)
+```bash
+python scripts/run.py cleanup_manager.py                    # Preview cleanup
+python scripts/run.py cleanup_manager.py --confirm          # Execute cleanup
+python scripts/run.py cleanup_manager.py --preserve-library # Keep notebooks
+```
+
+## Environment Management
+
+The virtual environment is automatically managed:
+- First run creates `.venv` automatically
+- Dependencies install automatically
+- Chromium browser installs automatically
+- Everything isolated in skill directory
+
+Manual setup (only if automatic fails):
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Linux/Mac
+pip install -r requirements.txt
+python -m patchright install chromium
+```
+
+## Data Storage
+
+All data stored in `~/.claude/skills/notebooklm/data/`:
+- `library.json` - Notebook metadata
+- `auth_info.json` - Authentication status
+- `browser_state/` - Browser cookies and session
+
+**Security:** Protected by `.gitignore`, never commit to git.
+
+## Configuration
+
+Optional `.env` file in skill directory:
+```env
+HEADLESS=false           # Browser visibility
+SHOW_BROWSER=false       # Default browser display
+STEALTH_ENABLED=true     # Human-like behavior
+TYPING_WPM_MIN=160       # Typing speed
+TYPING_WPM_MAX=240
+DEFAULT_NOTEBOOK_ID=     # Default notebook
+```
+
+## Decision Flow
+
+```
+User mentions NotebookLM
+    ↓
+Check auth → python scripts/run.py auth_manager.py status
+    ↓
+If not authenticated → python scripts/run.py auth_manager.py setup
+    ↓
+Check/Add notebook → python scripts/run.py notebook_manager.py list/add (with --description)
+    ↓
+Activate notebook → python scripts/run.py notebook_manager.py activate --id ID
+    ↓
+Ask question → python scripts/run.py ask_question.py --question "..."
+    ↓
+See "Is that ALL you need?" → Ask follow-ups until complete
+    ↓
+Synthesize and respond to user
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| ModuleNotFoundError | Use `run.py` wrapper |
+| Authentication fails | Browser must be visible for setup! --show-browser |
+| Rate limit (50/day) | Wait or switch Google account |
+| Browser crashes | `python scripts/run.py cleanup_manager.py --preserve-library` |
+| Notebook not found | Check with `notebook_manager.py list` |
+
+## Best Practices
+
+1. **Always use run.py** - Handles environment automatically
+2. **Check auth first** - Before any operations
+3. **Follow-up questions** - Don't stop at first answer
+4. **Browser visible for auth** - Required for manual login
+5. **Include context** - Each question is independent
+6. **Synthesize answers** - Combine multiple responses
+
+## Limitations
+
+- No session persistence (each question = new browser)
+- Rate limits on free Google accounts (50 queries/day)
+- Manual upload required (user must add docs to NotebookLM)
+- Browser overhead (few seconds per question)
+
+## Resources (Skill Structure)
+
+**Important directories and files:**
+
+- `scripts/` - All automation scripts (ask_question.py, notebook_manager.py, etc.)
+- `data/` - Local storage for authentication and notebook library
+- `references/` - Extended documentation:
+  - `api_reference.md` - Detailed API documentation for all scripts
+  - `troubleshooting.md` - Common issues and solutions
+  - `usage_patterns.md` - Best practices and workflow examples
+- `.venv/` - Isolated Python environment (auto-created on first run)
+- `.gitignore` - Protects sensitive data from being committed

--- a/skills/notebooklm/evals/evals.json
+++ b/skills/notebooklm/evals/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "notebooklm",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Ask my NotebookLM about the key findings in my research docs",
+      "expected_output": "Should trigger from natural language mentioning NotebookLM or querying docs. Should use the run.py wrapper (never call scripts directly). Should use ask_question.py with --question flag. Should require a notebook URL or check the library for a matching notebook. Should return source-grounded, citation-backed answer.",
+      "assertions": [
+        "Triggers from natural language request",
+        "Uses run.py wrapper to call scripts",
+        "Uses ask_question.py with proper flags",
+        "Requires or looks up notebook URL",
+        "Returns citation-backed answer"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Add this notebook to my library: https://notebooklm.google.com/notebook/abc123",
+      "expected_output": "Should use Smart Add workflow — query the notebook first to discover content, then use notebook_manager.py add with discovered --name, --description, and --topics. Should never guess or use generic descriptions. Should always use run.py wrapper.",
+      "assertions": [
+        "Uses Smart Add to discover content first",
+        "Queries notebook before adding",
+        "Uses notebook_manager.py add with all required flags",
+        "Never uses generic descriptions",
+        "Uses run.py wrapper"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "What notebooks do I have in my NotebookLM library?",
+      "expected_output": "Should use notebook_manager.py list via run.py wrapper. Should display notebook names, descriptions, and topics from the library.",
+      "assertions": [
+        "Uses notebook_manager.py list command",
+        "Uses run.py wrapper",
+        "Displays library contents"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/notebooklm/references/api_reference.md
+++ b/skills/notebooklm/references/api_reference.md
@@ -1,0 +1,309 @@
+# NotebookLM Skill API Reference
+
+Complete API documentation for all NotebookLM skill modules.
+
+## Important: Always Use run.py Wrapper
+
+**All commands must use the `run.py` wrapper to ensure proper environment:**
+
+```bash
+# ✅ CORRECT:
+python scripts/run.py [script_name].py [arguments]
+
+# ❌ WRONG:
+python scripts/[script_name].py [arguments]  # Will fail without venv!
+```
+
+## Core Scripts
+
+### ask_question.py
+Query NotebookLM with automated browser interaction.
+
+```bash
+# Basic usage
+python scripts/run.py ask_question.py --question "Your question"
+
+# With specific notebook
+python scripts/run.py ask_question.py --question "..." --notebook-id notebook-id
+
+# With direct URL
+python scripts/run.py ask_question.py --question "..." --notebook-url "https://..."
+
+# Show browser (debugging)
+python scripts/run.py ask_question.py --question "..." --show-browser
+```
+
+**Parameters:**
+- `--question` (required): Question to ask
+- `--notebook-id`: Use notebook from library
+- `--notebook-url`: Use URL directly
+- `--show-browser`: Make browser visible
+
+**Returns:** Answer text with follow-up prompt appended
+
+### notebook_manager.py
+Manage notebook library with CRUD operations.
+
+```bash
+# Smart Add (discover content first)
+python scripts/run.py ask_question.py --question "What is the content of this notebook? What topics are covered? Provide a complete overview briefly and concisely" --notebook-url "[URL]"
+# Then add with discovered info
+python scripts/run.py notebook_manager.py add \
+  --url "https://notebooklm.google.com/notebook/..." \
+  --name "Name" \
+  --description "Description" \
+  --topics "topic1,topic2"
+
+# Direct add (when you know the content)
+python scripts/run.py notebook_manager.py add \
+  --url "https://notebooklm.google.com/notebook/..." \
+  --name "Name" \
+  --description "What it contains" \
+  --topics "topic1,topic2"
+
+# List notebooks
+python scripts/run.py notebook_manager.py list
+
+# Search notebooks
+python scripts/run.py notebook_manager.py search --query "keyword"
+
+# Activate notebook
+python scripts/run.py notebook_manager.py activate --id notebook-id
+
+# Remove notebook
+python scripts/run.py notebook_manager.py remove --id notebook-id
+
+# Show statistics
+python scripts/run.py notebook_manager.py stats
+```
+
+**Commands:**
+- `add`: Add notebook (requires --url, --name, --topics)
+- `list`: Show all notebooks
+- `search`: Find notebooks by keyword
+- `activate`: Set default notebook
+- `remove`: Delete from library
+- `stats`: Display library statistics
+
+### auth_manager.py
+Handle Google authentication and browser state.
+
+```bash
+# Setup (browser visible for login)
+python scripts/run.py auth_manager.py setup
+
+# Check status
+python scripts/run.py auth_manager.py status
+
+# Re-authenticate
+python scripts/run.py auth_manager.py reauth
+
+# Clear authentication
+python scripts/run.py auth_manager.py clear
+```
+
+**Commands:**
+- `setup`: Initial authentication (browser MUST be visible)
+- `status`: Check if authenticated
+- `reauth`: Clear and re-setup
+- `clear`: Remove all auth data
+
+### cleanup_manager.py
+Clean skill data with preservation options.
+
+```bash
+# Preview cleanup
+python scripts/run.py cleanup_manager.py
+
+# Execute cleanup
+python scripts/run.py cleanup_manager.py --confirm
+
+# Keep library
+python scripts/run.py cleanup_manager.py --confirm --preserve-library
+
+# Force without prompt
+python scripts/run.py cleanup_manager.py --confirm --force
+```
+
+**Options:**
+- `--confirm`: Actually perform cleanup
+- `--preserve-library`: Keep notebook library
+- `--force`: Skip confirmation prompt
+
+### run.py
+Script wrapper that handles environment setup.
+
+```bash
+# Usage
+python scripts/run.py [script_name].py [arguments]
+
+# Examples
+python scripts/run.py auth_manager.py status
+python scripts/run.py ask_question.py --question "..."
+```
+
+**Automatic actions:**
+1. Creates `.venv` if missing
+2. Installs dependencies
+3. Activates environment
+4. Executes target script
+
+## Python API Usage
+
+### Using subprocess with run.py
+
+```python
+import subprocess
+import json
+
+# Always use run.py wrapper
+result = subprocess.run([
+    "python", "scripts/run.py", "ask_question.py",
+    "--question", "Your question",
+    "--notebook-id", "notebook-id"
+], capture_output=True, text=True)
+
+answer = result.stdout
+```
+
+### Direct imports (after venv exists)
+
+```python
+# Only works if venv is already created and activated
+from notebook_manager import NotebookLibrary
+from auth_manager import AuthManager
+
+library = NotebookLibrary()
+notebooks = library.list_notebooks()
+
+auth = AuthManager()
+is_auth = auth.is_authenticated()
+```
+
+## Data Storage
+
+Location: `~/.claude/skills/notebooklm/data/`
+
+```
+data/
+├── library.json       # Notebook metadata
+├── auth_info.json     # Auth status
+└── browser_state/     # Browser cookies
+    └── state.json
+```
+
+**Security:** Protected by `.gitignore`, never commit.
+
+## Environment Variables
+
+Optional `.env` file configuration:
+
+```env
+HEADLESS=false           # Browser visibility
+SHOW_BROWSER=false       # Default display
+STEALTH_ENABLED=true     # Human behavior
+TYPING_WPM_MIN=160       # Typing speed
+TYPING_WPM_MAX=240
+DEFAULT_NOTEBOOK_ID=     # Default notebook
+```
+
+## Error Handling
+
+Common patterns:
+
+```python
+# Using run.py prevents most errors
+result = subprocess.run([
+    "python", "scripts/run.py", "ask_question.py",
+    "--question", "Question"
+], capture_output=True, text=True)
+
+if result.returncode != 0:
+    error = result.stderr
+    if "rate limit" in error.lower():
+        # Wait or switch accounts
+        pass
+    elif "not authenticated" in error.lower():
+        # Run auth setup
+        subprocess.run(["python", "scripts/run.py", "auth_manager.py", "setup"])
+```
+
+## Rate Limits
+
+Free Google accounts: 50 queries/day
+
+Solutions:
+1. Wait for reset (midnight PST)
+2. Switch accounts with `reauth`
+3. Use multiple Google accounts
+
+## Advanced Patterns
+
+### Parallel Queries
+
+```python
+import concurrent.futures
+import subprocess
+
+def query(question, notebook_id):
+    result = subprocess.run([
+        "python", "scripts/run.py", "ask_question.py",
+        "--question", question,
+        "--notebook-id", notebook_id
+    ], capture_output=True, text=True)
+    return result.stdout
+
+# Run multiple queries simultaneously
+with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+    futures = [
+        executor.submit(query, q, nb)
+        for q, nb in zip(questions, notebooks)
+    ]
+    results = [f.result() for f in futures]
+```
+
+### Batch Processing
+
+```python
+def batch_research(questions, notebook_id):
+    results = []
+    for question in questions:
+        result = subprocess.run([
+            "python", "scripts/run.py", "ask_question.py",
+            "--question", question,
+            "--notebook-id", notebook_id
+        ], capture_output=True, text=True)
+        results.append(result.stdout)
+        time.sleep(2)  # Avoid rate limits
+    return results
+```
+
+## Module Classes
+
+### NotebookLibrary
+- `add_notebook(url, name, topics)`
+- `list_notebooks()`
+- `search_notebooks(query)`
+- `get_notebook(notebook_id)`
+- `activate_notebook(notebook_id)`
+- `remove_notebook(notebook_id)`
+
+### AuthManager
+- `is_authenticated()`
+- `setup_auth(headless=False)`
+- `get_auth_info()`
+- `clear_auth()`
+- `validate_auth()`
+
+### BrowserSession (internal)
+- Handles browser automation
+- Manages stealth behavior
+- Not intended for direct use
+
+## Best Practices
+
+1. **Always use run.py** - Ensures environment
+2. **Check auth first** - Before operations
+3. **Handle rate limits** - Implement retries
+4. **Include context** - Questions are independent
+5. **Clean sessions** - Use cleanup_manager

--- a/skills/notebooklm/references/troubleshooting.md
+++ b/skills/notebooklm/references/troubleshooting.md
@@ -1,0 +1,376 @@
+# NotebookLM Skill Troubleshooting Guide
+
+## Quick Fix Table
+
+| Error | Solution |
+|-------|----------|
+| ModuleNotFoundError | Use `python scripts/run.py [script].py` |
+| Authentication failed | Browser must be visible for setup |
+| Browser crash | `python scripts/run.py cleanup_manager.py --preserve-library` |
+| Rate limit hit | Wait 1 hour or switch accounts |
+| Notebook not found | `python scripts/run.py notebook_manager.py list` |
+| Script not working | Always use run.py wrapper |
+
+## Critical: Always Use run.py
+
+Most issues are solved by using the run.py wrapper:
+
+```bash
+# ✅ CORRECT - Always:
+python scripts/run.py auth_manager.py status
+python scripts/run.py ask_question.py --question "..."
+
+# ❌ WRONG - Never:
+python scripts/auth_manager.py status  # ModuleNotFoundError!
+```
+
+## Common Issues and Solutions
+
+### Authentication Issues
+
+#### Not authenticated error
+```
+Error: Not authenticated. Please run auth setup first.
+```
+
+**Solution:**
+```bash
+# Check status
+python scripts/run.py auth_manager.py status
+
+# Setup authentication (browser MUST be visible!)
+python scripts/run.py auth_manager.py setup
+# User must manually log in to Google
+
+# If setup fails, try re-authentication
+python scripts/run.py auth_manager.py reauth
+```
+
+#### Authentication expires frequently
+**Solution:**
+```bash
+# Clear old authentication
+python scripts/run.py cleanup_manager.py --preserve-library
+
+# Fresh authentication setup
+python scripts/run.py auth_manager.py setup --timeout 15
+
+# Use persistent browser profile
+export PERSIST_AUTH=true
+```
+
+#### Google blocks automated login
+**Solution:**
+1. Use dedicated Google account for automation
+2. Enable "Less secure app access" if available
+3. ALWAYS use visible browser:
+```bash
+python scripts/run.py auth_manager.py setup
+# Browser MUST be visible - user logs in manually
+# NO headless parameter exists - use --show-browser for debugging
+```
+
+### Browser Issues
+
+#### Browser crashes or hangs
+```
+TimeoutError: Waiting for selector failed
+```
+
+**Solution:**
+```bash
+# Kill hanging processes
+pkill -f chromium
+pkill -f chrome
+
+# Clean browser state
+python scripts/run.py cleanup_manager.py --confirm --preserve-library
+
+# Re-authenticate
+python scripts/run.py auth_manager.py reauth
+```
+
+#### Browser not found error
+**Solution:**
+```bash
+# Install Chromium via run.py (automatic)
+python scripts/run.py auth_manager.py status
+# run.py will install Chromium automatically
+
+# Or manual install if needed
+cd ~/.claude/skills/notebooklm
+source .venv/bin/activate
+python -m patchright install chromium
+```
+
+### Rate Limiting
+
+#### Rate limit exceeded (50 queries/day)
+**Solutions:**
+
+**Option 1: Wait**
+```bash
+# Check when limit resets (usually midnight PST)
+date -d "tomorrow 00:00 PST"
+```
+
+**Option 2: Switch accounts**
+```bash
+# Clear current auth
+python scripts/run.py auth_manager.py clear
+
+# Login with different account
+python scripts/run.py auth_manager.py setup
+```
+
+**Option 3: Rotate accounts**
+```python
+# Use multiple accounts
+accounts = ["account1", "account2"]
+for account in accounts:
+    # Switch account on rate limit
+    subprocess.run(["python", "scripts/run.py", "auth_manager.py", "reauth"])
+```
+
+### Notebook Access Issues
+
+#### Notebook not found
+**Solution:**
+```bash
+# List all notebooks
+python scripts/run.py notebook_manager.py list
+
+# Search for notebook
+python scripts/run.py notebook_manager.py search --query "keyword"
+
+# Add notebook if missing
+python scripts/run.py notebook_manager.py add \
+  --url "https://notebooklm.google.com/..." \
+  --name "Name" \
+  --topics "topics"
+```
+
+#### Access denied to notebook
+**Solution:**
+1. Check if notebook is still shared publicly
+2. Re-add notebook with updated URL
+3. Verify correct Google account is used
+
+#### Wrong notebook being used
+**Solution:**
+```bash
+# Check active notebook
+python scripts/run.py notebook_manager.py list | grep "active"
+
+# Activate correct notebook
+python scripts/run.py notebook_manager.py activate --id correct-id
+```
+
+### Virtual Environment Issues
+
+#### ModuleNotFoundError
+```
+ModuleNotFoundError: No module named 'patchright'
+```
+
+**Solution:**
+```bash
+# ALWAYS use run.py - it handles venv automatically!
+python scripts/run.py [any_script].py
+
+# run.py will:
+# 1. Create .venv if missing
+# 2. Install dependencies
+# 3. Run the script
+```
+
+#### Wrong Python version
+**Solution:**
+```bash
+# Check Python version (needs 3.8+)
+python --version
+
+# If wrong version, specify correct Python
+python3.8 scripts/run.py auth_manager.py status
+```
+
+### Network Issues
+
+#### Connection timeouts
+**Solution:**
+```bash
+# Increase timeout
+export TIMEOUT_SECONDS=60
+
+# Check connectivity
+ping notebooklm.google.com
+
+# Use proxy if needed
+export HTTP_PROXY=http://proxy:port
+export HTTPS_PROXY=http://proxy:port
+```
+
+### Data Issues
+
+#### Corrupted notebook library
+```
+JSON decode error when listing notebooks
+```
+
+**Solution:**
+```bash
+# Backup current library
+cp ~/.claude/skills/notebooklm/data/library.json library.backup.json
+
+# Reset library
+rm ~/.claude/skills/notebooklm/data/library.json
+
+# Re-add notebooks
+python scripts/run.py notebook_manager.py add --url ... --name ...
+```
+
+#### Disk space full
+**Solution:**
+```bash
+# Check disk usage
+df -h ~/.claude/skills/notebooklm/data/
+
+# Clean up
+python scripts/run.py cleanup_manager.py --confirm --preserve-library
+```
+
+## Debugging Techniques
+
+### Enable verbose logging
+```bash
+export DEBUG=true
+export LOG_LEVEL=DEBUG
+python scripts/run.py ask_question.py --question "Test" --show-browser
+```
+
+### Test individual components
+```bash
+# Test authentication
+python scripts/run.py auth_manager.py status
+
+# Test notebook access
+python scripts/run.py notebook_manager.py list
+
+# Test browser launch
+python scripts/run.py ask_question.py --question "test" --show-browser
+```
+
+### Save screenshots on error
+Add to scripts for debugging:
+```python
+try:
+    # Your code
+except Exception as e:
+    page.screenshot(path=f"error_{timestamp}.png")
+    raise e
+```
+
+## Recovery Procedures
+
+### Complete reset
+```bash
+#!/bin/bash
+# Kill processes
+pkill -f chromium
+
+# Backup library if exists
+if [ -f ~/.claude/skills/notebooklm/data/library.json ]; then
+    cp ~/.claude/skills/notebooklm/data/library.json ~/library.backup.json
+fi
+
+# Clean everything
+cd ~/.claude/skills/notebooklm
+python scripts/run.py cleanup_manager.py --confirm --force
+
+# Remove venv
+rm -rf .venv
+
+# Reinstall (run.py will handle this)
+python scripts/run.py auth_manager.py setup
+
+# Restore library if backup exists
+if [ -f ~/library.backup.json ]; then
+    mkdir -p ~/.claude/skills/notebooklm/data/
+    cp ~/library.backup.json ~/.claude/skills/notebooklm/data/library.json
+fi
+```
+
+### Partial recovery (keep data)
+```bash
+# Keep auth and library, fix execution
+cd ~/.claude/skills/notebooklm
+rm -rf .venv
+
+# run.py will recreate venv automatically
+python scripts/run.py auth_manager.py status
+```
+
+## Error Messages Reference
+
+### Authentication Errors
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Not authenticated | No valid auth | `run.py auth_manager.py setup` |
+| Authentication expired | Session old | `run.py auth_manager.py reauth` |
+| Invalid credentials | Wrong account | Check Google account |
+| 2FA required | Security challenge | Complete in visible browser |
+
+### Browser Errors
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Browser not found | Chromium missing | Use run.py (auto-installs) |
+| Connection refused | Browser crashed | Kill processes, restart |
+| Timeout waiting | Page slow | Increase timeout |
+| Context closed | Browser terminated | Check logs for crashes |
+
+### Notebook Errors
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Notebook not found | Invalid ID | `run.py notebook_manager.py list` |
+| Access denied | Not shared | Re-share in NotebookLM |
+| Invalid URL | Wrong format | Use full NotebookLM URL |
+| No active notebook | None selected | `run.py notebook_manager.py activate` |
+
+## Prevention Tips
+
+1. **Always use run.py** - Prevents 90% of issues
+2. **Regular maintenance** - Clear browser state weekly
+3. **Monitor queries** - Track daily count to avoid limits
+4. **Backup library** - Export notebook list regularly
+5. **Use dedicated account** - Separate Google account for automation
+
+## Getting Help
+
+### Diagnostic information to collect
+```bash
+# System info
+python --version
+cd ~/.claude/skills/notebooklm
+ls -la
+
+# Skill status
+python scripts/run.py auth_manager.py status
+python scripts/run.py notebook_manager.py list | head -5
+
+# Check data directory
+ls -la ~/.claude/skills/notebooklm/data/
+```
+
+### Common questions
+
+**Q: Why doesn't this work in Claude web UI?**
+A: Web UI has no network access. Use local Claude Code.
+
+**Q: Can I use multiple Google accounts?**
+A: Yes, use `run.py auth_manager.py reauth` to switch.
+
+**Q: How to increase rate limit?**
+A: Use multiple accounts or upgrade to Google Workspace.
+
+**Q: Is this safe for my Google account?**
+A: Use dedicated account for automation. Only accesses NotebookLM.

--- a/skills/notebooklm/references/usage_patterns.md
+++ b/skills/notebooklm/references/usage_patterns.md
@@ -1,0 +1,338 @@
+# NotebookLM Skill Usage Patterns
+
+Advanced patterns for using the NotebookLM skill effectively.
+
+## Critical: Always Use run.py
+
+**Every command must use the run.py wrapper:**
+```bash
+# ✅ CORRECT:
+python scripts/run.py auth_manager.py status
+python scripts/run.py ask_question.py --question "..."
+
+# ❌ WRONG:
+python scripts/auth_manager.py status  # Will fail!
+```
+
+## Pattern 1: Initial Setup
+
+```bash
+# 1. Check authentication (using run.py!)
+python scripts/run.py auth_manager.py status
+
+# 2. If not authenticated, setup (Browser MUST be visible!)
+python scripts/run.py auth_manager.py setup
+# Tell user: "Please log in to Google in the browser window"
+
+# 3. Add first notebook - ASK USER FOR DETAILS FIRST!
+# Ask: "What does this notebook contain?"
+# Ask: "What topics should I tag it with?"
+python scripts/run.py notebook_manager.py add \
+  --url "https://notebooklm.google.com/notebook/..." \
+  --name "User provided name" \
+  --description "User provided description" \  # NEVER GUESS!
+  --topics "user,provided,topics"  # NEVER GUESS!
+```
+
+**Critical Notes:**
+- Virtual environment created automatically by run.py
+- Browser MUST be visible for authentication
+- ALWAYS discover content via query OR ask user for notebook metadata
+
+## Pattern 2: Adding Notebooks (Smart Discovery!)
+
+**When user shares a NotebookLM URL:**
+
+**OPTION A: Smart Discovery (Recommended)**
+```bash
+# 1. Query the notebook to discover its content
+python scripts/run.py ask_question.py \
+  --question "What is the content of this notebook? What topics are covered? Provide a complete overview briefly and concisely" \
+  --notebook-url "[URL]"
+
+# 2. Use discovered info to add it
+python scripts/run.py notebook_manager.py add \
+  --url "[URL]" \
+  --name "[Based on content]" \
+  --description "[From discovery]" \
+  --topics "[Extracted topics]"
+```
+
+**OPTION B: Ask User (Fallback)**
+```bash
+# If discovery fails, ask user:
+"What does this notebook contain?"
+"What topics does it cover?"
+
+# Then add with user-provided info:
+python scripts/run.py notebook_manager.py add \
+  --url "[URL]" \
+  --name "[User's answer]" \
+  --description "[User's description]" \
+  --topics "[User's topics]"
+```
+
+**NEVER:**
+- Guess what's in a notebook
+- Use generic descriptions
+- Skip discovering content
+
+## Pattern 3: Daily Research Workflow
+
+```bash
+# Check library
+python scripts/run.py notebook_manager.py list
+
+# Research with comprehensive questions
+python scripts/run.py ask_question.py \
+  --question "Detailed question with all context" \
+  --notebook-id notebook-id
+
+# Follow-up when you see "Is that ALL you need to know?"
+python scripts/run.py ask_question.py \
+  --question "Follow-up question with previous context"
+```
+
+## Pattern 4: Follow-Up Questions (CRITICAL!)
+
+When NotebookLM responds with "EXTREMELY IMPORTANT: Is that ALL you need to know?":
+
+```python
+# 1. STOP - Don't respond to user yet
+# 2. ANALYZE - Is answer complete?
+# 3. If gaps exist, ask follow-up:
+python scripts/run.py ask_question.py \
+  --question "Specific follow-up with context from previous answer"
+
+# 4. Repeat until complete
+# 5. Only then synthesize and respond to user
+```
+
+## Pattern 5: Multi-Notebook Research
+
+```python
+# Query different notebooks for comparison
+python scripts/run.py notebook_manager.py activate --id notebook-1
+python scripts/run.py ask_question.py --question "Question"
+
+python scripts/run.py notebook_manager.py activate --id notebook-2
+python scripts/run.py ask_question.py --question "Same question"
+
+# Compare and synthesize answers
+```
+
+## Pattern 6: Error Recovery
+
+```bash
+# If authentication fails
+python scripts/run.py auth_manager.py status
+python scripts/run.py auth_manager.py reauth  # Browser visible!
+
+# If browser crashes
+python scripts/run.py cleanup_manager.py --preserve-library
+python scripts/run.py auth_manager.py setup  # Browser visible!
+
+# If rate limited
+# Wait or switch accounts
+python scripts/run.py auth_manager.py reauth  # Login with different account
+```
+
+## Pattern 7: Batch Processing
+
+```bash
+#!/bin/bash
+NOTEBOOK_ID="notebook-id"
+QUESTIONS=(
+    "First comprehensive question"
+    "Second comprehensive question"
+    "Third comprehensive question"
+)
+
+for question in "${QUESTIONS[@]}"; do
+    echo "Asking: $question"
+    python scripts/run.py ask_question.py \
+        --question "$question" \
+        --notebook-id "$NOTEBOOK_ID"
+    sleep 2  # Avoid rate limits
+done
+```
+
+## Pattern 8: Automated Research Script
+
+```python
+#!/usr/bin/env python
+import subprocess
+
+def research_topic(topic, notebook_id):
+    # Comprehensive question
+    question = f"""
+    Explain {topic} in detail:
+    1. Core concepts
+    2. Implementation details
+    3. Best practices
+    4. Common pitfalls
+    5. Examples
+    """
+
+    result = subprocess.run([
+        "python", "scripts/run.py", "ask_question.py",
+        "--question", question,
+        "--notebook-id", notebook_id
+    ], capture_output=True, text=True)
+
+    return result.stdout
+```
+
+## Pattern 9: Notebook Organization
+
+```python
+# Organize by domain - with proper metadata
+# ALWAYS ask user for descriptions!
+
+# Backend notebooks
+add_notebook("Backend API", "Complete API documentation", "api,rest,backend")
+add_notebook("Database", "Schema and queries", "database,sql,backend")
+
+# Frontend notebooks
+add_notebook("React Docs", "React framework documentation", "react,frontend")
+add_notebook("CSS Framework", "Styling documentation", "css,styling,frontend")
+
+# Search by domain
+python scripts/run.py notebook_manager.py search --query "backend"
+python scripts/run.py notebook_manager.py search --query "frontend"
+```
+
+## Pattern 10: Integration with Development
+
+```python
+# Query documentation during development
+def check_api_usage(api_endpoint):
+    result = subprocess.run([
+        "python", "scripts/run.py", "ask_question.py",
+        "--question", f"Parameters and response format for {api_endpoint}",
+        "--notebook-id", "api-docs"
+    ], capture_output=True, text=True)
+
+    # If follow-up needed
+    if "Is that ALL you need" in result.stdout:
+        # Ask for examples
+        follow_up = subprocess.run([
+            "python", "scripts/run.py", "ask_question.py",
+            "--question", f"Show code examples for {api_endpoint}",
+            "--notebook-id", "api-docs"
+        ], capture_output=True, text=True)
+
+    return combine_answers(result.stdout, follow_up.stdout)
+```
+
+## Best Practices
+
+### 1. Question Formulation
+- Be specific and comprehensive
+- Include all context in each question
+- Request structured responses
+- Ask for examples when needed
+
+### 2. Notebook Management
+- **ALWAYS ask user for metadata**
+- Use descriptive names
+- Add comprehensive topics
+- Keep URLs current
+
+### 3. Performance
+- Batch related questions
+- Use parallel processing for different notebooks
+- Monitor rate limits (50/day)
+- Switch accounts if needed
+
+### 4. Error Handling
+- Always use run.py to prevent venv issues
+- Check auth before operations
+- Implement retry logic
+- Have fallback notebooks ready
+
+### 5. Security
+- Use dedicated Google account
+- Never commit data/ directory
+- Regularly refresh auth
+- Track all access
+
+## Common Workflows for Claude
+
+### Workflow 1: User Sends NotebookLM URL
+
+```python
+# 1. Detect URL in message
+if "notebooklm.google.com" in user_message:
+    url = extract_url(user_message)
+
+    # 2. Check if in library
+    notebooks = run("notebook_manager.py list")
+
+    if url not in notebooks:
+        # 3. ASK USER FOR METADATA (CRITICAL!)
+        name = ask_user("What should I call this notebook?")
+        description = ask_user("What does this notebook contain?")
+        topics = ask_user("What topics does it cover?")
+
+        # 4. Add with user-provided info
+        run(f"notebook_manager.py add --url {url} --name '{name}' --description '{description}' --topics '{topics}'")
+
+    # 5. Use the notebook
+    answer = run(f"ask_question.py --question '{user_question}'")
+```
+
+### Workflow 2: Research Task
+
+```python
+# 1. Understand task
+task = "Implement feature X"
+
+# 2. Formulate comprehensive questions
+questions = [
+    "Complete implementation guide for X",
+    "Error handling for X",
+    "Performance considerations for X"
+]
+
+# 3. Query with follow-ups
+for q in questions:
+    answer = run(f"ask_question.py --question '{q}'")
+
+    # Check if follow-up needed
+    if "Is that ALL you need" in answer:
+        # Ask more specific question
+        follow_up = run(f"ask_question.py --question 'Specific detail about {q}'")
+
+# 4. Synthesize and implement
+```
+
+## Tips and Tricks
+
+1. **Always use run.py** - Prevents all venv issues
+2. **Ask for metadata** - Never guess notebook contents
+3. **Use verbose questions** - Include all context
+4. **Follow up automatically** - When you see the prompt
+5. **Monitor rate limits** - 50 queries per day
+6. **Batch operations** - Group related queries
+7. **Export important answers** - Save locally
+8. **Version control notebooks** - Track changes
+9. **Test auth regularly** - Before important tasks
+10. **Document everything** - Keep notes on notebooks
+
+## Quick Reference
+
+```bash
+# Always use run.py!
+python scripts/run.py [script].py [args]
+
+# Common operations
+run.py auth_manager.py status          # Check auth
+run.py auth_manager.py setup           # Login (browser visible!)
+run.py notebook_manager.py list        # List notebooks
+run.py notebook_manager.py add ...     # Add (ask user for metadata!)
+run.py ask_question.py --question ...  # Query
+run.py cleanup_manager.py ...          # Clean up
+```
+
+**Remember:** When in doubt, use run.py and ask the user for notebook details!

--- a/skills/notebooklm/requirements.txt
+++ b/skills/notebooklm/requirements.txt
@@ -1,0 +1,10 @@
+# NotebookLM Skill Dependencies
+# These will be installed in the skill's local .venv
+
+# Core browser automation with anti-detection
+# Note: After installation, run: patchright install chrome
+# (Chrome is required, not Chromium, for cross-platform reliability)
+patchright==1.55.2
+
+# Environment management
+python-dotenv==1.0.0

--- a/skills/notebooklm/scripts/__init__.py
+++ b/skills/notebooklm/scripts/__init__.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+NotebookLM Skill Scripts Package
+Provides automatic environment management for all scripts
+"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def ensure_venv_and_run():
+    """
+    Ensure virtual environment exists and run the requested script.
+    This is called when any script is imported or run directly.
+    """
+    # Only do this if we're not already in the skill's venv
+    skill_dir = Path(__file__).parent.parent
+    venv_dir = skill_dir / ".venv"
+
+    # Check if we're in a venv
+    in_venv = hasattr(sys, 'real_prefix') or (
+        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+    )
+
+    # Check if it's OUR venv
+    if in_venv:
+        venv_path = Path(sys.prefix)
+        if venv_path == venv_dir:
+            # We're already in the correct venv
+            return
+
+    # We need to set up or switch to our venv
+    if not venv_dir.exists():
+        print("🔧 First-time setup detected...")
+        print("   Creating isolated environment for NotebookLM skill...")
+        print("   This ensures clean dependency management...")
+
+        # Create venv
+        import venv
+        venv.create(venv_dir, with_pip=True)
+
+        # Install requirements
+        requirements_file = skill_dir / "requirements.txt"
+        if requirements_file.exists():
+            if os.name == 'nt':  # Windows
+                pip_exe = venv_dir / "Scripts" / "pip.exe"
+            else:
+                pip_exe = venv_dir / "bin" / "pip"
+
+            print("   Installing dependencies in isolated environment...")
+            subprocess.run(
+                [str(pip_exe), "install", "-q", "-r", str(requirements_file)],
+                check=True
+            )
+
+            # Also install patchright's chromium
+            print("   Setting up browser automation...")
+            if os.name == 'nt':
+                python_exe = venv_dir / "Scripts" / "python.exe"
+            else:
+                python_exe = venv_dir / "bin" / "python"
+
+            subprocess.run(
+                [str(python_exe), "-m", "patchright", "install", "chromium"],
+                check=True,
+                capture_output=True
+            )
+
+        print("✅ Environment ready! All dependencies isolated in .venv/")
+
+    # If we're here and not in the venv, we should recommend using the venv
+    if not in_venv:
+        print("\n⚠️  Running outside virtual environment")
+        print("   Recommended: Use scripts/run.py to ensure clean execution")
+        print("   Or activate: source .venv/bin/activate")
+
+
+# Check environment when module is imported
+ensure_venv_and_run()

--- a/skills/notebooklm/scripts/ask_question.py
+++ b/skills/notebooklm/scripts/ask_question.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+Simple NotebookLM Question Interface
+Based on MCP server implementation - simplified without sessions
+
+Implements hybrid auth approach:
+- Persistent browser profile (user_data_dir) for fingerprint consistency
+- Manual cookie injection from state.json for session cookies (Playwright bug workaround)
+See: https://github.com/microsoft/playwright/issues/36139
+"""
+
+import argparse
+import sys
+import time
+import re
+from pathlib import Path
+
+from patchright.sync_api import sync_playwright
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from auth_manager import AuthManager
+from notebook_manager import NotebookLibrary
+from config import QUERY_INPUT_SELECTORS, RESPONSE_SELECTORS
+from browser_utils import BrowserFactory, StealthUtils
+
+
+# Follow-up reminder (adapted from MCP server for stateless operation)
+# Since we don't have persistent sessions, we encourage comprehensive questions
+FOLLOW_UP_REMINDER = (
+    "\n\nEXTREMELY IMPORTANT: Is that ALL you need to know? "
+    "You can always ask another question! Think about it carefully: "
+    "before you reply to the user, review their original request and this answer. "
+    "If anything is still unclear or missing, ask me another comprehensive question "
+    "that includes all necessary context (since each question opens a new browser session)."
+)
+
+
+def ask_notebooklm(question: str, notebook_url: str, headless: bool = True) -> str:
+    """
+    Ask a question to NotebookLM
+
+    Args:
+        question: Question to ask
+        notebook_url: NotebookLM notebook URL
+        headless: Run browser in headless mode
+
+    Returns:
+        Answer text from NotebookLM
+    """
+    auth = AuthManager()
+
+    if not auth.is_authenticated():
+        print("⚠️ Not authenticated. Run: python auth_manager.py setup")
+        return None
+
+    print(f"💬 Asking: {question}")
+    print(f"📚 Notebook: {notebook_url}")
+
+    playwright = None
+    context = None
+
+    try:
+        # Start playwright
+        playwright = sync_playwright().start()
+
+        # Launch persistent browser context using factory
+        context = BrowserFactory.launch_persistent_context(
+            playwright,
+            headless=headless
+        )
+
+        # Navigate to notebook
+        page = context.new_page()
+        print("  🌐 Opening notebook...")
+        page.goto(notebook_url, wait_until="domcontentloaded")
+
+        # Wait for NotebookLM
+        page.wait_for_url(re.compile(r"^https://notebooklm\.google\.com/"), timeout=10000)
+
+        # Wait for query input (MCP approach)
+        print("  ⏳ Waiting for query input...")
+        query_element = None
+
+        for selector in QUERY_INPUT_SELECTORS:
+            try:
+                query_element = page.wait_for_selector(
+                    selector,
+                    timeout=10000,
+                    state="visible"  # Only check visibility, not disabled!
+                )
+                if query_element:
+                    print(f"  ✓ Found input: {selector}")
+                    break
+            except:
+                continue
+
+        if not query_element:
+            print("  ❌ Could not find query input")
+            return None
+
+        # Type question (human-like, fast)
+        print("  ⏳ Typing question...")
+        
+        # Use primary selector for typing
+        input_selector = QUERY_INPUT_SELECTORS[0]
+        StealthUtils.human_type(page, input_selector, question)
+
+        # Submit
+        print("  📤 Submitting...")
+        page.keyboard.press("Enter")
+
+        # Small pause
+        StealthUtils.random_delay(500, 1500)
+
+        # Wait for response (MCP approach: poll for stable text)
+        print("  ⏳ Waiting for answer...")
+
+        answer = None
+        stable_count = 0
+        last_text = None
+        deadline = time.time() + 120  # 2 minutes timeout
+
+        while time.time() < deadline:
+            # Check if NotebookLM is still thinking (most reliable indicator)
+            try:
+                thinking_element = page.query_selector('div.thinking-message')
+                if thinking_element and thinking_element.is_visible():
+                    time.sleep(1)
+                    continue
+            except:
+                pass
+
+            # Try to find response with MCP selectors
+            for selector in RESPONSE_SELECTORS:
+                try:
+                    elements = page.query_selector_all(selector)
+                    if elements:
+                        # Get last (newest) response
+                        latest = elements[-1]
+                        text = latest.inner_text().strip()
+
+                        if text:
+                            if text == last_text:
+                                stable_count += 1
+                                if stable_count >= 3:  # Stable for 3 polls
+                                    answer = text
+                                    break
+                            else:
+                                stable_count = 0
+                                last_text = text
+                except:
+                    continue
+
+            if answer:
+                break
+
+            time.sleep(1)
+
+        if not answer:
+            print("  ❌ Timeout waiting for answer")
+            return None
+
+        print("  ✅ Got answer!")
+        # Add follow-up reminder to encourage Claude to ask more questions
+        return answer + FOLLOW_UP_REMINDER
+
+    except Exception as e:
+        print(f"  ❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+    finally:
+        # Always clean up
+        if context:
+            try:
+                context.close()
+            except:
+                pass
+
+        if playwright:
+            try:
+                playwright.stop()
+            except:
+                pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Ask NotebookLM a question')
+
+    parser.add_argument('--question', required=True, help='Question to ask')
+    parser.add_argument('--notebook-url', help='NotebookLM notebook URL')
+    parser.add_argument('--notebook-id', help='Notebook ID from library')
+    parser.add_argument('--show-browser', action='store_true', help='Show browser')
+
+    args = parser.parse_args()
+
+    # Resolve notebook URL
+    notebook_url = args.notebook_url
+
+    if not notebook_url and args.notebook_id:
+        library = NotebookLibrary()
+        notebook = library.get_notebook(args.notebook_id)
+        if notebook:
+            notebook_url = notebook['url']
+        else:
+            print(f"❌ Notebook '{args.notebook_id}' not found")
+            return 1
+
+    if not notebook_url:
+        # Check for active notebook first
+        library = NotebookLibrary()
+        active = library.get_active_notebook()
+        if active:
+            notebook_url = active['url']
+            print(f"📚 Using active notebook: {active['name']}")
+        else:
+            # Show available notebooks
+            notebooks = library.list_notebooks()
+            if notebooks:
+                print("\n📚 Available notebooks:")
+                for nb in notebooks:
+                    mark = " [ACTIVE]" if nb.get('id') == library.active_notebook_id else ""
+                    print(f"  {nb['id']}: {nb['name']}{mark}")
+                print("\nSpecify with --notebook-id or set active:")
+                print("python scripts/run.py notebook_manager.py activate --id ID")
+            else:
+                print("❌ No notebooks in library. Add one first:")
+                print("python scripts/run.py notebook_manager.py add --url URL --name NAME --description DESC --topics TOPICS")
+            return 1
+
+    # Ask the question
+    answer = ask_notebooklm(
+        question=args.question,
+        notebook_url=notebook_url,
+        headless=not args.show_browser
+    )
+
+    if answer:
+        print("\n" + "=" * 60)
+        print(f"Question: {args.question}")
+        print("=" * 60)
+        print()
+        print(answer)
+        print()
+        print("=" * 60)
+        return 0
+    else:
+        print("\n❌ Failed to get answer")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/notebooklm/scripts/auth_manager.py
+++ b/skills/notebooklm/scripts/auth_manager.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Authentication Manager for NotebookLM
+Handles Google login and browser state persistence
+Based on the MCP server implementation
+
+Implements hybrid auth approach:
+- Persistent browser profile (user_data_dir) for fingerprint consistency
+- Manual cookie injection from state.json for session cookies (Playwright bug workaround)
+See: https://github.com/microsoft/playwright/issues/36139
+"""
+
+import json
+import time
+import argparse
+import shutil
+import re
+import sys
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from patchright.sync_api import sync_playwright, BrowserContext
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from config import BROWSER_STATE_DIR, STATE_FILE, AUTH_INFO_FILE, DATA_DIR
+from browser_utils import BrowserFactory
+
+
+class AuthManager:
+    """
+    Manages authentication and browser state for NotebookLM
+
+    Features:
+    - Interactive Google login
+    - Browser state persistence
+    - Session restoration
+    - Account switching
+    """
+
+    def __init__(self):
+        """Initialize the authentication manager"""
+        # Ensure directories exist
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        BROWSER_STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+        self.state_file = STATE_FILE
+        self.auth_info_file = AUTH_INFO_FILE
+        self.browser_state_dir = BROWSER_STATE_DIR
+
+    def is_authenticated(self) -> bool:
+        """Check if valid authentication exists"""
+        if not self.state_file.exists():
+            return False
+
+        # Check if state file is not too old (7 days)
+        age_days = (time.time() - self.state_file.stat().st_mtime) / 86400
+        if age_days > 7:
+            print(f"⚠️ Browser state is {age_days:.1f} days old, may need re-authentication")
+
+        return True
+
+    def get_auth_info(self) -> Dict[str, Any]:
+        """Get authentication information"""
+        info = {
+            'authenticated': self.is_authenticated(),
+            'state_file': str(self.state_file),
+            'state_exists': self.state_file.exists()
+        }
+
+        if self.auth_info_file.exists():
+            try:
+                with open(self.auth_info_file, 'r') as f:
+                    saved_info = json.load(f)
+                    info.update(saved_info)
+            except Exception:
+                pass
+
+        if info['state_exists']:
+            age_hours = (time.time() - self.state_file.stat().st_mtime) / 3600
+            info['state_age_hours'] = age_hours
+
+        return info
+
+    def setup_auth(self, headless: bool = False, timeout_minutes: int = 10) -> bool:
+        """
+        Perform interactive authentication setup
+
+        Args:
+            headless: Run browser in headless mode (False for login)
+            timeout_minutes: Maximum time to wait for login
+
+        Returns:
+            True if authentication successful
+        """
+        print("🔐 Starting authentication setup...")
+        print(f"  Timeout: {timeout_minutes} minutes")
+
+        playwright = None
+        context = None
+
+        try:
+            playwright = sync_playwright().start()
+
+            # Launch using factory
+            context = BrowserFactory.launch_persistent_context(
+                playwright,
+                headless=headless
+            )
+
+            # Navigate to NotebookLM
+            page = context.new_page()
+            page.goto("https://notebooklm.google.com", wait_until="domcontentloaded")
+
+            # Check if already authenticated
+            if "notebooklm.google.com" in page.url and "accounts.google.com" not in page.url:
+                print("  ✅ Already authenticated!")
+                self._save_browser_state(context)
+                return True
+
+            # Wait for manual login
+            print("\n  ⏳ Please log in to your Google account...")
+            print(f"  ⏱️  Waiting up to {timeout_minutes} minutes for login...")
+
+            try:
+                # Wait for URL to change to NotebookLM (regex ensures it's the actual domain, not a parameter)
+                timeout_ms = int(timeout_minutes * 60 * 1000)
+                page.wait_for_url(re.compile(r"^https://notebooklm\.google\.com/"), timeout=timeout_ms)
+
+                print(f"  ✅ Login successful!")
+
+                # Save authentication state
+                self._save_browser_state(context)
+                self._save_auth_info()
+                return True
+
+            except Exception as e:
+                print(f"  ❌ Authentication timeout: {e}")
+                return False
+
+        except Exception as e:
+            print(f"  ❌ Error: {e}")
+            return False
+
+        finally:
+            # Clean up browser resources
+            if context:
+                try:
+                    context.close()
+                except Exception:
+                    pass
+
+            if playwright:
+                try:
+                    playwright.stop()
+                except Exception:
+                    pass
+
+    def _save_browser_state(self, context: BrowserContext):
+        """Save browser state to disk"""
+        try:
+            # Save storage state (cookies, localStorage)
+            context.storage_state(path=str(self.state_file))
+            print(f"  💾 Saved browser state to: {self.state_file}")
+        except Exception as e:
+            print(f"  ❌ Failed to save browser state: {e}")
+            raise
+
+    def _save_auth_info(self):
+        """Save authentication metadata"""
+        try:
+            info = {
+                'authenticated_at': time.time(),
+                'authenticated_at_iso': time.strftime('%Y-%m-%d %H:%M:%S')
+            }
+            with open(self.auth_info_file, 'w') as f:
+                json.dump(info, f, indent=2)
+        except Exception:
+            pass  # Non-critical
+
+    def clear_auth(self) -> bool:
+        """
+        Clear all authentication data
+
+        Returns:
+            True if cleared successfully
+        """
+        print("🗑️ Clearing authentication data...")
+
+        try:
+            # Remove browser state
+            if self.state_file.exists():
+                self.state_file.unlink()
+                print("  ✅ Removed browser state")
+
+            # Remove auth info
+            if self.auth_info_file.exists():
+                self.auth_info_file.unlink()
+                print("  ✅ Removed auth info")
+
+            # Clear entire browser state directory
+            if self.browser_state_dir.exists():
+                shutil.rmtree(self.browser_state_dir)
+                self.browser_state_dir.mkdir(parents=True, exist_ok=True)
+                print("  ✅ Cleared browser data")
+
+            return True
+
+        except Exception as e:
+            print(f"  ❌ Error clearing auth: {e}")
+            return False
+
+    def re_auth(self, headless: bool = False, timeout_minutes: int = 10) -> bool:
+        """
+        Perform re-authentication (clear and setup)
+
+        Args:
+            headless: Run browser in headless mode
+            timeout_minutes: Login timeout in minutes
+
+        Returns:
+            True if successful
+        """
+        print("🔄 Starting re-authentication...")
+
+        # Clear existing auth
+        self.clear_auth()
+
+        # Setup new auth
+        return self.setup_auth(headless, timeout_minutes)
+
+    def validate_auth(self) -> bool:
+        """
+        Validate that stored authentication works
+        Uses persistent context to match actual usage pattern
+
+        Returns:
+            True if authentication is valid
+        """
+        if not self.is_authenticated():
+            return False
+
+        print("🔍 Validating authentication...")
+
+        playwright = None
+        context = None
+
+        try:
+            playwright = sync_playwright().start()
+
+            # Launch using factory
+            context = BrowserFactory.launch_persistent_context(
+                playwright,
+                headless=True
+            )
+
+            # Try to access NotebookLM
+            page = context.new_page()
+            page.goto("https://notebooklm.google.com", wait_until="domcontentloaded", timeout=30000)
+
+            # Check if we can access NotebookLM
+            if "notebooklm.google.com" in page.url and "accounts.google.com" not in page.url:
+                print("  ✅ Authentication is valid")
+                return True
+            else:
+                print("  ❌ Authentication is invalid (redirected to login)")
+                return False
+
+        except Exception as e:
+            print(f"  ❌ Validation failed: {e}")
+            return False
+
+        finally:
+            if context:
+                try:
+                    context.close()
+                except Exception:
+                    pass
+            if playwright:
+                try:
+                    playwright.stop()
+                except Exception:
+                    pass
+
+
+def main():
+    """Command-line interface for authentication management"""
+    parser = argparse.ArgumentParser(description='Manage NotebookLM authentication')
+
+    subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    # Setup command
+    setup_parser = subparsers.add_parser('setup', help='Setup authentication')
+    setup_parser.add_argument('--headless', action='store_true', help='Run in headless mode')
+    setup_parser.add_argument('--timeout', type=float, default=10, help='Login timeout in minutes (default: 10)')
+
+    # Status command
+    subparsers.add_parser('status', help='Check authentication status')
+
+    # Validate command
+    subparsers.add_parser('validate', help='Validate authentication')
+
+    # Clear command
+    subparsers.add_parser('clear', help='Clear authentication')
+
+    # Re-auth command
+    reauth_parser = subparsers.add_parser('reauth', help='Re-authenticate (clear + setup)')
+    reauth_parser.add_argument('--timeout', type=float, default=10, help='Login timeout in minutes (default: 10)')
+
+    args = parser.parse_args()
+
+    # Initialize manager
+    auth = AuthManager()
+
+    # Execute command
+    if args.command == 'setup':
+        if auth.setup_auth(headless=args.headless, timeout_minutes=args.timeout):
+            print("\n✅ Authentication setup complete!")
+            print("You can now use ask_question.py to query NotebookLM")
+        else:
+            print("\n❌ Authentication setup failed")
+            exit(1)
+
+    elif args.command == 'status':
+        info = auth.get_auth_info()
+        print("\n🔐 Authentication Status:")
+        print(f"  Authenticated: {'Yes' if info['authenticated'] else 'No'}")
+        if info.get('state_age_hours'):
+            print(f"  State age: {info['state_age_hours']:.1f} hours")
+        if info.get('authenticated_at_iso'):
+            print(f"  Last auth: {info['authenticated_at_iso']}")
+        print(f"  State file: {info['state_file']}")
+
+    elif args.command == 'validate':
+        if auth.validate_auth():
+            print("Authentication is valid and working")
+        else:
+            print("Authentication is invalid or expired")
+            print("Run: auth_manager.py setup")
+
+    elif args.command == 'clear':
+        if auth.clear_auth():
+            print("Authentication cleared")
+
+    elif args.command == 'reauth':
+        if auth.re_auth(timeout_minutes=args.timeout):
+            print("\n✅ Re-authentication complete!")
+        else:
+            print("\n❌ Re-authentication failed")
+            exit(1)
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/notebooklm/scripts/browser_session.py
+++ b/skills/notebooklm/scripts/browser_session.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Browser Session Management for NotebookLM
+Individual browser session for persistent NotebookLM conversations
+Based on the original NotebookLM API implementation
+"""
+
+import time
+import sys
+from typing import Any, Dict, Optional
+from pathlib import Path
+
+from patchright.sync_api import BrowserContext, Page
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from browser_utils import StealthUtils
+
+
+class BrowserSession:
+    """
+    Represents a single persistent browser session for NotebookLM
+
+    Each session gets its own Page (tab) within a shared BrowserContext,
+    allowing for contextual conversations where NotebookLM remembers
+    previous messages.
+    """
+
+    def __init__(self, session_id: str, context: BrowserContext, notebook_url: str):
+        """
+        Initialize a new browser session
+
+        Args:
+            session_id: Unique identifier for this session
+            context: Browser context (shared or dedicated)
+            notebook_url: Target NotebookLM URL for this session
+        """
+        self.id = session_id
+        self.created_at = time.time()
+        self.last_activity = time.time()
+        self.message_count = 0
+        self.notebook_url = notebook_url
+        self.context = context
+        self.page = None
+        self.stealth = StealthUtils()
+
+        # Initialize the session
+        self._initialize()
+
+    def _initialize(self):
+        """Initialize the browser session and navigate to NotebookLM"""
+        print(f"🚀 Creating session {self.id}...")
+
+        # Create new page (tab) in context
+        self.page = self.context.new_page()
+        print(f"  🌐 Navigating to NotebookLM...")
+
+        try:
+            # Navigate to notebook
+            self.page.goto(self.notebook_url, wait_until="domcontentloaded", timeout=30000)
+
+            # Check if login is needed
+            if "accounts.google.com" in self.page.url:
+                raise RuntimeError("Authentication required. Please run auth_manager.py setup first.")
+
+            # Wait for page to be ready
+            self._wait_for_ready()
+
+            # Simulate human inspection
+            self.stealth.random_mouse_movement(self.page)
+            self.stealth.random_delay(300, 600)
+
+            print(f"✅ Session {self.id} ready!")
+
+        except Exception as e:
+            print(f"❌ Failed to initialize session: {e}")
+            if self.page:
+                self.page.close()
+            raise
+
+    def _wait_for_ready(self):
+        """Wait for NotebookLM page to be ready"""
+        try:
+            # Wait for chat input
+            self.page.wait_for_selector("textarea.query-box-input", timeout=10000, state="visible")
+        except Exception:
+            # Try alternative selector
+            self.page.wait_for_selector('textarea[aria-label="Feld für Anfragen"]', timeout=5000, state="visible")
+
+    def ask(self, question: str) -> Dict[str, Any]:
+        """
+        Ask a question in this session
+
+        Args:
+            question: The question to ask
+
+        Returns:
+            Dict with status, question, answer, session_id
+        """
+        try:
+            self.last_activity = time.time()
+            self.message_count += 1
+
+            print(f"💬 [{self.id}] Asking: {question}")
+
+            # Snapshot current answer to detect new response
+            previous_answer = self._snapshot_latest_response()
+
+            # Find chat input
+            chat_input_selector = "textarea.query-box-input"
+            try:
+                self.page.wait_for_selector(chat_input_selector, timeout=5000, state="visible")
+            except Exception:
+                chat_input_selector = 'textarea[aria-label="Feld für Anfragen"]'
+                self.page.wait_for_selector(chat_input_selector, timeout=5000, state="visible")
+
+            # Click and type with human-like behavior
+            self.stealth.realistic_click(self.page, chat_input_selector)
+            self.stealth.human_type(self.page, chat_input_selector, question)
+
+            # Small pause before submit
+            self.stealth.random_delay(300, 800)
+
+            # Submit
+            self.page.keyboard.press("Enter")
+
+            # Wait for response
+            print("  ⏳ Waiting for response...")
+            self.stealth.random_delay(1500, 3000)
+
+            # Get new answer
+            answer = self._wait_for_latest_answer(previous_answer)
+
+            if not answer:
+                raise Exception("Empty response from NotebookLM")
+
+            print(f"  ✅ Got response ({len(answer)} chars)")
+
+            return {
+                "status": "success",
+                "question": question,
+                "answer": answer,
+                "session_id": self.id,
+                "notebook_url": self.notebook_url
+            }
+
+        except Exception as e:
+            print(f"  ❌ Error: {e}")
+            return {
+                "status": "error",
+                "question": question,
+                "error": str(e),
+                "session_id": self.id
+            }
+
+    def _snapshot_latest_response(self) -> Optional[str]:
+        """Get the current latest response text"""
+        try:
+            # Use correct NotebookLM selector
+            responses = self.page.query_selector_all(".to-user-container .message-text-content")
+            if responses:
+                return responses[-1].inner_text()
+        except Exception:
+            pass
+        return None
+
+    def _wait_for_latest_answer(self, previous_answer: Optional[str], timeout: int = 120) -> str:
+        """Wait for and extract the new answer"""
+        start_time = time.time()
+        last_candidate = None
+        stable_count = 0
+
+        while time.time() - start_time < timeout:
+            # Check if NotebookLM is still thinking (most reliable indicator)
+            try:
+                thinking_element = self.page.query_selector('div.thinking-message')
+                if thinking_element and thinking_element.is_visible():
+                    time.sleep(0.5)
+                    continue
+            except Exception:
+                pass
+
+            try:
+                # Use correct NotebookLM selector
+                responses = self.page.query_selector_all(".to-user-container .message-text-content")
+
+                if responses:
+                    latest_text = responses[-1].inner_text().strip()
+
+                    # Check if it's a new response
+                    if latest_text and latest_text != previous_answer:
+                        # Check if text is stable (3 consecutive polls)
+                        if latest_text == last_candidate:
+                            stable_count += 1
+                            if stable_count >= 3:
+                                return latest_text
+                        else:
+                            stable_count = 1
+                            last_candidate = latest_text
+
+            except Exception:
+                pass
+
+            time.sleep(0.5)
+
+        raise TimeoutError(f"No response received within {timeout} seconds")
+
+    def reset(self):
+        """Reset the chat by reloading the page"""
+        print(f"🔄 Resetting session {self.id}...")
+
+        self.page.reload(wait_until="domcontentloaded")
+        self._wait_for_ready()
+
+        previous_count = self.message_count
+        self.message_count = 0
+        self.last_activity = time.time()
+
+        print(f"✅ Session reset (cleared {previous_count} messages)")
+        return previous_count
+
+    def close(self):
+        """Close this session and clean up resources"""
+        print(f"🛑 Closing session {self.id}...")
+
+        if self.page:
+            try:
+                self.page.close()
+            except Exception as e:
+                print(f"  ⚠️ Error closing page: {e}")
+
+        print(f"✅ Session {self.id} closed")
+
+    def get_info(self) -> Dict[str, Any]:
+        """Get information about this session"""
+        return {
+            "id": self.id,
+            "created_at": self.created_at,
+            "last_activity": self.last_activity,
+            "age_seconds": time.time() - self.created_at,
+            "inactive_seconds": time.time() - self.last_activity,
+            "message_count": self.message_count,
+            "notebook_url": self.notebook_url
+        }
+
+    def is_expired(self, timeout_seconds: int = 900) -> bool:
+        """Check if session has expired (default: 15 minutes)"""
+        return (time.time() - self.last_activity) > timeout_seconds
+
+
+if __name__ == "__main__":
+    # Example usage
+    print("Browser Session Module - Use ask_question.py for main interface")
+    print("This module provides low-level browser session management.")

--- a/skills/notebooklm/scripts/browser_utils.py
+++ b/skills/notebooklm/scripts/browser_utils.py
@@ -1,0 +1,107 @@
+"""
+Browser Utilities for NotebookLM Skill
+Handles browser launching, stealth features, and common interactions
+"""
+
+import json
+import time
+import random
+from typing import Optional, List
+
+from patchright.sync_api import Playwright, BrowserContext, Page
+from config import BROWSER_PROFILE_DIR, STATE_FILE, BROWSER_ARGS, USER_AGENT
+
+
+class BrowserFactory:
+    """Factory for creating configured browser contexts"""
+
+    @staticmethod
+    def launch_persistent_context(
+        playwright: Playwright,
+        headless: bool = True,
+        user_data_dir: str = str(BROWSER_PROFILE_DIR)
+    ) -> BrowserContext:
+        """
+        Launch a persistent browser context with anti-detection features
+        and cookie workaround.
+        """
+        # Launch persistent context
+        context = playwright.chromium.launch_persistent_context(
+            user_data_dir=user_data_dir,
+            channel="chrome",  # Use real Chrome
+            headless=headless,
+            no_viewport=True,
+            ignore_default_args=["--enable-automation"],
+            user_agent=USER_AGENT,
+            args=BROWSER_ARGS
+        )
+
+        # Cookie Workaround for Playwright bug #36139
+        # Session cookies (expires=-1) don't persist in user_data_dir automatically
+        BrowserFactory._inject_cookies(context)
+
+        return context
+
+    @staticmethod
+    def _inject_cookies(context: BrowserContext):
+        """Inject cookies from state.json if available"""
+        if STATE_FILE.exists():
+            try:
+                with open(STATE_FILE, 'r') as f:
+                    state = json.load(f)
+                    if 'cookies' in state and len(state['cookies']) > 0:
+                        context.add_cookies(state['cookies'])
+                        # print(f"  🔧 Injected {len(state['cookies'])} cookies from state.json")
+            except Exception as e:
+                print(f"  ⚠️  Could not load state.json: {e}")
+
+
+class StealthUtils:
+    """Human-like interaction utilities"""
+
+    @staticmethod
+    def random_delay(min_ms: int = 100, max_ms: int = 500):
+        """Add random delay"""
+        time.sleep(random.uniform(min_ms / 1000, max_ms / 1000))
+
+    @staticmethod
+    def human_type(page: Page, selector: str, text: str, wpm_min: int = 320, wpm_max: int = 480):
+        """Type with human-like speed"""
+        element = page.query_selector(selector)
+        if not element:
+            # Try waiting if not immediately found
+            try:
+                element = page.wait_for_selector(selector, timeout=2000)
+            except:
+                pass
+        
+        if not element:
+            print(f"⚠️ Element not found for typing: {selector}")
+            return
+
+        # Click to focus
+        element.click()
+        
+        # Type
+        for char in text:
+            element.type(char, delay=random.uniform(25, 75))
+            if random.random() < 0.05:
+                time.sleep(random.uniform(0.15, 0.4))
+
+    @staticmethod
+    def realistic_click(page: Page, selector: str):
+        """Click with realistic movement"""
+        element = page.query_selector(selector)
+        if not element:
+            return
+
+        # Optional: Move mouse to element (simplified)
+        box = element.bounding_box()
+        if box:
+            x = box['x'] + box['width'] / 2
+            y = box['y'] + box['height'] / 2
+            page.mouse.move(x, y, steps=5)
+
+        StealthUtils.random_delay(100, 300)
+        element.click()
+        StealthUtils.random_delay(100, 300)

--- a/skills/notebooklm/scripts/cleanup_manager.py
+++ b/skills/notebooklm/scripts/cleanup_manager.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""
+Cleanup Manager for NotebookLM Skill
+Manages cleanup of skill data and browser state
+"""
+
+import shutil
+import argparse
+from pathlib import Path
+from typing import Dict, List, Any
+
+
+class CleanupManager:
+    """
+    Manages cleanup of NotebookLM skill data
+
+    Features:
+    - Preview what will be deleted
+    - Selective cleanup options
+    - Library preservation
+    - Safe deletion with confirmation
+    """
+
+    def __init__(self):
+        """Initialize the cleanup manager"""
+        # Skill directory paths
+        self.skill_dir = Path(__file__).parent.parent
+        self.data_dir = self.skill_dir / "data"
+
+    def get_cleanup_paths(self, preserve_library: bool = False) -> Dict[str, Any]:
+        """
+        Get paths that would be cleaned up
+
+        Args:
+            preserve_library: Keep library.json if True
+
+        Returns:
+            Dict with paths and sizes
+
+        Note: .venv is NEVER deleted - it's part of the skill infrastructure
+        """
+        paths = {
+            'browser_state': [],
+            'sessions': [],
+            'library': [],
+            'auth': [],
+            'other': []
+        }
+
+        total_size = 0
+
+        if self.data_dir.exists():
+            # Browser state
+            browser_state_dir = self.data_dir / "browser_state"
+            if browser_state_dir.exists():
+                for item in browser_state_dir.iterdir():
+                    size = self._get_size(item)
+                    paths['browser_state'].append({
+                        'path': str(item),
+                        'size': size,
+                        'type': 'dir' if item.is_dir() else 'file'
+                    })
+                    total_size += size
+
+            # Sessions
+            sessions_file = self.data_dir / "sessions.json"
+            if sessions_file.exists():
+                size = sessions_file.stat().st_size
+                paths['sessions'].append({
+                    'path': str(sessions_file),
+                    'size': size,
+                    'type': 'file'
+                })
+                total_size += size
+
+            # Library (unless preserved)
+            if not preserve_library:
+                library_file = self.data_dir / "library.json"
+                if library_file.exists():
+                    size = library_file.stat().st_size
+                    paths['library'].append({
+                        'path': str(library_file),
+                        'size': size,
+                        'type': 'file'
+                    })
+                    total_size += size
+
+            # Auth info
+            auth_info = self.data_dir / "auth_info.json"
+            if auth_info.exists():
+                size = auth_info.stat().st_size
+                paths['auth'].append({
+                    'path': str(auth_info),
+                    'size': size,
+                    'type': 'file'
+                })
+                total_size += size
+
+            # Other files in data dir (but NEVER .venv!)
+            for item in self.data_dir.iterdir():
+                if item.name not in ['browser_state', 'sessions.json', 'library.json', 'auth_info.json']:
+                    size = self._get_size(item)
+                    paths['other'].append({
+                        'path': str(item),
+                        'size': size,
+                        'type': 'dir' if item.is_dir() else 'file'
+                    })
+                    total_size += size
+
+        return {
+            'categories': paths,
+            'total_size': total_size,
+            'total_items': sum(len(items) for items in paths.values())
+        }
+
+    def _get_size(self, path: Path) -> int:
+        """Get size of file or directory in bytes"""
+        if path.is_file():
+            return path.stat().st_size
+        elif path.is_dir():
+            total = 0
+            try:
+                for item in path.rglob('*'):
+                    if item.is_file():
+                        total += item.stat().st_size
+            except Exception:
+                pass
+            return total
+        return 0
+
+    def _format_size(self, size: int) -> str:
+        """Format size in human-readable form"""
+        for unit in ['B', 'KB', 'MB', 'GB']:
+            if size < 1024:
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} TB"
+
+    def perform_cleanup(
+        self,
+        preserve_library: bool = False,
+        dry_run: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Perform the actual cleanup
+
+        Args:
+            preserve_library: Keep library.json if True
+            dry_run: Preview only, don't delete
+
+        Returns:
+            Dict with cleanup results
+        """
+        cleanup_data = self.get_cleanup_paths(preserve_library)
+        deleted_items = []
+        failed_items = []
+        deleted_size = 0
+
+        if dry_run:
+            return {
+                'dry_run': True,
+                'would_delete': cleanup_data['total_items'],
+                'would_free': cleanup_data['total_size']
+            }
+
+        # Perform deletion
+        for category, items in cleanup_data['categories'].items():
+            for item_info in items:
+                path = Path(item_info['path'])
+                try:
+                    if path.exists():
+                        if path.is_dir():
+                            shutil.rmtree(path)
+                        else:
+                            path.unlink()
+                        deleted_items.append(str(path))
+                        deleted_size += item_info['size']
+                        print(f"  ✅ Deleted: {path.name}")
+                except Exception as e:
+                    failed_items.append({
+                        'path': str(path),
+                        'error': str(e)
+                    })
+                    print(f"  ❌ Failed: {path.name} ({e})")
+
+        # Recreate browser_state dir if everything was deleted
+        if not preserve_library and not failed_items:
+            browser_state_dir = self.data_dir / "browser_state"
+            browser_state_dir.mkdir(parents=True, exist_ok=True)
+
+        return {
+            'deleted_items': deleted_items,
+            'failed_items': failed_items,
+            'deleted_size': deleted_size,
+            'deleted_count': len(deleted_items),
+            'failed_count': len(failed_items)
+        }
+
+    def print_cleanup_preview(self, preserve_library: bool = False):
+        """Print a preview of what will be cleaned"""
+        data = self.get_cleanup_paths(preserve_library)
+
+        print("\n🔍 Cleanup Preview")
+        print("=" * 60)
+
+        for category, items in data['categories'].items():
+            if items:
+                print(f"\n📁 {category.replace('_', ' ').title()}:")
+                for item in items:
+                    path = Path(item['path'])
+                    size_str = self._format_size(item['size'])
+                    type_icon = "📂" if item['type'] == 'dir' else "📄"
+                    print(f"  {type_icon} {path.name:<30} {size_str:>10}")
+
+        print("\n" + "=" * 60)
+        print(f"Total items: {data['total_items']}")
+        print(f"Total size: {self._format_size(data['total_size'])}")
+
+        if preserve_library:
+            print("\n📚 Library will be preserved")
+
+        print("\nThis preview shows what would be deleted.")
+        print("Use --confirm to actually perform the cleanup.")
+
+
+def main():
+    """Command-line interface for cleanup management"""
+    parser = argparse.ArgumentParser(
+        description='Clean up NotebookLM skill data',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Preview what will be deleted
+  python cleanup_manager.py
+
+  # Perform cleanup (delete everything)
+  python cleanup_manager.py --confirm
+
+  # Cleanup but keep library
+  python cleanup_manager.py --confirm --preserve-library
+
+  # Force cleanup without preview
+  python cleanup_manager.py --confirm --force
+        """
+    )
+
+    parser.add_argument(
+        '--confirm',
+        action='store_true',
+        help='Actually perform the cleanup (without this, only preview)'
+    )
+
+    parser.add_argument(
+        '--preserve-library',
+        action='store_true',
+        help='Keep the notebook library (library.json)'
+    )
+
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Skip confirmation prompt'
+    )
+
+    args = parser.parse_args()
+
+    # Initialize manager
+    manager = CleanupManager()
+
+    if args.confirm:
+        # Show preview first unless forced
+        if not args.force:
+            manager.print_cleanup_preview(args.preserve_library)
+
+            print("\n⚠️  WARNING: This will delete the files shown above!")
+            print("   Note: .venv is preserved (part of skill infrastructure)")
+            response = input("Are you sure? (yes/no): ")
+
+            if response.lower() != 'yes':
+                print("Cleanup cancelled.")
+                return
+
+        # Perform cleanup
+        print("\n🗑️ Performing cleanup...")
+        result = manager.perform_cleanup(args.preserve_library, dry_run=False)
+
+        print(f"\n✅ Cleanup complete!")
+        print(f"  Deleted: {result['deleted_count']} items")
+        print(f"  Freed: {manager._format_size(result['deleted_size'])}")
+
+        if result['failed_count'] > 0:
+            print(f"  ⚠️ Failed: {result['failed_count']} items")
+
+    else:
+        # Just show preview
+        manager.print_cleanup_preview(args.preserve_library)
+        print("\n💡 Note: Virtual environment (.venv) is never deleted")
+        print("   It's part of the skill infrastructure, not user data")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/notebooklm/scripts/config.py
+++ b/skills/notebooklm/scripts/config.py
@@ -1,0 +1,44 @@
+"""
+Configuration for NotebookLM Skill
+Centralizes constants, selectors, and paths
+"""
+
+from pathlib import Path
+
+# Paths
+SKILL_DIR = Path(__file__).parent.parent
+DATA_DIR = SKILL_DIR / "data"
+BROWSER_STATE_DIR = DATA_DIR / "browser_state"
+BROWSER_PROFILE_DIR = BROWSER_STATE_DIR / "browser_profile"
+STATE_FILE = BROWSER_STATE_DIR / "state.json"
+AUTH_INFO_FILE = DATA_DIR / "auth_info.json"
+LIBRARY_FILE = DATA_DIR / "library.json"
+
+# NotebookLM Selectors
+QUERY_INPUT_SELECTORS = [
+    "textarea.query-box-input",  # Primary
+    'textarea[aria-label="Feld für Anfragen"]',  # Fallback German
+    'textarea[aria-label="Input for queries"]',  # Fallback English
+]
+
+RESPONSE_SELECTORS = [
+    ".to-user-container .message-text-content",  # Primary
+    "[data-message-author='bot']",
+    "[data-message-author='assistant']",
+]
+
+# Browser Configuration
+BROWSER_ARGS = [
+    '--disable-blink-features=AutomationControlled',  # Patches navigator.webdriver
+    '--disable-dev-shm-usage',
+    '--no-sandbox',
+    '--no-first-run',
+    '--no-default-browser-check'
+]
+
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+
+# Timeouts
+LOGIN_TIMEOUT_MINUTES = 10
+QUERY_TIMEOUT_SECONDS = 120
+PAGE_LOAD_TIMEOUT = 30000

--- a/skills/notebooklm/scripts/notebook_manager.py
+++ b/skills/notebooklm/scripts/notebook_manager.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+Notebook Library Management for NotebookLM
+Manages a library of NotebookLM notebooks with metadata
+Based on the MCP server implementation
+"""
+
+import json
+import argparse
+import uuid
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+
+
+class NotebookLibrary:
+    """Manages a collection of NotebookLM notebooks with metadata"""
+
+    def __init__(self):
+        """Initialize the notebook library"""
+        # Store data within the skill directory
+        skill_dir = Path(__file__).parent.parent
+        self.data_dir = skill_dir / "data"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        self.library_file = self.data_dir / "library.json"
+        self.notebooks: Dict[str, Dict[str, Any]] = {}
+        self.active_notebook_id: Optional[str] = None
+
+        # Load existing library
+        self._load_library()
+
+    def _load_library(self):
+        """Load library from disk"""
+        if self.library_file.exists():
+            try:
+                with open(self.library_file, 'r') as f:
+                    data = json.load(f)
+                    self.notebooks = data.get('notebooks', {})
+                    self.active_notebook_id = data.get('active_notebook_id')
+                    print(f"📚 Loaded library with {len(self.notebooks)} notebooks")
+            except Exception as e:
+                print(f"⚠️ Error loading library: {e}")
+                self.notebooks = {}
+                self.active_notebook_id = None
+        else:
+            self._save_library()
+
+    def _save_library(self):
+        """Save library to disk"""
+        try:
+            data = {
+                'notebooks': self.notebooks,
+                'active_notebook_id': self.active_notebook_id,
+                'updated_at': datetime.now().isoformat()
+            }
+            with open(self.library_file, 'w') as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            print(f"❌ Error saving library: {e}")
+
+    def add_notebook(
+        self,
+        url: str,
+        name: str,
+        description: str,
+        topics: List[str],
+        content_types: Optional[List[str]] = None,
+        use_cases: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Add a new notebook to the library
+
+        Args:
+            url: NotebookLM notebook URL
+            name: Display name for the notebook
+            description: What's in this notebook
+            topics: Topics covered
+            content_types: Types of content (optional)
+            use_cases: When to use this notebook (optional)
+            tags: Additional tags for organization (optional)
+
+        Returns:
+            The created notebook object
+        """
+        # Generate ID from name
+        notebook_id = name.lower().replace(' ', '-').replace('_', '-')
+
+        # Check for duplicates
+        if notebook_id in self.notebooks:
+            raise ValueError(f"Notebook with ID '{notebook_id}' already exists")
+
+        # Create notebook object
+        notebook = {
+            'id': notebook_id,
+            'url': url,
+            'name': name,
+            'description': description,
+            'topics': topics,
+            'content_types': content_types or [],
+            'use_cases': use_cases or [],
+            'tags': tags or [],
+            'created_at': datetime.now().isoformat(),
+            'updated_at': datetime.now().isoformat(),
+            'use_count': 0,
+            'last_used': None
+        }
+
+        # Add to library
+        self.notebooks[notebook_id] = notebook
+
+        # Set as active if it's the first notebook
+        if len(self.notebooks) == 1:
+            self.active_notebook_id = notebook_id
+
+        self._save_library()
+
+        print(f"✅ Added notebook: {name} ({notebook_id})")
+        return notebook
+
+    def remove_notebook(self, notebook_id: str) -> bool:
+        """
+        Remove a notebook from the library
+
+        Args:
+            notebook_id: ID of notebook to remove
+
+        Returns:
+            True if removed, False if not found
+        """
+        if notebook_id in self.notebooks:
+            del self.notebooks[notebook_id]
+
+            # Clear active if it was removed
+            if self.active_notebook_id == notebook_id:
+                self.active_notebook_id = None
+                # Set new active if there are other notebooks
+                if self.notebooks:
+                    self.active_notebook_id = list(self.notebooks.keys())[0]
+
+            self._save_library()
+            print(f"✅ Removed notebook: {notebook_id}")
+            return True
+
+        print(f"⚠️ Notebook not found: {notebook_id}")
+        return False
+
+    def update_notebook(
+        self,
+        notebook_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        topics: Optional[List[str]] = None,
+        content_types: Optional[List[str]] = None,
+        use_cases: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        url: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Update notebook metadata
+
+        Args:
+            notebook_id: ID of notebook to update
+            Other args: Fields to update (None = keep existing)
+
+        Returns:
+            Updated notebook object
+        """
+        if notebook_id not in self.notebooks:
+            raise ValueError(f"Notebook not found: {notebook_id}")
+
+        notebook = self.notebooks[notebook_id]
+
+        # Update fields if provided
+        if name is not None:
+            notebook['name'] = name
+        if description is not None:
+            notebook['description'] = description
+        if topics is not None:
+            notebook['topics'] = topics
+        if content_types is not None:
+            notebook['content_types'] = content_types
+        if use_cases is not None:
+            notebook['use_cases'] = use_cases
+        if tags is not None:
+            notebook['tags'] = tags
+        if url is not None:
+            notebook['url'] = url
+
+        notebook['updated_at'] = datetime.now().isoformat()
+
+        self._save_library()
+        print(f"✅ Updated notebook: {notebook['name']}")
+        return notebook
+
+    def get_notebook(self, notebook_id: str) -> Optional[Dict[str, Any]]:
+        """Get a specific notebook by ID"""
+        return self.notebooks.get(notebook_id)
+
+    def list_notebooks(self) -> List[Dict[str, Any]]:
+        """List all notebooks in the library"""
+        return list(self.notebooks.values())
+
+    def search_notebooks(self, query: str) -> List[Dict[str, Any]]:
+        """
+        Search notebooks by query
+
+        Args:
+            query: Search query (searches name, description, topics, tags)
+
+        Returns:
+            List of matching notebooks
+        """
+        query_lower = query.lower()
+        results = []
+
+        for notebook in self.notebooks.values():
+            # Search in various fields
+            searchable = [
+                notebook['name'].lower(),
+                notebook['description'].lower(),
+                ' '.join(notebook['topics']).lower(),
+                ' '.join(notebook['tags']).lower(),
+                ' '.join(notebook.get('use_cases', [])).lower()
+            ]
+
+            if any(query_lower in field for field in searchable):
+                results.append(notebook)
+
+        return results
+
+    def select_notebook(self, notebook_id: str) -> Dict[str, Any]:
+        """
+        Set a notebook as active
+
+        Args:
+            notebook_id: ID of notebook to activate
+
+        Returns:
+            The activated notebook
+        """
+        if notebook_id not in self.notebooks:
+            raise ValueError(f"Notebook not found: {notebook_id}")
+
+        self.active_notebook_id = notebook_id
+        self._save_library()
+
+        notebook = self.notebooks[notebook_id]
+        print(f"✅ Activated notebook: {notebook['name']}")
+        return notebook
+
+    def get_active_notebook(self) -> Optional[Dict[str, Any]]:
+        """Get the currently active notebook"""
+        if self.active_notebook_id:
+            return self.notebooks.get(self.active_notebook_id)
+        return None
+
+    def increment_use_count(self, notebook_id: str) -> Dict[str, Any]:
+        """
+        Increment usage counter for a notebook
+
+        Args:
+            notebook_id: ID of notebook that was used
+
+        Returns:
+            Updated notebook
+        """
+        if notebook_id not in self.notebooks:
+            raise ValueError(f"Notebook not found: {notebook_id}")
+
+        notebook = self.notebooks[notebook_id]
+        notebook['use_count'] += 1
+        notebook['last_used'] = datetime.now().isoformat()
+
+        self._save_library()
+        return notebook
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get library statistics"""
+        total_notebooks = len(self.notebooks)
+        total_topics = set()
+        total_use_count = 0
+
+        for notebook in self.notebooks.values():
+            total_topics.update(notebook['topics'])
+            total_use_count += notebook['use_count']
+
+        # Find most used
+        most_used = None
+        if self.notebooks:
+            most_used = max(
+                self.notebooks.values(),
+                key=lambda n: n['use_count']
+            )
+
+        return {
+            'total_notebooks': total_notebooks,
+            'total_topics': len(total_topics),
+            'total_use_count': total_use_count,
+            'active_notebook': self.get_active_notebook(),
+            'most_used_notebook': most_used,
+            'library_path': str(self.library_file)
+        }
+
+
+def main():
+    """Command-line interface for notebook management"""
+    parser = argparse.ArgumentParser(description='Manage NotebookLM library')
+
+    subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    # Add command
+    add_parser = subparsers.add_parser('add', help='Add a notebook')
+    add_parser.add_argument('--url', required=True, help='NotebookLM URL')
+    add_parser.add_argument('--name', required=True, help='Display name')
+    add_parser.add_argument('--description', required=True, help='Description')
+    add_parser.add_argument('--topics', required=True, help='Comma-separated topics')
+    add_parser.add_argument('--use-cases', help='Comma-separated use cases')
+    add_parser.add_argument('--tags', help='Comma-separated tags')
+
+    # List command
+    subparsers.add_parser('list', help='List all notebooks')
+
+    # Search command
+    search_parser = subparsers.add_parser('search', help='Search notebooks')
+    search_parser.add_argument('--query', required=True, help='Search query')
+
+    # Activate command
+    activate_parser = subparsers.add_parser('activate', help='Set active notebook')
+    activate_parser.add_argument('--id', required=True, help='Notebook ID')
+
+    # Remove command
+    remove_parser = subparsers.add_parser('remove', help='Remove a notebook')
+    remove_parser.add_argument('--id', required=True, help='Notebook ID')
+
+    # Stats command
+    subparsers.add_parser('stats', help='Show library statistics')
+
+    args = parser.parse_args()
+
+    # Initialize library
+    library = NotebookLibrary()
+
+    # Execute command
+    if args.command == 'add':
+        topics = [t.strip() for t in args.topics.split(',')]
+        use_cases = [u.strip() for u in args.use_cases.split(',')] if args.use_cases else None
+        tags = [t.strip() for t in args.tags.split(',')] if args.tags else None
+
+        notebook = library.add_notebook(
+            url=args.url,
+            name=args.name,
+            description=args.description,
+            topics=topics,
+            use_cases=use_cases,
+            tags=tags
+        )
+        print(json.dumps(notebook, indent=2))
+
+    elif args.command == 'list':
+        notebooks = library.list_notebooks()
+        if notebooks:
+            print("\n📚 Notebook Library:")
+            for notebook in notebooks:
+                active = " [ACTIVE]" if notebook['id'] == library.active_notebook_id else ""
+                print(f"\n  📓 {notebook['name']}{active}")
+                print(f"     ID: {notebook['id']}")
+                print(f"     Topics: {', '.join(notebook['topics'])}")
+                print(f"     Uses: {notebook['use_count']}")
+        else:
+            print("📚 Library is empty. Add notebooks with: notebook_manager.py add")
+
+    elif args.command == 'search':
+        results = library.search_notebooks(args.query)
+        if results:
+            print(f"\n🔍 Found {len(results)} notebooks:")
+            for notebook in results:
+                print(f"\n  📓 {notebook['name']} ({notebook['id']})")
+                print(f"     {notebook['description']}")
+        else:
+            print(f"🔍 No notebooks found for: {args.query}")
+
+    elif args.command == 'activate':
+        notebook = library.select_notebook(args.id)
+        print(f"Now using: {notebook['name']}")
+
+    elif args.command == 'remove':
+        if library.remove_notebook(args.id):
+            print("Notebook removed from library")
+
+    elif args.command == 'stats':
+        stats = library.get_stats()
+        print("\n📊 Library Statistics:")
+        print(f"  Total notebooks: {stats['total_notebooks']}")
+        print(f"  Total topics: {stats['total_topics']}")
+        print(f"  Total uses: {stats['total_use_count']}")
+        if stats['active_notebook']:
+            print(f"  Active: {stats['active_notebook']['name']}")
+        if stats['most_used_notebook']:
+            print(f"  Most used: {stats['most_used_notebook']['name']} ({stats['most_used_notebook']['use_count']} uses)")
+        print(f"  Library path: {stats['library_path']}")
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/notebooklm/scripts/run.py
+++ b/skills/notebooklm/scripts/run.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Universal runner for NotebookLM skill scripts
+Ensures all scripts run with the correct virtual environment
+"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def get_venv_python():
+    """Get the virtual environment Python executable"""
+    skill_dir = Path(__file__).parent.parent
+    venv_dir = skill_dir / ".venv"
+
+    if os.name == 'nt':  # Windows
+        venv_python = venv_dir / "Scripts" / "python.exe"
+    else:  # Unix/Linux/Mac
+        venv_python = venv_dir / "bin" / "python"
+
+    return venv_python
+
+
+def ensure_venv():
+    """Ensure virtual environment exists"""
+    skill_dir = Path(__file__).parent.parent
+    venv_dir = skill_dir / ".venv"
+    setup_script = skill_dir / "scripts" / "setup_environment.py"
+
+    # Check if venv exists
+    if not venv_dir.exists():
+        print("🔧 First-time setup: Creating virtual environment...")
+        print("   This may take a minute...")
+
+        # Run setup with system Python
+        result = subprocess.run([sys.executable, str(setup_script)])
+        if result.returncode != 0:
+            print("❌ Failed to set up environment")
+            sys.exit(1)
+
+        print("✅ Environment ready!")
+
+    return get_venv_python()
+
+
+def main():
+    """Main runner"""
+    if len(sys.argv) < 2:
+        print("Usage: python run.py <script_name> [args...]")
+        print("\nAvailable scripts:")
+        print("  ask_question.py    - Query NotebookLM")
+        print("  notebook_manager.py - Manage notebook library")
+        print("  session_manager.py  - Manage sessions")
+        print("  auth_manager.py     - Handle authentication")
+        print("  cleanup_manager.py  - Clean up skill data")
+        sys.exit(1)
+
+    script_name = sys.argv[1]
+    script_args = sys.argv[2:]
+
+    # Handle both "scripts/script.py" and "script.py" formats
+    if script_name.startswith('scripts/'):
+        # Remove the scripts/ prefix if provided
+        script_name = script_name[8:]  # len('scripts/') = 8
+
+    # Ensure .py extension
+    if not script_name.endswith('.py'):
+        script_name += '.py'
+
+    # Get script path
+    skill_dir = Path(__file__).parent.parent
+    script_path = skill_dir / "scripts" / script_name
+
+    if not script_path.exists():
+        print(f"❌ Script not found: {script_name}")
+        print(f"   Working directory: {Path.cwd()}")
+        print(f"   Skill directory: {skill_dir}")
+        print(f"   Looked for: {script_path}")
+        sys.exit(1)
+
+    # Ensure venv exists and get Python executable
+    venv_python = ensure_venv()
+
+    # Build command
+    cmd = [str(venv_python), str(script_path)] + script_args
+
+    # Run the script
+    try:
+        result = subprocess.run(cmd)
+        sys.exit(result.returncode)
+    except KeyboardInterrupt:
+        print("\n⚠️ Interrupted by user")
+        sys.exit(130)
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/notebooklm/scripts/setup_environment.py
+++ b/skills/notebooklm/scripts/setup_environment.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Environment Setup for NotebookLM Skill
+Manages virtual environment and dependencies automatically
+"""
+
+import os
+import sys
+import subprocess
+import venv
+from pathlib import Path
+
+
+class SkillEnvironment:
+    """Manages skill-specific virtual environment"""
+
+    def __init__(self):
+        # Skill directory paths
+        self.skill_dir = Path(__file__).parent.parent
+        self.venv_dir = self.skill_dir / ".venv"
+        self.requirements_file = self.skill_dir / "requirements.txt"
+
+        # Python executable in venv
+        if os.name == 'nt':  # Windows
+            self.venv_python = self.venv_dir / "Scripts" / "python.exe"
+            self.venv_pip = self.venv_dir / "Scripts" / "pip.exe"
+        else:  # Unix/Linux/Mac
+            self.venv_python = self.venv_dir / "bin" / "python"
+            self.venv_pip = self.venv_dir / "bin" / "pip"
+
+    def ensure_venv(self) -> bool:
+        """Ensure virtual environment exists and is set up"""
+
+        # Check if we're already in the correct venv
+        if self.is_in_skill_venv():
+            print("✅ Already running in skill virtual environment")
+            return True
+
+        # Create venv if it doesn't exist
+        if not self.venv_dir.exists():
+            print(f"🔧 Creating virtual environment in {self.venv_dir.name}/")
+            try:
+                venv.create(self.venv_dir, with_pip=True)
+                print("✅ Virtual environment created")
+            except Exception as e:
+                print(f"❌ Failed to create venv: {e}")
+                return False
+
+        # Install/update dependencies
+        if self.requirements_file.exists():
+            print("📦 Installing dependencies...")
+            try:
+                # Upgrade pip first
+                subprocess.run(
+                    [str(self.venv_pip), "install", "--upgrade", "pip"],
+                    check=True,
+                    capture_output=True,
+                    text=True
+                )
+
+                # Install requirements
+                result = subprocess.run(
+                    [str(self.venv_pip), "install", "-r", str(self.requirements_file)],
+                    check=True,
+                    capture_output=True,
+                    text=True
+                )
+                print("✅ Dependencies installed")
+
+                # Install Chrome for Patchright (not Chromium!)
+                # Using real Chrome ensures cross-platform reliability and consistent browser fingerprinting
+                # See: https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python#anti-detection
+                print("🌐 Installing Google Chrome for Patchright...")
+                try:
+                    subprocess.run(
+                        [str(self.venv_python), "-m", "patchright", "install", "chrome"],
+                        check=True,
+                        capture_output=True,
+                        text=True
+                    )
+                    print("✅ Chrome installed")
+                except subprocess.CalledProcessError as e:
+                    print(f"⚠️ Warning: Failed to install Chrome: {e}")
+                    print("   You may need to run manually: python -m patchright install chrome")
+                    print("   Chrome is required (not Chromium) for reliability!")
+
+                return True
+            except subprocess.CalledProcessError as e:
+                print(f"❌ Failed to install dependencies: {e}")
+                print(f"   Output: {e.output if hasattr(e, 'output') else 'No output'}")
+                return False
+        else:
+            print("⚠️ No requirements.txt found, skipping dependency installation")
+            return True
+
+    def is_in_skill_venv(self) -> bool:
+        """Check if we're already running in the skill's venv"""
+        if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+            # We're in a venv, check if it's ours
+            venv_path = Path(sys.prefix)
+            return venv_path == self.venv_dir
+        return False
+
+    def get_python_executable(self) -> str:
+        """Get the correct Python executable to use"""
+        if self.venv_python.exists():
+            return str(self.venv_python)
+        return sys.executable
+
+    def run_script(self, script_name: str, args: list = None) -> int:
+        """Run a script with the virtual environment"""
+        script_path = self.skill_dir / "scripts" / script_name
+
+        if not script_path.exists():
+            print(f"❌ Script not found: {script_path}")
+            return 1
+
+        # Ensure venv is set up
+        if not self.ensure_venv():
+            print("❌ Failed to set up environment")
+            return 1
+
+        # Build command
+        cmd = [str(self.venv_python), str(script_path)]
+        if args:
+            cmd.extend(args)
+
+        print(f"🚀 Running: {script_name} with venv Python")
+
+        try:
+            # Run the script with venv Python
+            result = subprocess.run(cmd)
+            return result.returncode
+        except Exception as e:
+            print(f"❌ Failed to run script: {e}")
+            return 1
+
+    def activate_instructions(self) -> str:
+        """Get instructions for manual activation"""
+        if os.name == 'nt':
+            activate = self.venv_dir / "Scripts" / "activate.bat"
+            return f"Run: {activate}"
+        else:
+            activate = self.venv_dir / "bin" / "activate"
+            return f"Run: source {activate}"
+
+
+def main():
+    """Main entry point for environment setup"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Setup NotebookLM skill environment'
+    )
+
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Check if environment is set up'
+    )
+
+    parser.add_argument(
+        '--run',
+        help='Run a script with the venv (e.g., --run ask_question.py)'
+    )
+
+    parser.add_argument(
+        'args',
+        nargs='*',
+        help='Arguments to pass to the script'
+    )
+
+    args = parser.parse_args()
+
+    env = SkillEnvironment()
+
+    if args.check:
+        if env.venv_dir.exists():
+            print(f"✅ Virtual environment exists: {env.venv_dir}")
+            print(f"   Python: {env.get_python_executable()}")
+            print(f"   To activate manually: {env.activate_instructions()}")
+        else:
+            print(f"❌ No virtual environment found")
+            print(f"   Run setup_environment.py to create it")
+        return
+
+    if args.run:
+        # Run a script with venv
+        return env.run_script(args.run, args.args)
+
+    # Default: ensure environment is set up
+    if env.ensure_venv():
+        print("\n✅ Environment ready!")
+        print(f"   Virtual env: {env.venv_dir}")
+        print(f"   Python: {env.get_python_executable()}")
+        print(f"\nTo activate manually: {env.activate_instructions()}")
+        print(f"Or run scripts directly: python setup_environment.py --run script_name.py")
+    else:
+        print("\n❌ Environment setup failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
## Summary
- Adds the **Banana Claude** skill (v1.4.1) — a Creative Director pipeline for AI image generation using Google Gemini Nano Banana models
- Includes 9 domain modes (Cinema, Product, Portrait, Editorial, UI/Web, Logo, Landscape, Infographic, Abstract), 5-component prompt formula, MCP integration with direct API fallback scripts, batch workflows, brand presets, cost tracking, and post-processing pipelines
- Based on [AgriciDaniel/banana-claude](https://github.com/AgriciDaniel/banana-claude) (MIT license)

## What's included
- `skills/banana-image-gen/SKILL.md` — Main skill orchestration
- `skills/banana-image-gen/references/` — 6 reference docs (prompt engineering, Gemini models, MCP tools, post-processing, cost tracking, presets)
- `skills/banana-image-gen/scripts/` — 7 Python scripts (zero pip dependencies, stdlib only)
- `skills/banana-image-gen/evals/evals.json` — 6 evaluation scenarios

## Test plan
- [ ] Verify skill loads correctly via `/banana` command
- [ ] Validate evals pass against skill behavior
- [ ] Confirm references load on-demand as documented
- [ ] Test MCP setup flow with `/banana setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)