### PR TITLE
fix(ai-seo): remove llms.txt recommendations

### DIFF
--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -257,7 +257,7 @@ Add these machine-readable files to your site root:
 - AI agents increasingly compare products programmatically before a human ever visits your site
 - Opaque pricing gets filtered out of AI-mediated buying journeys
 - A simple markdown file is trivially parseable by any LLM — no rendering, no JavaScript, no login walls
-- Same principle as `robots.txt` (for crawlers), `llms.txt` (for AI context), and `AGENTS.md` (for agent capabilities)
+- Same principle as `robots.txt` (for crawlers) and `AGENTS.md` (for agent capabilities)
 
 **Best practices:**
 - Use consistent units (monthly vs. annual, per-seat vs. flat)
@@ -265,10 +265,6 @@ Add these machine-readable files to your site root:
 - List what's included at each tier, not just what's different
 - Keep it updated — stale pricing is worse than no file
 - Link to it from your sitemap and main pricing page
-
-**`/llms.txt`** — Context file for AI systems (see [llmstxt.org](https://llmstxt.org))
-
-If you don't have one yet, add an `llms.txt` that gives AI systems a quick overview of what your product does, who it's for, and links to key pages (including your pricing).
 
 ### Schema Markup for AI
 


### PR DESCRIPTION
## Summary

Removes the two `llms.txt` references from `skills/ai-seo/SKILL.md` (one passing comparison and one explicit recommendation block).

## Why

`llms.txt` is a community proposal from [llmstxt.org](https://llmstxt.org) that has **not been adopted by any major AI provider**. Anthropic, OpenAI, Google (Gemini / AI Overviews), and Perplexity do not document crawling or weighting it, and there is no public evidence that publishing one improves citation rates or AI visibility.

Recommending it as an AI-SEO best practice in this skill:
- sends users to optimize for a signal that nothing currently reads
- conflates an unadopted proposal with proven techniques (schema markup, sitemaps, content quality, machine-readable pricing) which the same section already covers
- risks dating the skill quickly if/when the proposal is formally rejected or fades

The surrounding "Pricing transparency for AI" guidance — plain-markdown pricing files, schema, sitemap linking — stands on its own without it.

## Changes

- `skills/ai-seo/SKILL.md`: drop `llms.txt` from the `robots.txt` / `AGENTS.md` comparison line, and remove the standalone `**/llms.txt**` recommendation block (3 lines).

Net: 1 insertion, 5 deletions.

## Test plan

- [x] No remaining `llms.txt` mentions in the file: `grep -i 'llms\.txt' skills/ai-seo/SKILL.md` returns nothing
- [x] Section flow reads cleanly — "Best practices" bullets now lead directly into `### Schema Markup for AI`
- [x] No other skills in the repo reference `llms.txt`, so no cross-skill cleanup needed