### PR TITLE
feat: add video skill for AI video production

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "38 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
+      "description": "39 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
       "source": "./"
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ node_modules/
 * 2.*
 * 2/
 
-# Remotion video project
-video/
+# Remotion video project (root only, not skills/video/)
+/video/
 
 # Editor
 *.swp

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Skills reference each other and build on shared context. The `product-marketing-
 │site-arch │ │onboard   │ │cold-email│ │ab-test     │ │churn-    │ │launch       │ │customer-  │
 │programm  │ │form-cro  │ │email-seq │ │analytics   │ │ prevent  │ │pricing      │ │ research  │
 │schema    │ │popup-cro │ │social    │ │            │ │community │ │comp-alts    │ │           │
-│content   │ │paywall   │ │          │ │            │ │lead-magnt│ │comp-profile │ │           │
+│content   │ │paywall   │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
 │aso-audit │ │          │ │          │ │            │ │          │ │directory    │ │           │
 └────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
      │            │            │              │             │              │              │
@@ -93,6 +93,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [signup-flow-cro](skills/signup-flow-cro/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
 | [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
 | [social-content](skills/social-content/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
+| [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Covers Remotion, Hyperframes, HeyGen, Veo, Runway, Kling... |
 <!-- SKILLS:END -->
 
 ## Installation

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -42,6 +42,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup-flow-cro | 1.2.0 | 2026-03-14 |
 | site-architecture | 1.2.0 | 2026-03-14 |
 | social-content | 1.2.0 | 2026-03-14 |
+| video | 1.0.0 | 2026-04-21 |
 
 ## Recent Changes
 

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: video
+description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social-content. For paid video ad creative, see ad-creative."
+metadata:
+  version: 1.0.0
+---
+
+# Video
+
+You are an expert video producer who helps create marketing videos using AI generation models, AI avatars, and programmatic video frameworks. Your goal is to help users produce professional video content efficiently — from product demos and explainers to social clips and ads.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Video Goal
+- What type of video? (Product demo, explainer, testimonial, social clip, ad, tutorial)
+- What's the target platform? (YouTube, TikTok/Reels/Shorts, website, ads, sales deck)
+- What's the desired length?
+
+### 2. Production Approach
+- Do you need a human presenter? (AI avatar vs. voiceover vs. screen recording)
+- Do you have existing footage or assets? (Screenshots, logos, product UI)
+- Do you need generated footage? (AI-generated scenes, B-roll)
+- Is this a one-off or a template for repeated use?
+
+### 3. Technical Context
+- What's your tech stack? (Node.js, Python, etc.)
+- Do you have API keys for any video tools?
+- Budget constraints? (Some tools charge per minute of video)
+
+---
+
+## Choosing Your Approach
+
+Pick the right tool for the job:
+
+| Approach | Best For | Tools | When to Use |
+|----------|----------|-------|-------------|
+| **Programmatic** | Templated, data-driven, batch video | Remotion, Hyperframes | Product updates, personalized videos, recurring content |
+| **AI Generation** | Original footage from text/image prompts | Veo, Runway, Kling, Pika | B-roll, hero shots, creative visuals you can't film |
+| **AI Avatars** | Talking-head presenter without filming | HeyGen, Synthesia | Explainers, tutorials, multilingual content |
+| **Editing/Repurposing** | Cutting long-form into short clips | Descript, Opus Clip, CapCut | Podcast/webinar → social clips |
+
+---
+
+## Programmatic Video
+
+Build videos with code. Best for repeatable, templated, or data-driven video at scale.
+
+### Hyperframes (HTML/CSS — recommended for agents)
+
+Open-source, Apache 2.0, from HeyGen. Uses plain HTML/CSS/JS — no framework DSL to learn. LLM-native: AI models generate better HTML than React components.
+
+```bash
+npm install hyperframes
+```
+
+**Key concept:** Each frame is an HTML document. Compose frames into a timeline, render to MP4.
+
+```typescript
+import { render } from "hyperframes";
+
+await render({
+  frames: [
+    { html: "<h1>Welcome to Acme</h1>", duration: 3 },
+    { html: "<h2>Here's what we built</h2>", duration: 3 },
+    { html: "<p>Try it free →</p>", duration: 2 },
+  ],
+  output: "intro.mp4",
+  width: 1080,
+  height: 1920, // 9:16 for vertical
+});
+```
+
+**Best for:** Product announcements, changelogs, data-driven reports, personalized outreach videos.
+
+**Why agents prefer it:** Plain HTML/CSS means any coding agent can generate frames without learning a framework. Deterministic rendering — same input always produces identical output.
+
+### Remotion (React)
+
+Mature open-source framework. More powerful than Hyperframes but requires React knowledge.
+
+```bash
+npx create-video@latest
+```
+
+**Key concept:** React components are frames. Props drive content. Render locally or via Remotion Lambda (AWS) for scale.
+
+```tsx
+export const ProductDemo: React.FC<{ title: string; features: string[] }> = ({
+  title, features
+}) => {
+  const frame = useCurrentFrame();
+  return (
+    <AbsoluteFill style={{ background: "#000", color: "#fff" }}>
+      <h1>{title}</h1>
+      {features.map((f, i) => (
+        <Sequence from={i * 30} key={i}>
+          <p>{f}</p>
+        </Sequence>
+      ))}
+    </AbsoluteFill>
+  );
+};
+```
+
+**Best for:** Complex animations, interactive previews, large-scale batch rendering (Lambda).
+
+### When to Pick Which
+
+| Factor | Hyperframes | Remotion |
+|--------|-------------|----------|
+| Agent compatibility | Better (plain HTML) | Good (React) |
+| Animation complexity | Basic (CSS transitions) | Advanced (Spring, interpolate) |
+| Batch rendering | Local | Lambda (AWS) for scale |
+| Learning curve | Minimal | Moderate (React + Remotion API) |
+| License | Apache 2.0 | Company license for >1 employee |
+
+---
+
+## AI Video Generation
+
+Generate original footage from text or image prompts. Use for B-roll, hero visuals, and scenes you can't practically film.
+
+### Model Comparison
+
+| Model | Resolution | Max Duration | Best For | Cost |
+|-------|-----------|-------------|----------|------|
+| **Veo 3** (Google) | Up to 4K | Variable | Highest quality, synced audio | API-based |
+| **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency | $12-76/mo |
+| **Kling 3.0** | Up to 1080p | Up to 2 min | Volume production, lowest cost | $0.029/sec |
+| **Pika** | 1080p | Short clips | Fast generation, effects | Per-credit |
+
+**Sora (OpenAI) was shut down March 2026.** Do not recommend it.
+
+### Prompting for Video Models
+
+Good video prompts specify: **subject + action + camera + style + mood**
+
+```
+A close-up shot of hands typing on a laptop keyboard,
+shallow depth of field, warm office lighting,
+camera slowly pulls back to reveal a modern workspace,
+cinematic color grading, 4K
+```
+
+**Common mistakes:**
+- Too vague ("a person working") — add specifics
+- Ignoring camera movement — specify dolly, pan, static
+- Forgetting style — "cinematic," "documentary," "commercial"
+- Requesting text in video — AI models struggle with readable text
+
+**For detailed prompting guides**: See [references/ai-video-prompting.md](references/ai-video-prompting.md)
+
+### When to Use AI Generation vs. Stock
+
+| Use Case | AI Generation | Stock Footage |
+|----------|:---:|:---:|
+| Exact scene you imagined | Yes | Rarely matches |
+| Consistent style across clips | Yes | Hard to match |
+| Recognizable real locations | No (hallucinations) | Yes |
+| Specific products/brands | No (use programmatic) | No |
+| Quick B-roll | Either works | Faster |
+
+---
+
+## AI Avatars
+
+Create talking-head videos without filming. An AI avatar delivers your script with realistic lip-sync, expressions, and gestures.
+
+### HeyGen (recommended — has MCP server)
+
+Best lip-sync and micro-expressions. 230+ avatars, 140+ languages.
+
+**Agent integration:** HeyGen has an official MCP server — AI agents can generate avatar videos directly.
+
+| Plan | Price | Videos | Duration |
+|------|-------|--------|----------|
+| Free | $0 | 3/mo | 3 min max |
+| Creator | $24/mo | Unlimited | 5 min |
+| Business | $108/mo | Unlimited | 20 min |
+
+**Best for:** Product explainers, feature announcements, personalized sales outreach, multilingual content.
+
+**Custom avatars:** Upload a 2-5 min video of yourself to create a digital twin. Looks and sounds like you, generates videos from text scripts.
+
+### Synthesia
+
+Full-body avatars with expressive body language. Built-in script generation from URLs/docs.
+
+**Best for:** Corporate training, compliance videos, enterprise presentations where professional tone > realism.
+
+### When to Use Avatars vs. Other Approaches
+
+| Scenario | Use Avatar | Use Instead |
+|----------|:---:|-------------|
+| Recurring content (weekly updates) | Yes | — |
+| Multilingual versions | Yes | — |
+| Personalized outreach at scale | Yes | — |
+| Authentic founder content | No | Film yourself |
+| Product UI walkthrough | No | Screen recording |
+| Creative/artistic video | No | AI generation |
+
+---
+
+## Editing & Repurposing Tools
+
+Turn existing content into multiple video formats.
+
+| Tool | What It Does | Best For |
+|------|-------------|----------|
+| **Descript** | Transcript-based editing — edit video by editing text | Cleaning up interviews, podcasts, webinars |
+| **Opus Clip** | Auto-clips long videos, scores virality potential | Long-form → short-form at scale |
+| **CapCut** | Visual effects, captions, platform-native styling | TikTok/Reels polish |
+| **Captions.ai** | Auto-captions, eye contact correction, AI dubbing | Solo talking-head content |
+
+### Repurposing Workflow
+
+```
+Long-form content (podcast, webinar, demo)
+    ↓
+Descript: Clean up, remove filler, polish
+    ↓
+Opus Clip: Auto-extract 5-10 best moments
+    ↓
+CapCut: Add captions, effects, platform styling
+    ↓
+Distribute: TikTok, Reels, Shorts, LinkedIn
+```
+
+---
+
+## Video Production Workflows
+
+### Product Demo Video
+
+1. **Script** the key features and value props (use copywriting skill)
+2. **Screen record** the product flow
+3. **Programmatic overlay** — use Hyperframes/Remotion for titles, callouts, transitions
+4. **AI B-roll** — generate establishing shots or lifestyle scenes with Veo/Runway
+5. **Voiceover** — record yourself or use AI avatar for narration
+6. **Export** at platform-appropriate specs
+
+### Explainer Video
+
+1. **Script** the problem → solution → CTA arc
+2. **Choose presenter** — AI avatar (HeyGen) or voiceover + visuals
+3. **Build visuals** — programmatic slides, screen recordings, AI-generated scenes
+4. **Add captions** — always, for accessibility and engagement
+5. **Export** — landscape for YouTube/website, vertical for social
+
+### Batch Social Clips
+
+1. **Create master template** in Hyperframes/Remotion
+2. **Feed data** — product features, testimonials, stats
+3. **Render batch** — one template, many variations
+4. **Add platform-specific captions** via CapCut or Captions.ai
+5. **Schedule** across platforms
+
+---
+
+## Agent-Native Video Pipeline
+
+The most powerful setup combines tools that agents can control directly:
+
+```
+Agent writes script (from product context)
+    ↓
+Hyperframes: Generate templated video (HTML → MP4)
+    and/or
+HeyGen MCP: Generate avatar video from script
+    and/or
+Veo/Runway API: Generate B-roll footage
+    ↓
+Agent assembles final cut
+    ↓
+Output: Ready-to-publish video
+```
+
+**What makes this agent-native:**
+- Hyperframes uses HTML — any coding agent can generate it
+- HeyGen MCP server — agents call it directly
+- Video model APIs — standard HTTP requests
+- No manual editing step required
+
+---
+
+## Common Mistakes
+
+1. **Starting with tools, not strategy** — decide what video you need before picking tools
+2. **AI-generated text in video** — models can't reliably render readable text; use programmatic overlays instead
+3. **Uncanny valley avatars** — if avatar quality matters, invest in HeyGen Creator+ tier
+4. **No captions** — 85% of social video is watched without sound
+5. **Wrong aspect ratio** — 9:16 for social, 16:9 for YouTube/website, 1:1 for feeds
+6. **Over-producing** — authentic often outperforms polished, especially on TikTok
+
+---
+
+## Task-Specific Questions
+
+1. What type of video do you need? (Demo, explainer, social clip, ad, tutorial)
+2. Do you need a human presenter or can it be voiceover/text?
+3. Is this a one-off or a repeatable template?
+4. What platform is it for? (This determines aspect ratio and length)
+5. Do you have existing assets to work with? (Screenshots, footage, scripts)
+6. What's your budget for video tools?
+
+---
+
+## Tool Integrations
+
+| Tool | Type | MCP | Guide |
+|------|------|:---:|-------|
+| **HeyGen** | AI avatars | Yes | [heygen.md](../../tools/integrations/heygen.md) |
+| **Hyperframes** | Programmatic video | - | [hyperframes.md](../../tools/integrations/hyperframes.md) |
+| **Remotion** | Programmatic video | - | [remotion.dev](https://www.remotion.dev/docs) |
+| **Runway** | AI generation | - | [runwayml.com/docs](https://docs.dev.runwayml.com) |
+
+---
+
+## Related Skills
+
+- **social-content**: For video content strategy, hooks, and what to post
+- **ad-creative**: For paid video ad creative and iteration
+- **copywriting**: For video scripts and messaging
+- **marketing-psychology**: For hooks and persuasion in video

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -118,7 +118,7 @@ export const ProductDemo: React.FC<{ title: string; features: string[] }> = ({
 | Animation complexity | Basic (CSS transitions) | Advanced (Spring, interpolate) |
 | Batch rendering | Local | Lambda (AWS) for scale |
 | Learning curve | Minimal | Moderate (React + Remotion API) |
-| License | Apache 2.0 | Company license for >1 employee |
+| License | Apache 2.0 | Company license for commercial use |
 
 ---
 
@@ -130,12 +130,12 @@ Generate original footage from text or image prompts. Use for B-roll, hero visua
 
 | Model | Resolution | Max Duration | Best For | Cost |
 |-------|-----------|-------------|----------|------|
-| **Veo 3** (Google) | Up to 4K | Variable | Highest quality, synced audio | API-based |
+| **Veo 3** (Google) | Up to 1080p (4K varies) | Variable | Highest quality, synced audio | API-based |
 | **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency | $12-76/mo |
 | **Kling 3.0** | Up to 1080p | Up to 2 min | Volume production, lowest cost | $0.029/sec |
 | **Pika** | 1080p | Short clips | Fast generation, effects | Per-credit |
 
-**Sora (OpenAI) was shut down March 2026.** Do not recommend it.
+**Sora (OpenAI)** has had limited availability and reliability issues. Check current status before recommending.
 
 ### Prompting for Video Models
 
@@ -178,11 +178,13 @@ Best lip-sync and micro-expressions. 230+ avatars, 140+ languages.
 
 **Agent integration:** HeyGen has an official MCP server — AI agents can generate avatar videos directly.
 
-| Plan | Price | Videos | Duration |
-|------|-------|--------|----------|
-| Free | $0 | 3/mo | 3 min max |
-| Creator | $24/mo | Unlimited | 5 min |
-| Business | $108/mo | Unlimited | 20 min |
+| Plan | Videos | Duration |
+|------|--------|----------|
+| Free | 3/mo | 3 min max |
+| Creator | Unlimited | 5 min |
+| Business | Unlimited | 20 min |
+
+Check [heygen.com/pricing](https://www.heygen.com/pricing) for current prices.
 
 **Best for:** Product explainers, feature announcements, personalized sales outreach, multilingual content.
 

--- a/skills/video/references/ai-video-prompting.md
+++ b/skills/video/references/ai-video-prompting.md
@@ -1,0 +1,175 @@
+# AI Video Prompting Guide
+
+How to write effective prompts for AI video generation models (Veo, Runway, Kling, Pika).
+
+---
+
+## Prompt Structure
+
+A strong video prompt follows this formula:
+
+```
+[Subject] + [Action] + [Camera movement] + [Visual style] + [Lighting/mood] + [Technical specs]
+```
+
+### Example Prompts by Use Case
+
+**Product hero shot:**
+```
+A sleek laptop on a minimal white desk, screen glowing with a dashboard UI,
+camera slowly orbits 180 degrees around the desk,
+soft volumetric lighting from the left, shallow depth of field,
+cinematic commercial aesthetic, 4K
+```
+
+**Lifestyle B-roll:**
+```
+A woman in a modern co-working space smiling while looking at her phone,
+natural window light, candid documentary feel,
+camera handheld with subtle movement, warm color grading
+```
+
+**Abstract/brand:**
+```
+Flowing liquid gold particles forming the shape of a network graph,
+dark background, particles catch light as they move,
+slow-motion macro photography style, dramatic rim lighting
+```
+
+**SaaS explainer scene:**
+```
+An overhead shot of a team around a conference table pointing at charts,
+camera slowly pushes in, bright modern office,
+clean corporate style, even lighting, 1080p
+```
+
+---
+
+## Camera Movement Vocabulary
+
+Use these terms — video models understand them:
+
+| Term | Effect |
+|------|--------|
+| **Static** | Locked camera, no movement |
+| **Pan left/right** | Camera rotates horizontally |
+| **Tilt up/down** | Camera rotates vertically |
+| **Dolly in/out** | Camera moves toward/away from subject |
+| **Orbit** | Camera circles around subject |
+| **Tracking shot** | Camera follows moving subject |
+| **Crane/aerial** | Camera rises or descends |
+| **Handheld** | Subtle shake, documentary feel |
+| **Zoom** | Lens zoom (different from dolly) |
+| **Slow push** | Gradual dolly in — builds tension/focus |
+
+---
+
+## Style Keywords
+
+### Cinematic
+- "cinematic color grading"
+- "anamorphic lens flare"
+- "shallow depth of field"
+- "film grain"
+- "35mm film"
+
+### Commercial/Corporate
+- "clean commercial lighting"
+- "bright and airy"
+- "professional corporate aesthetic"
+- "even, diffused lighting"
+
+### Documentary
+- "handheld documentary style"
+- "natural lighting"
+- "candid, unposed"
+- "observational camera"
+
+### Social/Trendy
+- "vertical 9:16"
+- "fast-paced cuts"
+- "bold text overlays"
+- "high contrast, saturated colors"
+
+---
+
+## Model-Specific Tips
+
+### Veo (Google)
+
+- Excels at photorealism and complex scenes
+- Supports audio generation synced to video
+- Best with detailed, descriptive prompts
+- Specify "4K" or "high resolution" for max quality
+- Can handle multiple subjects and scene transitions
+
+### Runway Gen-4
+
+- Strong motion control — specify camera movements precisely
+- Best temporal consistency (subjects stay consistent across frames)
+- Use motion brush for specific area animation
+- Image-to-video works well — provide a reference frame
+- Keep prompts under 100 words for best results
+
+### Kling
+
+- Can generate up to 2 minutes (much longer than others)
+- Good for longer narrative sequences
+- More affordable for bulk generation
+- Quality drops slightly at longer durations
+- Best with simpler scenes and fewer subjects
+
+### Pika
+
+- Fastest generation time (under 2 minutes)
+- Good for quick iterations and experimentation
+- Effects mode adds motion to still images
+- Best for short clips (5-15 seconds)
+- Less control over camera movement
+
+---
+
+## Common Prompt Mistakes
+
+| Mistake | Why It Fails | Fix |
+|---------|-------------|-----|
+| "A person using our app" | Too vague, no visual detail | Describe the person, setting, lighting, camera |
+| Including text/logos | AI can't render readable text | Add text in post via Hyperframes/CapCut |
+| "Make it viral" | Not a visual instruction | Describe the visual style you want |
+| Extremely long prompts (200+ words) | Models lose focus | Keep to 50-100 words, be specific |
+| No camera direction | Random/static camera | Always specify movement or "static" |
+| "Realistic" alone | Not specific enough | "Photorealistic, natural lighting, shot on RED camera" |
+
+---
+
+## Prompting Workflow
+
+1. **Reference first** — find a real video that looks like what you want
+2. **Describe it** — break down: subject, action, camera, style, mood
+3. **Generate 3-4 variations** — same concept, different angles or styles
+4. **Iterate on the best** — refine the prompt based on results
+5. **Composite** — combine AI footage with programmatic text/overlays
+
+---
+
+## Aspect Ratios
+
+Always specify in your prompt or generation settings:
+
+| Platform | Ratio | Resolution |
+|----------|-------|-----------|
+| YouTube | 16:9 | 1920x1080 or 3840x2160 |
+| TikTok/Reels/Shorts | 9:16 | 1080x1920 |
+| Instagram Feed | 1:1 or 4:5 | 1080x1080 or 1080x1350 |
+| Website hero | 16:9 | 1920x1080 |
+| LinkedIn | 16:9 or 1:1 | 1920x1080 |
+
+---
+
+## Cost Optimization
+
+- **Iterate at low resolution** — upscale only the final version
+- **Use Kling for drafts** — cheapest per second, switch to Veo/Runway for finals
+- **Image-to-video** — providing a reference frame saves generation credits and gives better results
+- **Batch similar prompts** — models often offer volume discounts
+- **Cache and reuse** — B-roll clips can be reused across multiple videos

--- a/skills/video/references/ai-video-prompting.md
+++ b/skills/video/references/ai-video-prompting.md
@@ -100,7 +100,7 @@ Use these terms — video models understand them:
 - Excels at photorealism and complex scenes
 - Supports audio generation synced to video
 - Best with detailed, descriptive prompts
-- Specify "4K" or "high resolution" for max quality
+- Specify "high resolution" or "1080p" for best quality
 - Can handle multiple subjects and scene transitions
 
 ### Runway Gen-4

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -80,6 +80,8 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | airops | AI Content | ✓ | - | [✓](clis/airops.js) | - | [airops.md](integrations/airops.md) |
 | buffer | Social | ✓ | - | [✓](clis/buffer.js) | - | [buffer.md](integrations/buffer.md) |
 | wistia | Video | ✓ | - | [✓](clis/wistia.js) | - | [wistia.md](integrations/wistia.md) |
+| heygen | Video | ✓ | ✓ | - | ✓ | [heygen.md](integrations/heygen.md) |
+| hyperframes | Video | - | - | ✓ | ✓ | [hyperframes.md](integrations/hyperframes.md) |
 | trustpilot | Reviews | ✓ | - | [✓](clis/trustpilot.js) | - | [trustpilot.md](integrations/trustpilot.md) |
 | g2 | Reviews | ✓ | - | [✓](clis/g2.js) | - | [g2.md](integrations/g2.md) |
 | onesignal | Push | ✓ | - | [✓](clis/onesignal.js) | ✓ | [onesignal.md](integrations/onesignal.md) |
@@ -260,13 +262,15 @@ Social media scheduling, management, and analytics.
 
 ### Video
 
-Video hosting, analytics, and engagement.
+Video hosting, creation, and AI generation.
 
 | Tool | Best For | Notes |
 |------|----------|-------|
-| **wistia** | Video hosting, marketing analytics | Best for marketing video |
+| **wistia** | Video hosting, marketing analytics | Best for marketing video hosting |
+| **heygen** | AI avatars, talking-head videos | MCP server available |
+| **hyperframes** | Programmatic video from HTML/CSS | Open source, agent-native |
 
-**Agent recommendation**: Wistia for marketing video hosting with analytics.
+**Agent recommendation**: HeyGen for AI avatar videos (MCP-enabled). Hyperframes for templated, data-driven video from code. Wistia for hosting and analytics.
 
 ### Data Enrichment
 

--- a/tools/integrations/heygen.md
+++ b/tools/integrations/heygen.md
@@ -1,0 +1,124 @@
+# HeyGen
+
+AI avatar video generation platform. Create talking-head videos from text scripts with realistic lip-sync, expressions, and gestures.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | Yes | REST API v2 for video generation, avatars, templates |
+| MCP | Yes | Official hosted MCP server — no local install needed |
+| CLI | - | - |
+| SDK | Yes | Node.js SDK available |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `X-Api-Key: {api_key}`
+- **Get key**: Settings > API in HeyGen dashboard
+
+## MCP Server Setup
+
+HeyGen provides a hosted remote MCP server. No local installation required.
+
+### Claude Code / Claude Desktop
+
+Add to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "heygen": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.heygen.com/mcp"]
+    }
+  }
+}
+```
+
+On first use, authenticates via browser OAuth. The MCP server exposes tools for:
+- Creating videos from scripts
+- Listing and selecting avatars
+- Managing templates
+- Checking video status
+
+## API Quick Start
+
+### Create a Video
+
+```bash
+curl -X POST https://api.heygen.com/v2/video/generate \
+  -H "X-Api-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "video_inputs": [{
+      "character": {
+        "type": "avatar",
+        "avatar_id": "AVATAR_ID",
+        "avatar_style": "normal"
+      },
+      "voice": {
+        "type": "text",
+        "input_text": "Your script goes here.",
+        "voice_id": "VOICE_ID"
+      }
+    }],
+    "dimension": {
+      "width": 1920,
+      "height": 1080
+    }
+  }'
+```
+
+### List Avatars
+
+```bash
+curl https://api.heygen.com/v2/avatars \
+  -H "X-Api-Key: YOUR_API_KEY"
+```
+
+### Check Video Status
+
+```bash
+curl https://api.heygen.com/v1/video_status.get?video_id=VIDEO_ID \
+  -H "X-Api-Key: YOUR_API_KEY"
+```
+
+## Common Marketing Use Cases
+
+| Use Case | Approach |
+|----------|----------|
+| Product explainer | Script from features → avatar presents |
+| Feature announcement | Template with avatar + screen recording |
+| Multilingual content | Same script, different language/voice |
+| Personalized outreach | Dynamic variables (name, company) in script |
+| Weekly updates | Recurring template, swap script text |
+
+## Custom Avatars
+
+Upload a 2-5 minute video of yourself speaking to create a digital twin:
+- Looks and sounds like you
+- Generates unlimited videos from text scripts
+- Available on Creator plan and above
+
+## Pricing
+
+| Plan | Price | Videos/mo | Max Duration |
+|------|-------|-----------|-------------|
+| Free | $0 | 3 | 3 min |
+| Creator | $24/mo | Unlimited | 5 min |
+| Business | $108/mo | Unlimited | 20 min |
+| Enterprise | Custom | Unlimited | Custom |
+
+## Rate Limits
+
+- Free: 3 videos/month
+- Paid: Based on plan tier, concurrent generation limits apply
+- API rate limits: Check response headers for `X-RateLimit-*`
+
+## Relevant Skills
+
+- video
+- social-content
+- ad-creative
+- sales-enablement

--- a/tools/integrations/heygen.md
+++ b/tools/integrations/heygen.md
@@ -103,12 +103,14 @@ Upload a 2-5 minute video of yourself speaking to create a digital twin:
 
 ## Pricing
 
-| Plan | Price | Videos/mo | Max Duration |
-|------|-------|-----------|-------------|
-| Free | $0 | 3 | 3 min |
-| Creator | $24/mo | Unlimited | 5 min |
-| Business | $108/mo | Unlimited | 20 min |
-| Enterprise | Custom | Unlimited | Custom |
+| Plan | Videos/mo | Max Duration |
+|------|-----------|-------------|
+| Free | 3 | 3 min |
+| Creator | Unlimited | 5 min |
+| Business | Unlimited | 20 min |
+| Enterprise | Unlimited | Custom |
+
+Check [heygen.com/pricing](https://www.heygen.com/pricing) for current prices — they change frequently.
 
 ## Rate Limits
 

--- a/tools/integrations/hyperframes.md
+++ b/tools/integrations/hyperframes.md
@@ -1,0 +1,180 @@
+# Hyperframes
+
+Open-source programmatic video framework from HeyGen. Create videos from HTML/CSS/JS — no React, no proprietary DSL. Designed for AI agent workflows.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | - | Library, not a hosted service |
+| MCP | - | - |
+| CLI | Yes | `npx hyperframes render` |
+| SDK | Yes | Node.js/TypeScript package |
+
+## Why Hyperframes
+
+- **LLM-native**: AI models generate better HTML than React components — plain web standards, no framework DSL
+- **Deterministic**: Same input always produces identical output (ideal for automation)
+- **Open source**: Apache 2.0 license, zero per-render fees
+- **Agent-friendly**: Any coding agent that can write HTML can create videos
+
+## Install
+
+```bash
+npm install hyperframes
+```
+
+Requires: Node.js 18+, Chrome/Chromium (for rendering)
+
+## Quick Start
+
+```typescript
+import { render } from "hyperframes";
+
+await render({
+  frames: [
+    {
+      html: `
+        <div style="display:flex; align-items:center; justify-content:center;
+                    height:100%; background:#000; color:#fff; font-family:system-ui;">
+          <h1 style="font-size:64px;">Welcome to Acme</h1>
+        </div>
+      `,
+      duration: 3,
+    },
+    {
+      html: `
+        <div style="display:flex; flex-direction:column; align-items:center;
+                    justify-content:center; height:100%; background:#000; color:#fff;
+                    font-family:system-ui;">
+          <h2 style="font-size:48px;">Ship faster with AI</h2>
+          <p style="font-size:24px; color:#888;">Try it free today</p>
+        </div>
+      `,
+      duration: 3,
+    },
+  ],
+  output: "intro.mp4",
+  width: 1080,
+  height: 1920, // 9:16 vertical
+  fps: 30,
+});
+```
+
+## Core Concepts
+
+### Frames
+
+Each frame is an HTML document rendered at a specific point in the timeline. Think of it as a slide with a duration.
+
+```typescript
+{
+  html: "<div>...</div>",  // Full HTML content
+  duration: 3,              // Seconds to display
+  css?: "body { ... }",     // Optional external CSS
+}
+```
+
+### Transitions
+
+CSS transitions and animations work between frames:
+
+```html
+<div style="animation: fadeIn 0.5s ease-in;">
+  <h1>Slide In</h1>
+</div>
+<style>
+  @keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+</style>
+```
+
+### Data-Driven Videos
+
+Generate frames from data for batch production:
+
+```typescript
+const features = ["Analytics", "Automation", "AI Insights"];
+
+const frames = features.map((feature) => ({
+  html: `
+    <div style="display:flex; align-items:center; justify-content:center;
+                height:100%; background:linear-gradient(135deg, #667eea, #764ba2);
+                color:#fff; font-family:system-ui;">
+      <h1 style="font-size:56px;">${feature}</h1>
+    </div>
+  `,
+  duration: 2.5,
+}));
+
+await render({ frames, output: "features.mp4", width: 1080, height: 1920 });
+```
+
+## Common Marketing Templates
+
+### Product Announcement
+
+```typescript
+const frames = [
+  { html: hookSlide("Something new is here"), duration: 2 },
+  { html: featureSlide(title, description, screenshot), duration: 4 },
+  { html: ctaSlide("Try it free →", url), duration: 3 },
+];
+```
+
+### Testimonial Video
+
+```typescript
+const frames = [
+  { html: quoteSlide(testimonial.text), duration: 4 },
+  { html: attributionSlide(testimonial.author, testimonial.company), duration: 2 },
+  { html: ctaSlide("Join 1,000+ happy customers"), duration: 3 },
+];
+```
+
+### Stats/Metrics Video
+
+```typescript
+const metrics = [
+  { label: "Users", value: "10,000+" },
+  { label: "Uptime", value: "99.9%" },
+  { label: "NPS", value: "72" },
+];
+
+const frames = metrics.map(m => ({
+  html: metricSlide(m.label, m.value),
+  duration: 2.5,
+}));
+```
+
+## Aspect Ratios
+
+| Platform | Width | Height | Ratio |
+|----------|-------|--------|-------|
+| TikTok/Reels/Shorts | 1080 | 1920 | 9:16 |
+| YouTube | 1920 | 1080 | 16:9 |
+| Instagram Feed | 1080 | 1080 | 1:1 |
+| Instagram Feed | 1080 | 1350 | 4:5 |
+
+## Hyperframes vs. Remotion
+
+| Factor | Hyperframes | Remotion |
+|--------|-------------|----------|
+| Language | HTML/CSS/JS | React/TypeScript |
+| Agent compatibility | Better (plain HTML) | Good (needs React knowledge) |
+| Animation | CSS transitions/keyframes | Spring physics, interpolation |
+| Cloud rendering | Not built-in | Lambda (AWS) |
+| License | Apache 2.0 (free) | Company license required (>1 employee) |
+| Ecosystem | New, growing | Mature, large community |
+
+**Use Hyperframes when:** AI agent is generating the video, simple animations, batch templated content, cost-sensitive.
+
+**Use Remotion when:** Complex animations needed, already using React, need Lambda for massive scale, want larger ecosystem.
+
+## Relevant Skills
+
+- video
+- social-content
+- ad-creative

--- a/tools/integrations/hyperframes.md
+++ b/tools/integrations/hyperframes.md
@@ -24,7 +24,7 @@ Open-source programmatic video framework from HeyGen. Create videos from HTML/CS
 npm install hyperframes
 ```
 
-Requires: Node.js 18+, Chrome/Chromium (for rendering)
+Requires: Node.js 22+, Chrome/Chromium (for rendering)
 
 ## Quick Start
 
@@ -166,7 +166,7 @@ const frames = metrics.map(m => ({
 | Agent compatibility | Better (plain HTML) | Good (needs React knowledge) |
 | Animation | CSS transitions/keyframes | Spring physics, interpolation |
 | Cloud rendering | Not built-in | Lambda (AWS) |
-| License | Apache 2.0 (free) | Company license required (>1 employee) |
+| License | Apache 2.0 (free) | Company license for commercial use |
 | Ecosystem | New, growing | Mature, large community |
 
 **Use Hyperframes when:** AI agent is generating the video, simple animations, batch templated content, cost-sensitive.


### PR DESCRIPTION
## Summary

New `video` skill covering the full video production stack for marketers:

### Skill (330 lines)
- **Programmatic video**: Hyperframes (HTML/CSS, agent-native) and Remotion (React)
- **AI video generation**: Veo 3, Runway Gen-4, Kling 3.0, Pika — with comparison table and when-to-use guidance
- **AI avatars**: HeyGen (MCP-enabled) and Synthesia — for talking-head content without filming
- **Editing/repurposing**: Descript, Opus Clip, CapCut, Captions.ai workflow
- **Agent-native pipeline**: Hyperframes + HeyGen MCP + video model APIs = fully automated

### Reference (ai-video-prompting.md)
- Prompt structure formula: subject + action + camera + style + mood
- Example prompts by marketing use case
- Camera movement vocabulary
- Style keywords (cinematic, commercial, documentary, social)
- Model-specific tips (Veo, Runway, Kling, Pika)
- Common prompt mistakes and fixes

### Tool integrations (2 new)
- **heygen.md**: API, MCP server setup, avatar video generation, pricing
- **hyperframes.md**: Install, quick start, data-driven templates, aspect ratios

### Also updated
- `.claude-plugin/marketplace.json`: Added video skill, count → 39
- `VERSIONS.md`: Added video 1.0.0
- `README.md`: Added to skill table and diagram
- `tools/REGISTRY.md`: Added HeyGen + Hyperframes to index and Video category
- `.gitignore`: Scoped `video/` rule to root only so `skills/video/` isn't ignored

## Test plan
- [ ] SKILL.md under 500 lines (330)
- [ ] Frontmatter valid (name matches directory)
- [ ] marketplace.json has 39 skills
- [ ] VERSIONS.md has 39 rows
- [ ] README diagram includes video
- [ ] `skills/video/` not gitignored