### PR TITLE
fix: update marketplace.json source field to object format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,10 @@
     {
       "name": "marketing-skills",
       "description": "38 marketing skills for technical marketers and founders: ASO, CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, churn prevention, pricing strategy, referral programs, revenue operations, sales enablement, customer research, site architecture, and more",
-      "source": ".",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/coreyhaines31/marketingskills.git"
+      },
       "strict": false,
       "skills": [
         "./skills/ab-test-setup",


### PR DESCRIPTION
## What changed

Updated plugins[0].source in .claude-plugin/marketplace.json from a plain string ('.') to the object format required by the current Claude Code plugin schema.

## Why

The current 'source: .' value fails Claude Code validation with: 'plugins.0.source: Invalid input'. This prevents users from installing the plugin via claude plugin marketplace add — the install fails before any files are downloaded.

## How to verify

Run: claude plugin validate .claude-plugin/marketplace.json
Expected: Validation passed

Then: claude plugin marketplace add https://github.com/coreyhaines31/marketingskills && claude plugin install marketing-skills

Generated with Claude Code