### PR TITLE
docs: add Sequenzy email marketing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
 | [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
 | [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
+| [sequenzy-email-marketing](skills/sequenzy-email-marketing/) | When the user wants to build, launch, or analyze lifecycle email marketing in Sequenzy, including subscriber workflows, segments, templates, campaigns, onboarding sequences, winback flows, and transactional email QA. |
 <!-- SKILLS:END -->
 
 ## Installation

--- a/skills/sequenzy-email-marketing/SKILL.md
+++ b/skills/sequenzy-email-marketing/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sequenzy-email-marketing
+description: When the user wants to build, launch, or analyze lifecycle email marketing in Sequenzy, including subscriber workflows, segments, templates, campaigns, onboarding sequences, winback flows, and transactional email QA.
+---
+
+# Sequenzy Email Marketing
+
+Use this skill to turn marketing strategy into executable Sequenzy workflows.
+
+## Process
+
+1. Clarify the lifecycle goal: onboarding, activation, retention, winback, launch, or transactional notification.
+2. Identify the audience: list, segment, subscriber attributes, or event trigger.
+3. Draft the email flow with subject lines, body copy, CTA, timing, and success metric.
+4. Use Sequenzy CLI/API or dashboard to create templates, campaigns, sequences, lists, or segments.
+5. Send tests before live delivery.
+6. Review stats after launch: sends, opens, clicks, bounces, unsubscribes, and replies where available.
+
+## Safety
+
+- Inspect account and target objects before mutating anything.
+- Never send or enable a live campaign without explicit approval.
+- Validate recipient emails, unsubscribe expectations, and sender identity.
+- Keep copy honest, specific, and human.
+
+## Useful commands
+
+```bash
+npm install -g @sequenzy/cli@latest
+sequenzy whoami
+sequenzy subscribers list
+sequenzy lists list
+sequenzy segments list
+sequenzy templates list
+sequenzy campaigns list
+sequenzy sequences list
+sequenzy stats
+```
+
+## Examples
+
+- Build a 4-email SaaS trial onboarding sequence.
+- Create a Product Hunt launch follow-up campaign.
+- Draft a churn-prevention winback flow.
+- Review campaign performance and suggest the next test.


### PR DESCRIPTION
Adds a focused Sequenzy email marketing skill for lifecycle campaigns, subscriber workflows, sequences, and reporting. Follows the repository naming/frontmatter guidelines and keeps the skill under 500 lines.