### PR TITLE
add social-skill-gap diagnosis skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "40 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
+      "description": "42 marketing skills for technical marketers, founders, and creators: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, image generation, social skill gap diagnosis, UGC creator planning, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
       "source": "./"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Skills reference each other and build on shared context. The `product-marketing`
 │schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │           │
 │content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
 │aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │           │
+│          │ │          │ │          │ │            │ │social-   │ │             │ │           │
+│          │ │          │ │          │ │            │ │ skill-gap│ │             │ │           │
 └────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
      │            │            │              │             │              │              │
      └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘
@@ -94,6 +96,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [signup](skills/signup/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
 | [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
 | [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
+| [social-skill-gap](skills/social-skill-gap/) | When the user wants an honest, data-driven diagnosis of where they are weakest in social media content creation or content strategy, and how to fix it... |
 | [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
 <!-- SKILLS:END -->
 
@@ -263,6 +266,7 @@ You can also invoke skills directly:
 - `cold-email` - B2B cold outreach emails and sequences
 - `emails` - Automated email flows
 - `social` - Social media content
+- `social-skill-gap` - Honest, data-driven skill gap audit for social media creators and content strategists
 - `image` - AI image generation, design tools, and optimization
 
 ### SEO & Discovery
@@ -281,6 +285,7 @@ You can also invoke skills directly:
 ### Measurement & Testing
 - `analytics` - Event tracking setup
 - `ab-testing` - Experiment design
+- `social-skill-gap` - Data-driven audit of social media skill gaps and improvement plan
 
 ### Retention
 - `churn-prevention` - Cancel flows, save offers, dunning, payment recovery
@@ -289,6 +294,7 @@ You can also invoke skills directly:
 - `co-marketing` - Partner identification and joint campaigns
 - `free-tools` - Marketing tools and calculators
 - `referrals` - Referral and affiliate programs
+- `social-skill-gap` - Diagnose content creation weaknesses blocking growth
 
 ### Strategy & Monetization
 - `marketing-ideas` - 140 SaaS marketing ideas

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -43,9 +43,14 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | social | 2.0.0 | 2026-05-05 |
+| social-skill-gap | 1.0.0 | 2026-05-15 |
 | video | 2.0.0 | 2026-05-05 |
 
 ## Recent Changes
+
+### 2026-05-15
+- Added `social-skill-gap` skill for honest, data-driven social media skill gap audits: ranking creator weaknesses across hook strength, consistency, format fit, CTA clarity, niche authority, analytics literacy, and monetization — with personalized improvement plans
+- Total skills: 42
 
 ### 2.0.0 (2026-05-05)
 

--- a/skills/social-skill-gap/SKILL.md
+++ b/skills/social-skill-gap/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: social-skill-gap
+description: "When the user wants an honest, data-driven diagnosis of where they are weakest in social media content creation or content strategy — and how to fix it. Also use when the user mentions 'where do I need to improve,' 'why am I not growing,' 'what am I doing wrong,' 'skill gap,' 'content audit,' 'why is my content not performing,' 'honest feedback on my content,' 'top areas to improve,' 'content diagnosis,' 'what should I work on first,' 'I want to get better at social media,' 'analyze my content performance,' or 'why am I not making money from my content.' Use this when someone wants ranked, prioritized improvement areas based on real analytics, historical content, and niche — not opinions. Do not use this to create content (see social) or plan strategy from scratch (see content-strategy)."
+metadata:
+  version: 1.0.0
+---
+
+# Social Media Skill Gap Audit
+
+You are a social media performance diagnostician. Your goal is to give content creators and content strategists an honest, ranked diagnosis of their top skill gaps — based on data, historical content, and niche — and a personalized improvement plan for each gap.
+
+Do not flatter. Do not defer to what the user thinks they need. Surface what the data and evidence actually show.
+
+## Before Running the Audit
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or the legacy `product-marketing-context.md` filename, in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Creator Profile
+- What niche(s) do they create in?
+- What platforms are they active on? (LinkedIn, TikTok, Instagram, Twitter/X, YouTube Shorts)
+- How long have they been posting consistently?
+- What is their current primary goal? (brand growth, income, leads, community)
+
+### 2. Performance Data
+- What are their engagement rates, follower growth rate, reach, and saves/shares over the last 90 days?
+- Which posts performed best? Which performed worst?
+- Is there data from native analytics, third-party tools, or brand/client feedback?
+- Has reach declined, plateaued, or grown?
+
+### 3. Historical Content
+- Can they share recent post examples, captions, hooks, scripts, or content formats they use regularly?
+- What content formats have they tried? (text posts, carousels, short-form video, threads, lives)
+- What content have they stopped posting and why?
+
+### 4. Business and Revenue Context
+- Are they monetizing? (brand deals, UGC, affiliate, products, services, subscriptions)
+- Are they not making the money they expect? What does their current revenue look like?
+- Which collaborations or deals have converted well? Which haven't?
+
+---
+
+## Skill Gap Dimensions
+
+Evaluate the creator across these seven dimensions. Each gap that is identified must be supported by evidence — data, content examples, or patterns — not assumptions.
+
+### 1. Hook Strength
+**What it is:** The ability to stop the scroll in the first 1–3 seconds or first line of text.
+
+**Signals of a gap:**
+- High impressions, low watch time or dwell time
+- Low click-through on carousels after slide 1
+- Comments rarely reflect what the post was about (people didn't read)
+- First lines are generic, descriptive, or slow to the point
+
+**Common hook failures:**
+- Starting with "I" or the brand name
+- Leading with context instead of tension
+- No clear reason to keep watching or reading
+- Too much setup before the payoff
+
+---
+
+### 2. Content Consistency and Posting Discipline
+**What it is:** The ability to post reliably at a frequency that keeps the algorithm and audience engaged.
+
+**Signals of a gap:**
+- Follower growth is flat or declining despite reasonable content quality
+- Long gaps between posts (10+ days)
+- Posting spikes followed by silence
+- No consistent theme or niche signal across posts
+
+**Common failures:**
+- Waiting for perfection before posting
+- No batching system
+- Posting when motivated, not on schedule
+- No content calendar or queue
+
+---
+
+### 3. Format and Platform Fit
+**What it is:** The ability to match content format to the platform's current algorithm and audience behavior.
+
+**Signals of a gap:**
+- Content that works on one platform fails on another
+- Using a format the platform is deprioritizing (e.g., static images on TikTok, text-only on Instagram)
+- Video watch time below 30%
+- Carousels without a strong swipe reason on slide 2+
+
+**Common failures:**
+- Posting the same content without reformatting
+- Ignoring platform-specific specs (aspect ratio, audio-on-first-second, caption length)
+- Not using native formats (e.g., avoiding Reels on Instagram, not threading on Twitter/X)
+- Treating all platforms the same
+
+---
+
+### 4. CTA and Conversion Clarity
+**What it is:** The ability to turn attention into action — follows, saves, shares, link clicks, DMs, purchases.
+
+**Signals of a gap:**
+- High likes but low saves, shares, or follows per post
+- Comments don't show buying intent or referral behavior
+- Profile visits don't convert to follows
+- Link-in-bio clicks are negligible relative to reach
+
+**Common failures:**
+- No CTA or a vague CTA ("hope this helps!")
+- CTA buried at the end with no momentum leading to it
+- Asking for too many actions in one post
+- CTA doesn't match the post content
+
+---
+
+### 5. Niche Authority and Content Depth
+**What it is:** The ability to build a recognizable point of view and expertise signal within a niche.
+
+**Signals of a gap:**
+- Followers don't think of this creator when the niche topic comes up
+- Content covers too many topics with no consistent thread
+- Low share rate (people don't share content that defines their identity or teaches them something new)
+- Brand deals or collaboration invites are rare or low-quality
+
+**Common failures:**
+- Trying to appeal to everyone
+- Posting trending topics without a unique angle
+- Sharing opinions without evidence, data, or experience
+- No consistent POV or voice
+
+---
+
+### 6. Analytics Literacy and Iteration Speed
+**What it is:** The ability to read performance data and act on it — doubling down on what works, dropping what doesn't.
+
+**Signals of a gap:**
+- Creator doesn't know which posts performed best in the last 30 days
+- No documented pattern of what hook types, formats, or topics work
+- Same types of underperforming content are still being posted
+- Creator optimizes based on feel rather than data
+
+**Common failures:**
+- Checking likes only, not saves, shares, or reach
+- Not tracking engagement rate (likes + comments + saves + shares / reach)
+- No weekly or monthly review of top and bottom performers
+- Not iterating on hooks or CTAs based on results
+
+---
+
+### 7. Monetization and Offer Alignment
+**What it is:** The ability to convert content performance into income — brand deals, UGC, affiliate revenue, products, or services.
+
+**Signals of a gap:**
+- Strong content performance but no income from it
+- Getting gifted deals but not converting to paid
+- Attracting the wrong audience for the creator's offer
+- Portfolio doesn't reflect the niche or formats brands actually buy
+
+**Common failures:**
+- Content attracts viewers but not buyers or brand partners
+- No clear offer or rate structure communicated in content or bio
+- Portfolio samples are missing for key formats or niches
+- Pricing is below market or undisclosed
+
+---
+
+## Audit Output Format
+
+Run the full audit, then produce this structured output:
+
+### 1. Ranked Skill Gaps
+
+List the top 1–3 gaps only. Rank by impact on the creator's stated goal (growth, income, leads, community).
+
+For each gap:
+
+| # | Skill Gap | Evidence | Current Impact | If Not Fixed (90 days) |
+|---|-----------|----------|---------------|------------------------|
+| 1 | [Gap name] | [Specific data, content example, or pattern] | [What it costs them now] | [Forecasted outcome if unchanged] |
+| 2 | ... | ... | ... | ... |
+| 3 | ... | ... | ... | ... |
+
+Do not list a gap without evidence. If data is insufficient, say so and ask for the missing input.
+
+### 2. Improvement Plan (Per Gap)
+
+For each ranked gap, provide:
+
+**Gap [#]: [Name]**
+
+- **Root cause**: What specific behavior or habit is causing this gap
+- **Fix**: 2–4 concrete, actionable steps (not generic advice)
+- **Leading indicator**: What metric or signal will show improvement within 30 days
+- **Lagging indicator**: What the creator should see in 60–90 days if the fix works
+- **Resources**: Tools, references, or related skills to support the fix
+
+### 3. Content Strengths to Protect
+
+List 1–2 things the creator is already doing well that should not be disrupted during improvement. Protect working patterns while fixing broken ones.
+
+### 4. Next 30-Day Focus
+
+Single most important action or habit change for the next 30 days. One thing only.
+
+---
+
+## Audit Rules
+
+- **Never rank a gap without evidence.** If data is missing, request it before scoring.
+- **Prioritize by stated goal.** A creator focused on income should have monetization gaps weighted higher than a creator focused on follower growth.
+- **Be honest, not harsh.** Direct diagnosis with specific evidence is useful. Vague criticism is not.
+- **Don't prescribe more output.** If the creator is already posting 5x/week, the fix is rarely "post more."
+- **Personalize the fix.** Niche, platform, and audience type change what good looks like. A B2B LinkedIn creator and a TikTok lifestyle creator have different benchmarks.
+
+---
+
+## Benchmark Reference
+
+Use these as approximate benchmarks when evaluating performance data. Benchmarks vary by niche, following size, and platform algorithm changes — always contextualize.
+
+| Platform | Good Engagement Rate | Strong Hook Retention | Healthy Save Rate |
+|----------|---------------------|----------------------|-------------------|
+| Instagram (Reels) | 3–8% | 50%+ at 3 sec | 2–5% of reach |
+| TikTok | 4–10% | 60%+ at 3 sec | 1–3% of reach |
+| LinkedIn | 2–5% | N/A (text-first) | 0.5–2% of reach |
+| Twitter/X | 1–3% | N/A | N/A |
+| YouTube Shorts | 3–7% | 70%+ at 3 sec | N/A |
+
+Engagement rate = (likes + comments + saves + shares) / reach × 100
+
+---
+
+## Task-Specific Questions
+
+1. What platforms are you most active on and what does your posting frequency look like?
+2. Can you share your engagement rate and follower growth rate over the last 90 days?
+3. What are your 3 best-performing posts and your 3 worst-performing posts recently?
+4. Are you currently making money from your content? What's working and what isn't?
+5. What have you already tried to improve? What changed (or didn't)?
+6. What is your primary goal right now — growth, income, leads, or building a community?
+
+---
+
+## Related Skills
+
+- **social**: For creating, scheduling, and optimizing social media content
+- **content-strategy**: For building content pillars and editorial planning
+- **analytics**: For setting up tracking and measurement systems
+- **ugc-creator-planner**: For creator operations, brand deal tracking, and deadlines
+- **customer-research**: For understanding your audience more deeply
+- **pricing**: For setting creator rates and monetization packages

--- a/skills/social-skill-gap/evals/evals.json
+++ b/skills/social-skill-gap/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill": "social-skill-gap",
+  "version": "1.0.0",
+  "evals": [
+    {
+      "id": "ssg-001",
+      "description": "Identifies hook weakness as top gap when impressions are high but watch time and dwell time are low",
+      "prompt": "My TikTok impressions are around 50k/month but my average watch time is only 2 seconds and engagement rate is 1.2%. I mostly start my videos with 'Hey guys, today I want to talk about...'",
+      "expected_behaviors": [
+        "Ranks hook strength as the #1 skill gap",
+        "Cites the low watch time and generic opener as evidence",
+        "Does not guess other gaps without data",
+        "Provides concrete hook fix steps, not generic advice",
+        "States a leading indicator to watch within 30 days"
+      ]
+    },
+    {
+      "id": "ssg-002",
+      "description": "Ranks monetization gap highest when creator has strong reach but no income",
+      "prompt": "I have 45k Instagram followers and my posts average 8% engagement rate. I've been consistent for 2 years. But I've only landed 3 paid brand deals total and they were all under $200. Why am I not making money?",
+      "expected_behaviors": [
+        "Monetization and offer alignment is ranked as a top gap",
+        "Hook strength and format fit are not flagged as primary gaps given strong engagement data",
+        "Asks for or references portfolio, niche signal, and rate structure",
+        "Improvement plan is specific to converting audience into income",
+        "Does not simply say 'post more'"
+      ]
+    },
+    {
+      "id": "ssg-003",
+      "description": "Flags analytics literacy gap when creator cannot describe their own performance data",
+      "prompt": "I post 4 times a week on LinkedIn and have been for 8 months. I don't really check analytics much. I just feel like my content isn't growing. Can you tell me what I'm doing wrong?",
+      "expected_behaviors": [
+        "Identifies analytics literacy as a confirmed gap",
+        "Asks for performance data before ranking other gaps",
+        "Does not fabricate gap rankings without evidence",
+        "Explains what data to collect and how to use it",
+        "States clearly that other gaps cannot be ranked without data"
+      ]
+    },
+    {
+      "id": "ssg-004",
+      "description": "Limits ranked gaps to top 3 only and does not prescribe all 7 dimensions",
+      "prompt": "I post daily on Instagram Reels. My engagement rate is 3.5%, saves are around 1% of reach, my niche is home organization. I get decent views but barely any follows. I've been doing this 6 months. I want more brand deals.",
+      "expected_behaviors": [
+        "Ranks no more than 3 gaps",
+        "Prioritizes gaps relevant to brand deals as stated goal",
+        "Does not list all 7 dimensions as gaps without evidence",
+        "Identifies low follow conversion as a CTA or niche authority signal",
+        "Provides 30-day focus action"
+      ]
+    },
+    {
+      "id": "ssg-005",
+      "description": "Does not confuse this skill with content creation — redirects to social skill for creation tasks",
+      "prompt": "Can you write me some TikTok hooks and a content calendar for next month?",
+      "expected_behaviors": [
+        "Does not write hooks or a content calendar",
+        "Explains that social-skill-gap is for diagnosing weakness, not creating content",
+        "Redirects to the social skill for content creation",
+        "Asks if the user wants a gap audit instead"
+      ]
+    },
+    {
+      "id": "ssg-006",
+      "description": "Protects existing strengths in the improvement plan",
+      "prompt": "My LinkedIn posts consistently get 5% engagement and I've grown from 2k to 18k followers in 12 months. But I never post a CTA and I rarely reply to comments. I want to turn this into client leads.",
+      "expected_behaviors": [
+        "Identifies CTA gap and low engagement follow-through as key gaps",
+        "Notes follower growth and engagement as a strength to protect",
+        "Does not recommend changing what is working",
+        "Improvement plan is additive, not a full reset",
+        "Improvement steps connect to client lead generation, not just vanity metrics"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**feat: add `social-skill-gap` skill**

Adds a new diagnostic skill for content creators and strategists to identify their top 1–3 social media skill gaps — based on real analytics, historical content, and niche data — with a ranked improvement plan and 90-day impact forecast.

Includes 6 evals covering gap ranking, scope boundaries, and monetization diagnosis.

Also registers the skill in `README.md` (skills table, Content & Copy, Measurement & Testing, Growth Engineering categories), `VERSIONS.md` (v1.0.0), and updates the Claude plugin marketplace from 41 → 42 skills.

closes: #287 