### PR TITLE
docs: add TweetClaw social tool integration

### DIFF
--- a/skills/social-content/SKILL.md
+++ b/skills/social-content/SKILL.md
@@ -401,6 +401,19 @@ Tools: CapCut (free), Descript, Captions.ai, Premiere Pro
 
 ---
 
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key tools for social content workflows:
+
+| Tool | Best For | MCP | Guide |
+|------|----------|:---:|-------|
+| **Buffer** | Multi-platform scheduling, queue management, analytics | - | [buffer.md](../../tools/integrations/buffer.md) |
+| **TweetClaw** | X/Twitter search, tweet replies, posting, follower export, monitors | ✓ | [tweetclaw.md](../../tools/integrations/tweetclaw.md) |
+
+Use Buffer when the workflow is calendar-first and cross-platform. Use TweetClaw when the workflow is X/Twitter-specific and needs both research and execution.
+
+---
+
 ## Related Skills
 
 - **copywriting**: For longer-form content that feeds social

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -79,6 +79,7 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | gong | Revenue Intelligence | ✓ | - | - | - | [gong.md](integrations/gong.md) |
 | airops | AI Content | ✓ | - | [✓](clis/airops.js) | - | [airops.md](integrations/airops.md) |
 | buffer | Social | ✓ | - | [✓](clis/buffer.js) | - | [buffer.md](integrations/buffer.md) |
+| tweetclaw | Social | ✓ | ✓ | - | - | [tweetclaw.md](integrations/tweetclaw.md) |
 | wistia | Video | ✓ | - | [✓](clis/wistia.js) | - | [wistia.md](integrations/wistia.md) |
 | heygen | Video | ✓ | ✓ | - | ✓ | [heygen.md](integrations/heygen.md) |
 | hyperframes | Video | - | - | ✓ | ✓ | [hyperframes.md](integrations/hyperframes.md) |
@@ -257,8 +258,9 @@ Social media scheduling, management, and analytics.
 | Tool | Best For | Notes |
 |------|----------|-------|
 | **buffer** | Social scheduling, analytics | Multi-platform |
+| **tweetclaw** | X/Twitter search, posting, replies, follower export, monitors | OpenClaw plugin + MCP |
 
-**Agent recommendation**: Buffer for scheduling and analytics across social platforms.
+**Agent recommendation**: Buffer for multi-platform scheduling and queue management. Use TweetClaw when the workflow is specifically X/Twitter and needs both research and execution.
 
 ### Video
 

--- a/tools/integrations/tweetclaw.md
+++ b/tools/integrations/tweetclaw.md
@@ -1,0 +1,81 @@
+# TweetClaw
+
+OpenClaw plugin and MCP-accessible X/Twitter automation layer for tweet search, reply search, posting, follower export, monitors, webhooks, and giveaway draws.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Structured Xquik REST endpoints |
+| MCP | ✓ | StreamableHTTP MCP server plus packaged OpenClaw plugin runtime |
+| CLI | - | No standalone CLI in this repo |
+| SDK | - | Use the packaged plugin path for agents |
+
+## Authentication
+
+- **Type**: API key for account-backed workflows, or MPP signing key for read-only pay-per-use mode
+- **Install**: `openclaw plugins install @xquik/tweetclaw`
+- **API key**: `openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"`
+- **MPP mode**: `openclaw config set plugins.entries.tweetclaw.config.tempoSigningKey "$MPP_SIGNING_KEY"`
+- **Tool access**: `openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'` when your OpenClaw profile hides external tools
+
+TweetClaw can be installed before credentials are configured. In that state, the free `explore` tool remains available for endpoint discovery and the live tool returns setup guidance instead of failing installation.
+
+## Common Agent Operations
+
+### Search tweets about a topic
+
+```text
+Search tweets about AI agents from the last 7 days.
+```
+
+### Search tweet replies for objections or feedback
+
+```text
+Find replies to this product-launch tweet and summarize the top objections.
+```
+
+### Post a tweet or reply
+
+```text
+Post this launch tweet from my connected account after you show me the final text.
+```
+
+### Export followers from a target account
+
+```text
+Export followers of @openclawapp and group them by role keywords in bio.
+```
+
+### Monitor an account and route events to a webhook
+
+```text
+Create a monitor for @openclawapp and send new tweet events to this webhook.
+```
+
+### Run a giveaway draw from tweet replies
+
+```text
+Run a giveaway draw from replies to this tweet and return the winners list.
+```
+
+## When to Use
+
+- X/Twitter research that needs live tweet search, reply analysis, or user lookup
+- Approval-gated posting, replies, likes, follows, DMs, or profile actions
+- Follower export, tweet extraction, and giveaway workflows
+- Monitor and webhook setups for launch, support, or brand tracking
+
+## Limitations
+
+- MPP mode is read-only and covers 31 X/Twitter endpoints
+- Posting, replies, monitors, webhooks, uploads, and other state-changing actions need an API key
+- Media downloads are not MPP-eligible
+- OpenClaw should show the exact payload before any visible or recurring action is approved
+
+## Relevant Skills
+
+- social-content
+- launch-strategy
+- customer-research
+- directory-submissions


### PR DESCRIPTION
## Summary

- add TweetClaw to the tools registry as an X/Twitter social tool
- add a focused integration guide for install, auth, approval boundaries, and common workflows
- connect the existing social-content skill to Buffer and TweetClaw as implementation options

## Files changed

- `tools/REGISTRY.md`
- `tools/integrations/tweetclaw.md`
- `skills/social-content/SKILL.md`

## Checklist

- [x] Links are valid
- [x] Formatting is consistent with existing docs
- [x] No sensitive data or credentials
