### PR TITLE
Fix marketplace.json source field so plugin install works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "marketing-skills",
       "description": "38 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
-      "source": ".",
+      "source": "./",
       "strict": false,
       "skills": [
         "./skills/ab-test-setup",


### PR DESCRIPTION
## Summary
- In v1.8.0 of `.claude-plugin/marketplace.json`, the `plugins[0].source` field changed from `./` to `.`.
- Claude Code's marketplace schema validator rejects `"."` with:
  ```
  plugins.0.source: Invalid input
  ```
- That means `claude plugin marketplace add coreyhaines31/marketingskills` and any subsequent `claude plugin install marketing-skills@marketingskills` fail for anyone pulling the current upstream.
- Previous versions used `"./"` and installed fine.

This PR restores `"./"` so installs work again. One-character change, nothing else touched.

## Test plan
- [x] Clone locally, patch `.` → `./`, run `claude plugin marketplace add <local path>`: succeeds.
- [x] `claude plugin install marketing-skills@marketingskills`: succeeds, 38 skills load under `marketing-skills:*` with no duplicate `1.0.0:*` namespace.

Noticed while reinstalling the plugin after the old v1.0.0 cache went stale. Thanks for maintaining this.