### PR TITLE
fix: Remove Malicious Agent URL (https://aiagentsverse.com/submit)

### DIFF
--- a/skills/directory-submissions/references/submission-tracker-template.csv
+++ b/skills/directory-submissions/references/submission-tracker-template.csv
@@ -61,7 +61,6 @@ Linux Foundation MCP Registry,4,https://github.com/modelcontextprotocol/registry
 AI Agent Store,4,https://aiagentstore.ai/submit,Agent,,Yes,,Draft,,,Agent,,,
 AI Agents Base,4,https://aiagentsbase.com/submit,Agent,,Yes,,Draft,,,Agent,,,
 AI Agents Directory,4,https://aiagentsdirectory.com/submit,Agent,,Yes,,Draft,,,Agent,,,
-AI Agents Verse,4,https://aiagentsverse.com/submit,Agent,,Yes,,Draft,,,Agent,,,
 AgentHunter,4,https://agenthunter.com/submit,Agent,,Yes,,Draft,,,Agent,,,
 AI Agents Live,4,https://aiagents.live/submit,Agent,,Yes,,Draft,,,Agent,,,
 AI Agents Marketplace,4,https://aiagentsmarketplace.com/submit,Agent,,Yes,,Draft,,,Agent,,,


### PR DESCRIPTION
Vercel skills.sh flags this URL as dangerous with potential data exfiltration. Gives me a warning when trying to install. 

https://skills.sh/coreyhaines31/marketingskills/directory-submissions/security/agent-trust-hub