### PR TITLE
fix: harden CLI tools against credential leakage

### DIFF
--- a/tools/clis/supermetrics.js
+++ b/tools/clis/supermetrics.js
@@ -9,17 +9,18 @@ if (!API_KEY) {
 }
 
 async function api(method, path, body) {
-  const separator = path.includes('?') ? '&' : '?'
-  const url = `${BASE_URL}${path}${separator}api_key=${API_KEY}`
+  const url = `${BASE_URL}${path}`
+  const headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'x-api-key': API_KEY,
+  }
   if (args['dry-run']) {
-    return { _dry_run: true, method, url: url.replace(API_KEY, '***'), headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' }, body: body || undefined }
+    return { _dry_run: true, method, url, headers: { ...headers, 'x-api-key': '***' }, body: body || undefined }
   }
   const res = await fetch(url, {
     method,
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json',
-    },
+    headers,
     body: body ? JSON.stringify(body) : undefined,
   })
   const text = await res.text()

--- a/tools/clis/zoominfo.js
+++ b/tools/clis/zoominfo.js
@@ -92,7 +92,14 @@ async function main() {
         break
       }
       const token = await authenticate()
-      result = { jwt: token }
+      if (args['show-token']) {
+        result = { jwt: token }
+      } else {
+        const masked = token.length > 12
+          ? token.slice(0, 6) + '…' + token.slice(-6)
+          : '***'
+        result = { jwt: masked, hint: 'Use --show-token to reveal full JWT' }
+      }
       break
     }
 
@@ -188,7 +195,7 @@ async function main() {
       result = {
         error: 'Unknown command',
         usage: {
-          auth: 'auth — authenticate and get JWT token',
+          auth: 'auth [--show-token] — authenticate and get JWT token (masked by default)',
           contacts: {
             search: 'contacts search [--job-title <t>] [--company <c>] [--location <l>] [--seniority <s>] [--department <d>] [--page <n>]',
             enrich: 'contacts enrich --email <email> | --person-id <id>',


### PR DESCRIPTION
## Summary
- **Supermetrics CLI**: Move API key from query string to `x-api-key` header (prevents key appearing in server logs and browser history)
- **ZoomInfo CLI**: Mask JWT by default in `auth` command output; add `--show-token` flag to reveal full token when needed

Cherry-picked the useful security fixes from #201 (the rest introduced breaking changes).

Closes #201

## Test plan
- [ ] `node --check tools/clis/supermetrics.js` passes
- [ ] `node --check tools/clis/zoominfo.js` passes
- [ ] Supermetrics dry-run shows `x-api-key: ***` in headers, no key in URL
- [ ] ZoomInfo `auth` shows masked JWT by default
- [ ] ZoomInfo `auth --show-token` reveals full JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)