### PR TITLE
feat: add short-form video to social-content skill

### DIFF
--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: social-content
-description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' or 'grow my following.' Use this for any social media content creation, repurposing, or scheduling task. For broader content strategy, see content-strategy."
+description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' or 'create a reel.' Use this for social media content creation, repurposing, scheduling, and short-form video scripting. For broader content strategy, see content-strategy. For paid video ads, see ad-creative."
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Social Content
@@ -306,6 +306,87 @@ Instead of guessing, analyze what's working for top creators in your niche:
 6. **Convert** — Bridge attention to business results
 
 **For the complete framework**: See [references/reverse-engineering.md](references/reverse-engineering.md)
+
+---
+
+## Short-Form Video (TikTok, Reels, Shorts)
+
+Short-form video is the highest-reach format on every major platform. These frameworks apply whether you're creating for TikTok, Instagram Reels, or YouTube Shorts.
+
+### Platform Specs
+
+| Platform | Optimal Length | Aspect Ratio | Key Difference |
+|----------|---------------|--------------|----------------|
+| TikTok | 15-60 sec | 9:16 | Trending sounds, raw/authentic feel |
+| Reels | 15-30 sec | 9:16 | Polished content, rewards saves/shares |
+| Shorts | 30-60 sec | 9:16 | YouTube SEO applies, searchable titles |
+
+### The 3-Second Rule
+
+You have 3 seconds to stop the scroll. Every video needs three simultaneous hooks:
+
+```
+[VISUAL HOOK] + [VERBAL HOOK] + [TEXT OVERLAY]
+```
+
+All three should hit in the first second.
+
+### Video Structures
+
+**Problem-Solution (15-30 sec):**
+```
+[0-3s]  Hook: State the problem
+[3-10s] Agitate: Why it matters
+[10-25s] Solution: Your method/product/tip
+[25-30s] CTA: What to do next
+```
+
+**List Format (30-60 sec):**
+```
+[0-3s]  Hook: "X things that [outcome]"
+[3-50s] Items: One every 5-8 seconds
+[50-60s] CTA
+```
+
+**Tutorial (30-60 sec):**
+```
+[0-3s]  Hook: Show the end result first
+[3-8s]  Overview: "Here's how..."
+[8-50s] Steps: Quick, clear instructions
+[50-60s] Result + CTA
+```
+
+### Caption & Subtitle Best Practices
+
+Captions increase watch time by 25-40%. Most social video is watched without sound.
+
+- **MAX 2 lines** on screen at once
+- **3-5 words per line**
+- Bold, sans-serif font with black outline
+- **Highlight key words** in a different color
+- Match timing to speech exactly
+
+Tools: CapCut (free), Descript, Captions.ai, Premiere Pro
+
+### Content Ideas by Type
+
+| Business Type | Video Ideas |
+|---------------|-------------|
+| SaaS | Feature demos (show outcome first), before/after, "Watch me do X in Y seconds" |
+| E-commerce | Unboxing, comparisons, how it's made, customer reviews |
+| Services | Process reveals, client transformations, myth-busting |
+| Personal brand | Lessons learned, controversial takes, day-in-the-life |
+
+### Common Mistakes
+
+1. **Slow hooks** — don't build up to the point
+2. **No text overlay** — many watch without sound
+3. **Poor audio** — bad audio kills retention instantly
+4. **Too long** — if it can be shorter, make it shorter
+5. **No CTA** — tell viewers what to do
+6. **Ignoring comments** — engagement in first hour matters
+
+**For video hook formulas and scripting templates**: See [references/short-form-video.md](references/short-form-video.md)
 
 ---
 

--- a/skills/social-content/references/short-form-video.md
+++ b/skills/social-content/references/short-form-video.md
@@ -1,0 +1,237 @@
+# Short-Form Video: Hooks, Scripts & Strategy
+
+Detailed reference for creating short-form video content on TikTok, Instagram Reels, and YouTube Shorts.
+
+---
+
+## Video Hook Library
+
+### Curiosity Hooks (Best for engagement)
+
+**The "Secret" Formula:**
+- "The secret to [outcome] that nobody talks about"
+- "I found the hidden feature in [product/platform] that changes everything"
+- "I can't believe this actually works..."
+
+**The Unexpected Discovery:**
+- "I tried [thing] for 30 days and I was NOT expecting this"
+- "This completely changed how I think about [topic]"
+- "Nobody talks about this, but..."
+
+**The Question:**
+- "Why does nobody talk about this?"
+- "Am I the only one who didn't know this?"
+- "The reason [common thing] doesn't work is..."
+
+### Value Hooks (Best for saves)
+
+**The Promise:**
+- "How to [achieve outcome] in [specific timeframe]"
+- "[Number] [things] that will [benefit]"
+- "Everything you need to know about [topic] in 60 seconds"
+
+**The Hack/Shortcut:**
+- "[Outcome] hack that actually works"
+- "The [adjective] way to [outcome]"
+- "If you're struggling with [problem], watch this"
+
+**The Warning:**
+- "Stop doing [common practice] — here's why"
+- "[Number] mistakes that are killing your [results]"
+- "Why [thing you think is good] is actually hurting you"
+
+### Story Hooks (Best for watch time)
+
+**The Transformation:**
+- "3 months ago, I [bad state]. Today, I [good state]."
+- "Here's how I went from [before] to [after]"
+- "I used to think [old belief]. Then [event] changed everything."
+
+**The Failure:**
+- "I made a huge mistake with [topic]"
+- "Here's why I stopped [common practice]"
+- "I lost [something significant] because of this mistake"
+
+**The Journey:**
+- "So this just happened..."
+- "This changed everything for me"
+- "Let me tell you about the time I [interesting situation]"
+
+### Controversial Hooks (Best for comments)
+
+- "Unpopular opinion: [bold statement]"
+- "[Common advice] is actually wrong"
+- "I'm going to get hate for this, but..."
+- "Most [audience] get this completely wrong"
+
+---
+
+## Scripting Template
+
+```markdown
+## Video: [Working Title]
+
+**Platform:** TikTok / Reels / Shorts
+**Length:** XX seconds
+**Format:** [Talking head / Slideshow / Demo / Screen recording]
+
+### Hook (0-3 sec)
+- Visual: [What viewer sees]
+- Audio: [What they hear]
+- Text overlay: [On-screen text]
+
+### Body (3-X sec)
+- [Timestamp] - [What happens/what you say]
+- [Timestamp] - [Next beat]
+- [Continue...]
+
+### CTA (final 3-5 sec)
+- Verbal: [What you say]
+- Text: [On-screen text]
+- Action: [Follow, comment, link in bio, etc.]
+
+### Production Notes
+- Music/sound: [Trending sound or music choice]
+- B-roll needed: [List any clips needed]
+- Graphics: [Any text animations or overlays]
+```
+
+---
+
+## Additional Video Structures
+
+### The Story Arc (45-60 sec)
+
+```
+[0-3s]  Hook: Tease the outcome
+[3-15s] Setup: Context and stakes
+[15-45s] Journey: What happened
+[45-55s] Resolution: The result
+[55-60s] Lesson/CTA
+```
+
+Best for: Personal stories, case studies, testimonials
+
+### The POV/Skit (15-30 sec)
+
+```
+[0-3s]  Setup: Text overlay sets the scene
+[3-25s] Performance: Act out the relatable scenario
+[25-30s] Punchline or twist
+```
+
+Best for: Relatable content, humor, niche communities
+
+---
+
+## Visual Patterns
+
+### Talking Head
+- Good lighting (ring light or window light)
+- Eye contact with camera
+- Hand gestures for emphasis
+- Interesting background (bookshelf, plants, studio setup)
+
+### Slideshow/Carousel Video
+- Strong visual on each slide (2-4 seconds per slide)
+- Text overlays with key points
+- Consistent style/branding
+- Voiceover or trending sound
+
+### Screen Recording
+- Zoom in on important areas
+- Add cursor highlight or click animations
+- Keep movements smooth and intentional
+- Overlay your face in corner (optional but boosts engagement)
+
+### B-Roll Heavy
+- Show don't tell
+- Quick cuts (1-3 seconds per shot)
+- Match cuts to voiceover beats
+- Mix wide, medium, and close-up shots
+
+---
+
+## Audio Strategy
+
+### When to Use Trending Sounds
+- Entertainment/lifestyle content where the sound fits your message
+- When the trend is still rising (check platform trending pages)
+- Don't use when it distracts from your message or is already declining
+
+### When to Use Original Audio
+- Educational content where you're speaking
+- Storytimes and personal narratives
+- Product demos and tutorials
+- Building a recognizable brand voice
+
+### Voiceover Tips
+- Speak slightly faster than normal conversation
+- Vary your tone — avoid monotone delivery
+- Pause for emphasis on key points
+- Record in a quiet space, use noise removal
+- AI voices work for faceless content (ElevenLabs, etc.)
+
+### Music Selection
+- Match energy to content (upbeat for tips, emotional for stories)
+- Avoid copyrighted music on Reels/Shorts
+- Use platform music libraries for safety
+- Lower music volume under voiceover (ducking)
+
+---
+
+## Posting Strategy
+
+### Optimal Posting Times (test your audience)
+
+| Platform | Best Times (local) |
+|----------|-------------------|
+| TikTok | 7-9 AM, 12-3 PM, 7-11 PM |
+| Reels | 9 AM, 12 PM, 7-9 PM |
+| Shorts | 12-3 PM, 7-9 PM |
+
+### Frequency Recommendations
+
+| Goal | Minimum | Optimal |
+|------|---------|---------|
+| Growing | 1/day | 2-4/day |
+| Maintaining | 3/week | 1/day |
+| Testing | 2/week | 5/week |
+
+### Batch Creation Workflow
+
+1. **Ideate** (30 min): Generate 10-20 concepts
+2. **Script** (1 hour): Write scripts for 5-10 videos
+3. **Batch film** (2 hours): Record all talking head content
+4. **Edit** (2-3 hours): Edit and add captions
+5. **Schedule** (30 min): Queue for optimal times
+
+---
+
+## Analytics & Iteration
+
+### Metrics That Matter
+
+| Metric | What It Tells You |
+|--------|-------------------|
+| Watch time % | Is content engaging throughout? |
+| Completion rate | Did hook + content deliver? |
+| Saves | Is content valuable enough to revisit? |
+| Shares | Is content worth spreading? |
+| Comments | Did content spark conversation? |
+| Follows | Did viewer want more from you? |
+
+### What to Test
+
+1. **Hooks**: Same content, different opening
+2. **Length**: 15 sec vs 30 sec vs 60 sec
+3. **Format**: Talking head vs slideshow vs demo
+4. **Time**: Morning vs afternoon vs evening
+5. **CTA**: Different calls to action
+
+### When to Pivot
+
+- 5+ videos with <1% completion rate → change hooks
+- High views but low follows → check CTA and content-audience fit
+- High saves but low shares → content is valuable but not social
+- Lots of comments but negative → lean into controversy or adjust tone


### PR DESCRIPTION
## Summary

Adds short-form video (TikTok, Reels, Shorts) guidance to the social-content skill:

- **SKILL.md**: New section with platform specs, 3-second rule, video structures (problem-solution, list, tutorial), caption best practices, content ideas by business type, common mistakes
- **references/short-form-video.md**: Hook library (curiosity, value, story, controversial), scripting template, additional structures (story arc, POV/skit), visual patterns, audio strategy, posting strategy, analytics
- Updated description with short-form video trigger phrases
- Version bump: 1.2.0 → 1.3.0

Incorporates the vendor-neutral content from rejected PR #200 as suggested in that PR's closing comment.

## Test plan
- [ ] SKILL.md under 500 lines (409)
- [ ] Frontmatter valid (name matches directory, description under 1024 chars)
- [ ] Reference file linked correctly from SKILL.md
- [ ] No vendor-specific tool recommendations (vendor-neutral)