### PR TITLE
fix: use "./" for plugin source to match Claude Code marketplace schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "marketing-skills",
       "description": "38 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
-      "source": ".",
+      "source": "./",
       "strict": false,
       "skills": [
         "./skills/ab-test-setup",


### PR DESCRIPTION
## Problem

Running `/plugin marketplace add coreyhaines31/marketingskills` in Claude Code currently fails with:

```
Error: Failed to parse marketplace file at .../coreyhaines31-marketingskills/.claude-plugin/marketplace.json:
Invalid schema: plugins.0.source: Invalid input
```

## Cause

`.claude-plugin/marketplace.json` sets `"source": "."` for the `marketing-skills` plugin. Claude Code's marketplace schema rejects that form.

## Fix

Change to `"source": "./"` (with a trailing slash), which is the convention used by `anthropic-agent-skills` and other marketplaces that load cleanly. One-line change, no behavioral impact beyond unblocking installation.

## Repro / Verification

Before the fix — `/plugin marketplace add coreyhaines31/marketingskills` errors as above.
After the fix (confirmed locally by patching the installed marketplace file) — the marketplace loads, the 38 skills are discovered and listable via `/plugin`.