### PR TITLE
chore: sync main with v1.8.0 post-release fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "1.0.0",
+    "version": "1.8.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Skills reference each other and build on shared context. The `product-marketing-
 │seo-audit │ │page-cro  │ │copywritng│ │paid-ads    │ │referral  │ │revops       │ │mktg-ideas │
 │ai-seo    │ │signup-cro│ │copy-edit │ │ad-creative │ │free-tool │ │sales-enable │ │mktg-psych │
 │site-arch │ │onboard   │ │cold-email│ │ab-test     │ │churn-    │ │launch       │ │customer-  │
-│programm  │ │form-cro  │ │email-seq │ │analytics   │ │ prevent  │ │pricing      │ │research   │
-│schema    │ │popup-cro │ │social    │ │            │ │          │ │competitor   │ │           │
-│content   │ │paywall   │ │          │ │            │ │          │ │             │ │           │
+│programm  │ │form-cro  │ │email-seq │ │analytics   │ │ prevent  │ │pricing      │ │ research  │
+│schema    │ │popup-cro │ │social    │ │            │ │community │ │comp-alts    │ │           │
+│content   │ │paywall   │ │          │ │            │ │lead-magnt│ │comp-profile │ │           │
+│aso-audit │ │          │ │          │ │            │ │          │ │directory    │ │           │
 └────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
      │            │            │              │             │              │              │
      └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -46,18 +46,16 @@ Current versions of all skills. Agents can compare against local versions to che
 ## Recent Changes
 
 ### 2026-04-21
-- Added `aso-audit` skill for App Store and Google Play optimization
-- Added `community-marketing` skill for community-led growth
-- Added `customer-research` skill for customer interviews, surveys, and voice-of-customer analysis
 - Added `directory-submissions` skill for Product Hunt, G2, AI directories, and backlink strategy
 - Added `competitor-profiling` skill for competitive intelligence research
 - Added international SEO & localization section to `seo-audit` (1.2.0)
 - Added conversion tracking reference to `paid-ads` (cross-platform pixel setup)
 - Added Zapier SDK integration for 8,000+ app access
-- Fixed plugin loading: removed `./` prefix from marketplace.json skill paths
+- Fixed plugin loading: removed `./` prefix from marketplace.json skill paths (#243)
 - Hardened CLI tools: Supermetrics API key moved to header, ZoomInfo JWT masked by default
-- Fixed community-marketing YAML frontmatter
-- Fixed Zapier webhook URL validation
+- Fixed community-marketing YAML frontmatter (#240)
+- Fixed Zapier webhook URL validation (#247)
+- Added missing skills to VERSIONS.md (aso-audit, community-marketing, customer-research — shipped in prior releases)
 - Total skills: 38
 
 ### 2026-03-14


### PR DESCRIPTION
## Summary

Post-release fixes after v1.8.0:

- Updated marketplace.json version from 1.0.0 to 1.8.0
- Corrected v1.8.0 changelog (aso-audit, community-marketing, customer-research shipped in prior releases)
- Updated README diagram to include all 38 skills (was missing 5)

No new features — just accuracy fixes for the release.