### PR TITLE
fix: change source from "." to "./" to pass Claude Code schema validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "marketing-skills",
       "description": "38 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
-      "source": ".",
+      "source": "./",
       "strict": false,
       "skills": [
         "./skills/ab-test-setup",


### PR DESCRIPTION
## Problem

When running `/plugin marketplace add coreyhaines31/marketingskills`, Claude Code throws:

```
Failed to parse marketplace file at .../.claude-plugin/marketplace.json: Invalid schema:
plugins.0.source: Invalid input
```

The `source` field for the `marketing-skills` plugin is set to `"."`, which doesn't pass the Zod schema validation used by the Claude Code plugin system.

## Fix

Change `"source": "."` to `"source": "./"` in `.claude-plugin/marketplace.json`. The two values are semantically equivalent (both refer to the current directory), but `"./"` passes the schema validator while `"."` does not.

## How to reproduce

```bash
# In Claude Code:
/plugin marketplace add coreyhaines31/marketingskills
# Error: Failed to parse marketplace file... plugins.0.source: Invalid input
```

## Tested

After applying this fix, the marketplace installs and the plugin is available:
```
Successfully added marketplace: marketingskills
✓ Installed marketing-skills
```