### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,6 +53,14 @@
         "./skills/site-architecture",
         "./skills/social-content"
       ]
+    },
+    {
+      "name": "mmx-cli",
+      "description": "Generate text, images, video, speech, and music via MiniMax AI platform",
+      "source": "MiniMax-AI/cli",
+      "skills": [
+        "./skill/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `.claude-plugin/marketplace.json` plugins array so the mmx-cli skill is discoverable out of the box
- Users can install via `/plugin install mmx-cli` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**8 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `/plugin marketplace add coreyhaines31/marketingskills` lists the mmx-cli plugin
- `/plugin install mmx-cli` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal