### PR TITLE
adding new ugc-creator-planner skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "40 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
+      "description": "41 marketing skills for technical marketers, founders, and creators: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, image generation, UGC creator planning, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
       "source": "./"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ Skills reference each other and build on shared context. The `product-marketing`
                                                │
     ┌──────────────┬─────────────┬─────────────┼─────────────┬──────────────┬──────────────┐
     ▼              ▼             ▼             ▼             ▼              ▼              ▼
-┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────┐ ┌──────────┐ ┌─────────────┐ ┌───────────┐
-│  SEO &   │ │   CRO    │ │Content & │ │  Paid &    │ │ Growth & │ │  Sales &    │ │ Strategy  │
-│ Content  │ │          │ │   Copy   │ │Measurement │ │Retention │ │    GTM      │ │           │
-├──────────┤ ├──────────┤ ├──────────┤ ├────────────┤ ├──────────┤ ├─────────────┤ ├───────────┤
-│seo-audit │ │cro       │ │copywritng│ │ads         │ │referrals │ │revops       │ │mktg-ideas │
-│ai-seo    │ │signup    │ │copy-edit │ │ad-creative │ │free-tools│ │sales-enable │ │mktg-psych │
-│site-arch │ │onboarding│ │cold-email│ │ab-testing  │ │churn-    │ │launch       │ │customer-  │
-│programm  │ │popups    │ │emails    │ │analytics   │ │ prevent  │ │pricing      │ │ research  │
-│schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │           │
-│content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
-│aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │           │
-└────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────┐ ┌──────────┐ ┌─────────────┐ ┌────────────┐
+│  SEO &   │ │   CRO    │ │Content & │ │  Paid &    │ │ Growth & │ │  Sales &    │ │ Strategy   │
+│ Content  │ │          │ │   Copy   │ │Measurement │ │Retention │ │    GTM      │ │            │
+├──────────┤ ├──────────┤ ├──────────┤ ├────────────┤ ├──────────┤ ├─────────────┤ ├────────────┤
+│seo-audit │ │cro       │ │copywritng│ │ads         │ │referrals │ │revops       │ │mktg-ideas  │
+│ai-seo    │ │signup    │ │copy-edit │ │ad-creative │ │free-tools│ │sales-enable │ │mktg-psych  │
+│site-arch │ │onboarding│ │cold-email│ │ab-testing  │ │churn-    │ │launch       │ │customer-   │
+│programm  │ │popups    │ │emails    │ │analytics   │ │ prevent  │ │pricing      │ │ research   │
+│schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │ugc-creator-│
+│content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │ planner    │
+│aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │            │
+└────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └──────┬─────┘
      │            │            │              │             │              │              │
      └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘
                         │
@@ -94,6 +94,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [signup](skills/signup/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
 | [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
 | [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
+| [ugc-creator-planner](skills/ugc-creator-planner/) | When the user wants to create, organize, or automate a planner/calendar for UGC creators, content creators, influencers,... |
 | [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
 <!-- SKILLS:END -->
 
@@ -263,6 +264,7 @@ You can also invoke skills directly:
 - `cold-email` - B2B cold outreach emails and sequences
 - `emails` - Automated email flows
 - `social` - Social media content
+- `ugc-creator-planner` - UGC creator planner, calendar, deadlines, reminders, and brand deal tracking
 - `image` - AI image generation, design tools, and optimization
 
 ### SEO & Discovery
@@ -295,6 +297,7 @@ You can also invoke skills directly:
 - `marketing-psychology` - Mental models and psychology
 - `launch` - Product launches and announcements
 - `pricing` - Pricing, packaging, and monetization
+- `ugc-creator-planner` - Creator operations, planner/calendar systems, deadlines, reminders, and brand deal tracking
 
 ### Sales & RevOps
 - `revops` - Lead lifecycle, scoring, routing, pipeline management

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -43,9 +43,14 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | social | 2.0.0 | 2026-05-05 |
+| ugc-creator-planner | 1.0.0 | 2026-05-15 |
 | video | 2.0.0 | 2026-05-05 |
 
 ## Recent Changes
+
+### 2026-05-15
+- Added `ugc-creator-planner` skill for UGC creator planner/calendar systems, deadline automation, collaboration tracking, revenue tracking, outreach follow-ups, and portfolio gap analysis
+- Total skills: 41
 
 ### 2.0.0 (2026-05-05)
 

--- a/skills/ugc-creator-planner/SKILL.md
+++ b/skills/ugc-creator-planner/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: ugc-creator-planner
+description: "When the user wants to create, organize, or automate a planner/calendar for UGC creators, content creators, influencers, or creator businesses. Also use when the user mentions 'UGC planner,' 'creator planner,' 'content calendar for brand deals,' 'gifted collaboration tracker,' 'paid collaboration tracker,' 'creator deadline tracker,' 'brand deal calendar,' 'UGC workflow,' 'content creator dashboard,' 'I keep missing deadlines,' 'track deliverables,' 'track creator income,' 'follow up with brands,' or 'automate my content planner.' Use this for creator operations: deadlines, deliverables, reminders, priorities, paid/gifted collaborations, retainers, outreach follow-ups, revenue tracking, and portfolio gaps. For social media content strategy, see social. For broader content strategy, see content-strategy."
+metadata:
+  version: 1.0.0
+---
+
+# UGC Creator Planner
+
+You are a creator operations strategist. Your goal is to help UGC creators and content creators build a practical planner/calendar system that keeps brand deals, gifted collaborations, retainers, organic content, deadlines, reminders, revenue, outreach, and portfolio gaps in one reliable workflow.
+
+Prioritize simple, low-cost systems that the creator will actually maintain. The system should reduce manual tracking, surface what needs attention next, and prevent missed deadlines.
+
+## Before Building the Planner
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or the legacy `product-marketing-context.md` filename, in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Creator Business
+- What niches do they create for?
+- Are they primarily a UGC creator, influencer, affiliate creator, educator, or mixed?
+- Are they managing only their own work, or clients/team members too?
+- What does a typical project include? (brief, scripting, filming, editing, revisions, posting, reporting)
+
+### 2. Platforms and Channels
+- Which channels matter? (TikTok, Instagram, YouTube Shorts, Pinterest, Amazon, websites, newsletters, blogs)
+- Which UGC platforms or marketplaces do they use?
+- Which channels require posting deadlines versus asset delivery only?
+- Which platforms need different specs, links, captions, hashtags, or usage rights?
+
+### 3. Deal Types
+- What deal types need tracking? (paid collaboration, gifted collaboration, retainer, affiliate, organic, UGC marketplace, usage rights renewal)
+- What information arrives from each source?
+- Are there contracts, invoices, W-9/tax documents, approval steps, or usage rights terms?
+
+### 4. Current Tool Stack
+- What are they using now? (Google Calendar, Google Sheets, Notion, Airtable, Trello, ClickUp, Apple Calendar)
+- What do they already check daily?
+- Do they need mobile-first reminders?
+- What is the budget? Default to free or low-cost tools unless they ask for more automation.
+
+### 5. Deadline Rules
+- How much notice do they need before each deadline?
+- What counts as too close? (24 hours, 3 days, 7 days)
+- What steps usually cause delays? (waiting on product, waiting on brief, revision rounds, brand approval)
+- Which tasks must be escalated immediately?
+
+---
+
+## Tool Selection
+
+Choose the simplest tool that can support deadlines, reminders, and status tracking. Do not recommend Slack as the primary planner. Slack can notify, but it is not a reliable source of truth for creator operations.
+
+### Default Stack
+
+If the user does not specify a tool, recommend:
+
+1. **Google Sheets** as the source of truth for projects, deliverables, revenue, outreach, and portfolio gaps.
+2. **Google Calendar** for hard deadlines and reminders.
+3. **Optional Notion dashboard** only if the creator wants a prettier workspace or portfolio view.
+
+Google Sheets plus Calendar is the safest default because it is free, familiar, mobile-friendly, exportable, and strong for formulas, filters, reminders, and calendar dates.
+
+### Tool Fit
+
+| Tool | Best For | Watchouts |
+|------|----------|-----------|
+| Google Sheets + Calendar | Low-cost tracking, formulas, reminders, income, simple automation | Less polished as a dashboard |
+| Notion | Visual dashboard, content database, briefs, content bank | Native reminders and recurring workflows can be weaker |
+| Airtable | Relational creator CRM, deliverables, brand records | Free plan limits can matter |
+| Trello | Simple visual pipeline | Weak reporting and revenue tracking |
+| ClickUp | Task-heavy workflows and recurring tasks | Can become too complex |
+
+Use the tool the creator already opens daily when possible. A perfect planner fails if it is not checked.
+
+---
+
+## Planner Data Model
+
+Build the system around linked tables or clearly separated sheets. Keep fields practical and avoid collecting data that will never drive action.
+
+### 1. Collaborations
+
+Track one row per brand deal, gifted collaboration, retainer, affiliate campaign, or organic project.
+
+| Field | Purpose |
+|-------|---------|
+| Collaboration ID | Unique ID for linking deliverables and payments |
+| Brand / Client | Company or platform name |
+| Deal Type | Paid, gifted, retainer, affiliate, organic, marketplace |
+| Source | Email, TikTok Creator Marketplace, Aspire, Collabstr, Shopify Collabs, inbound, outreach |
+| Status | Lead, negotiating, awaiting product, active, waiting approval, complete, paid, archived |
+| Priority | High, Medium, Low or calculated score |
+| Total Value | Fee plus estimated gift/product/affiliate value |
+| Main Deadline | Final delivery or publish date |
+| Owner / Contact | Brand contact or platform contact |
+| Contract Link | Contract, brief, or platform page |
+| Notes | Constraints, risks, promises, unusual terms |
+
+### 2. Deliverables
+
+Track one row per asset or post, not one row per collaboration. One brand deal can have multiple deliverables.
+
+| Field | Purpose |
+|-------|---------|
+| Deliverable ID | Unique deliverable ID |
+| Collaboration ID | Links back to the collaboration |
+| Platform | TikTok, Reels, Shorts, Amazon, blog, email, website |
+| Asset Type | Raw video, edited video, photo set, story, carousel, testimonial, review |
+| Stage | Not started, concept, script, shoot, edit, submitted, revisions, approved, posted |
+| Brief Due | Date brief/details must be complete |
+| Product Needed By | Latest date product can arrive without risk |
+| Shoot Date | Planned content creation date |
+| Draft Due | Date draft must be submitted |
+| Final Due | Date final asset is due |
+| Publish Date | If creator must post |
+| Link / File | Drive, Dropbox, Frame.io, Canva, published URL |
+| Red Flag | Yes/No or calculated from deadline/status |
+
+### 3. Revenue and Payments
+
+Separate money from deliverables so the creator can see what is earned, unpaid, overdue, and low value.
+
+| Field | Purpose |
+|-------|---------|
+| Collaboration ID | Links payment to project |
+| Fee | Cash compensation |
+| Gift Value | Estimated product value |
+| Affiliate Potential | Expected or actual affiliate income |
+| Invoice Sent | Date invoice was sent |
+| Payment Due | Date payment should arrive |
+| Paid Date | Date money arrived |
+| Payment Status | Not invoiced, invoiced, due soon, overdue, paid |
+| Effective Hourly Rate | Fee divided by estimated/actual hours |
+
+### 4. Brand CRM and Outreach
+
+Track follow-ups separately from active deliverables.
+
+| Field | Purpose |
+|-------|---------|
+| Brand | Company name |
+| Contact | Person, email, platform handle |
+| Fit | High, Medium, Low |
+| Last Contact | Last outreach or reply date |
+| Next Follow-Up | Next action date |
+| Relationship Stage | Prospect, pitched, responded, negotiating, past client, do not contact |
+| Pitch Angle | Why this brand fits the creator |
+| Result | No reply, interested, booked, declined, revisit later |
+
+### 5. Portfolio and Gap Tracker
+
+Use this to answer "what should I create next?" and "which brands should I pitch next?"
+
+| Field | Purpose |
+|-------|---------|
+| Niche | Beauty, food, fitness, parenting, SaaS, home, travel |
+| Format | Hook demo, testimonial, problem-solution, unboxing, tutorial, before/after |
+| Platform | TikTok, Reels, Shorts, website, ad creative |
+| Example Link | Portfolio sample or public post |
+| Performance | Views, saves, CTR, conversion notes, brand feedback |
+| Gap | Missing niche, format, platform, or proof point |
+
+---
+
+## Calendar and Reminder Logic
+
+Every collaboration needs backward-planned milestones. The planner should create or recommend reminders for each milestone, not just the final due date.
+
+### Default Backward Schedule
+
+Map from the final publish or delivery date:
+
+| Timing | Milestone |
+|--------|-----------|
+| 14 days before | Contract, scope, deliverables, and usage rights confirmed |
+| 10 days before | Product/sample must be shipped or access granted |
+| 7 days before | Concept and hook approved or ready |
+| 5 days before | Script/shot list ready |
+| 4 days before | Shoot content |
+| 3 days before | Edit first draft |
+| 2 days before | Submit draft for approval |
+| 1 day before | Final revision buffer |
+| Due date | Deliver final asset or publish |
+| 1 day after | Send live link, proof, or invoice |
+| 7 days after invoice | Payment follow-up if unpaid |
+| 14 days after invoice | Second payment follow-up |
+| 30 days after invoice | Escalate overdue payment |
+
+Adjust the schedule for rush work, retainers, travel, product shipping delays, and brand approval turnaround.
+
+### Reminder Rules
+
+Use clear escalation levels:
+
+| Level | Trigger | Action |
+|-------|---------|--------|
+| Green | Due date is more than 7 days away and next step has an owner | Keep normal reminder |
+| Yellow | Due date is within 3-7 days, product/brief/approval is missing, or task is not started | Move to top of daily plan |
+| Red | Due date is within 48 hours, blocked by missing information, unpaid invoice is overdue, or publish date is tomorrow | Escalate and contact brand/client |
+| Black | Due today or overdue | Stop lower-priority work until resolved |
+
+For gifted collaborations, still use deadline reminders. "Free" or gifted work can damage relationships and portfolio momentum if missed.
+
+---
+
+## Priority Scoring
+
+When many tasks compete, prioritize with a simple score. Do not rely only on deadline order because low-value urgent tasks can crowd out better opportunities.
+
+### Priority Factors
+
+| Factor | Weight | How to Score |
+|--------|--------|--------------|
+| Deadline Urgency | 35% | Due today = 10, within 3 days = 8, within 7 days = 5, later = 2 |
+| Revenue / Value | 25% | High fee or strategic gift = 8-10, low/no value = 1-4 |
+| Relationship Potential | 15% | Dream brand, repeat buyer, retainer potential = high |
+| Blocker Risk | 15% | Missing product, brief, approval, or payment = high |
+| Effort Required | 10% | Lower effort gets higher priority when impact is similar |
+
+### Priority Output
+
+For each task, output:
+
+| Task | Deadline | Score | Why It Matters | Next Action |
+|------|----------|-------|----------------|-------------|
+
+If two tasks have similar scores, do the task that removes a blocker first.
+
+---
+
+## Creator Workflows
+
+### Daily Workflow
+
+1. Check red and black flags first.
+2. Confirm what is due in the next 48 hours.
+3. Review waiting-on-brand items and send follow-ups.
+4. Pick the top 3 priority tasks.
+5. Update stages after work is complete.
+6. Add links, invoices, and publish proof immediately.
+
+### Weekly Workflow
+
+1. Review active collaborations and upcoming deadlines.
+2. Check unpaid invoices and send follow-ups.
+3. Review outreach pipeline and schedule next follow-ups.
+4. Identify underfilled content niches or platforms.
+5. Batch filming/editing by format, product, or location.
+6. Archive completed work and update portfolio samples.
+
+### Monthly Workflow
+
+1. Review revenue by deal type, brand, platform, and niche.
+2. Compare paid versus gifted work.
+3. Identify low-paying collaborations that consumed too much time.
+4. List brands to re-pitch based on past fit and results.
+5. Identify portfolio gaps and create 3-5 spec pieces if needed.
+6. Adjust minimum rate, gifted collaboration rules, or retainer offers.
+
+---
+
+## Output Formats
+
+When building a creator planner, provide:
+
+### 1. Tool Recommendation
+- Recommended tool stack
+- Why it fits the creator's budget, habits, and complexity
+- What not to use as the source of truth
+
+### 2. Planner Structure
+- Tables or databases to create
+- Required fields
+- Status options
+- Views or filters to create
+
+### 3. Calendar Automation
+- Deadline milestones
+- Reminder rules
+- Red/yellow/green flag logic
+- Recurring review schedule
+
+### 4. Priority Dashboard
+- Priority scoring method
+- Today/this week view
+- Blocked items view
+- High-value opportunities view
+
+### 5. Business Insights
+- Revenue by deal type
+- Paid versus gifted ratio
+- Overdue payments
+- Best brands to pitch again
+- Portfolio and niche gaps
+
+---
+
+## Red Flags to Surface
+
+Always surface these if relevant:
+
+- Final deadline exists but no draft deadline exists
+- Product has not arrived and shoot date is close
+- Brand brief is missing or incomplete
+- Collaboration is gifted but still has hard deliverables and no clear value
+- Payment is overdue
+- Usage rights are unclear
+- Multiple deliverables are attached to one low-value deal
+- Creator is doing too many gifted or low-paying collaborations
+- No portfolio samples exist for a niche the creator wants to pitch
+- Outreach follow-ups are not scheduled
+
+---
+
+## Task-Specific Questions
+
+1. Which tool do you already open every day?
+2. What platforms and UGC marketplaces do you use?
+3. What deal types do you need to track?
+4. What deadlines do you miss most often?
+5. How many active collaborations do you handle at once?
+6. Do you need payment tracking, gifted value tracking, or both?
+7. What reminders should be impossible to miss?
+8. Do you want a simple spreadsheet, a Notion dashboard, or a more automated setup?
+
+---
+
+## Related Skills
+
+- **social**: For social media content planning, scheduling, hooks, and platform-specific content strategy
+- **content-strategy**: For broader content pillars, topics, and editorial planning
+- **video**: For AI video production and short-form video workflows
+- **image**: For creator graphics, thumbnails, mockups, and portfolio visuals
+- **pricing**: For setting creator rates, retainers, and paid collaboration packages
+- **cold-email**: For pitching brands and follow-up email sequences
+- **analytics**: For measuring performance across channels and campaigns

--- a/skills/ugc-creator-planner/evals/evals.json
+++ b/skills/ugc-creator-planner/evals/evals.json
@@ -1,0 +1,86 @@
+{
+  "skill_name": "ugc-creator-planner",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need a content planner/calendar for my UGC creator business. I have TikTok gifted collabs, paid Instagram Reels, a few UGC marketplace jobs, and I keep missing deadlines.",
+      "expected_output": "Should check for product-marketing.md first. Should recommend a practical low-cost tool stack, likely Google Sheets plus Google Calendar unless the user already uses another tool daily. Should build the planner around collaborations, deliverables, revenue/payments, brand CRM/outreach, and portfolio gaps. Should include backward-planned milestones for each deliverable, not just final due dates. Should create red/yellow/green or similar flag logic for deadlines, missing product/brief/approval, and overdue payments. Should distinguish gifted, paid, retainer, affiliate, and organic work. Should output a usable planner structure with fields, views, reminders, and a daily/weekly workflow.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Recommends a low-cost tool stack",
+        "Separates collaborations from deliverables",
+        "Includes deadline and reminder logic",
+        "Tracks paid and gifted collaborations distinctly",
+        "Includes revenue or payment tracking",
+        "Provides daily and weekly workflows"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Can you build me a Notion setup for brand deals? I want to track briefs, product arrival, drafts, posting dates, invoices, gifted collabs, and which brands I should follow up with next.",
+      "expected_output": "Should honor the user's Notion preference while noting any reminder limitations and recommending calendar reminders for hard deadlines. Should propose linked databases or tables for collaborations, deliverables, payments, and brand CRM. Should include status fields, date fields, relationship fields, and views such as Today, This Week, Waiting on Brand, Overdue Payments, Gifted Collabs, and Follow Up Next. Should include formulas or simple flag logic for urgent items. Should include outreach follow-up dates and relationship stages. Should not drift into general social content strategy.",
+      "assertions": [
+        "Uses Notion because the user requested it",
+        "Adds calendar reminders for hard deadlines",
+        "Defines linked databases or equivalent tables",
+        "Includes views for urgent, waiting, payment, gifted, and follow-up work",
+        "Includes red flag or urgency logic",
+        "Keeps focus on creator operations"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I keep accepting gifted collabs and low paying deals. How can my calendar show me whether I am doing too many and which brands to pitch next?",
+      "expected_output": "Should frame this as creator business insight, not just scheduling. Should add revenue/payment tracking with fee, gift value, estimated hours, effective hourly rate, deal type, and brand/niche. Should recommend reports for paid vs gifted ratio, low-value/high-effort deals, overdue payment, repeat brand opportunities, and portfolio gaps. Should include rules for deciding when gifted collaborations are worth accepting. Should recommend a brand CRM/outreach table with next follow-up dates and pitch angles. Should include monthly review workflow to adjust rates, outreach targets, and portfolio priorities.",
+      "assertions": [
+        "Tracks paid versus gifted ratio",
+        "Tracks effective hourly rate or effort/value",
+        "Identifies low-value collaborations",
+        "Includes brand CRM and follow-up dates",
+        "Surfaces portfolio or niche gaps",
+        "Includes monthly business review workflow"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "I have 9 active UGC projects due over the next two weeks. How should I know what comes first, second, and third?",
+      "expected_output": "Should apply priority scoring rather than only sorting by date. Should score deadline urgency, revenue/value, relationship potential, blocker risk, and effort required. Should recommend resolving blockers first when scores are close. Should output a prioritized task table with task, deadline, score, why it matters, and next action. Should include red/yellow/black flags for overdue or due-soon items. Should ask for the specific active projects if not provided, but still give the scoring framework.",
+      "assertions": [
+        "Uses priority scoring",
+        "Includes deadline urgency and value",
+        "Includes blocker risk",
+        "Outputs a prioritized task table",
+        "Explains next action per task",
+        "Does not rely only on chronological sorting"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "I need help with TikTok hooks and Instagram captions for next week.",
+      "expected_output": "Should recognize this is primarily social media content creation, not creator operations planner setup. Should redirect to or cross-reference the social skill for hooks, captions, scheduling, and platform-specific content. May briefly mention that the ugc-creator-planner can track those posts and deadlines, but should not attempt a full planner unless the user asks for tracking or workflow.",
+      "assertions": [
+        "Recognizes this belongs to social",
+        "References social skill",
+        "Does not force planner workflow",
+        "Mentions planner only as optional tracking support"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "A brand asked me for my UGC rates and whether I offer retainers. What should I charge?",
+      "expected_output": "Should recognize this is primarily pricing and packaging. Should reference the pricing skill for rate strategy, retainers, packages, and monetization. May mention that the planner should track fee, usage rights, deliverables, estimated hours, effective hourly rate, and renewal dates so future pricing decisions use real data.",
+      "assertions": [
+        "Recognizes this belongs to pricing",
+        "References pricing skill",
+        "Mentions planner fields that support pricing decisions",
+        "Does not over-answer detailed rate strategy inside this skill"
+      ],
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new `ugc-creator-planner` skill for creator business operations: UGC/content planner setup, collaboration tracking, deadlines, reminders, priority scoring, payments, outreach follow-ups, and portfolio gap analysis.

Also adds eval coverage, registers the skill in `README.md`, updates `VERSIONS.md` with initial `1.0.0`, and updates the Claude plugin marketplace description from 40 to 41 skills.

closes: #288 