### PR TITLE
feat: add sms skill + 5 platform integration docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "40 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
+      "description": "41 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
       "source": "./"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Skills reference each other and build on shared context. The `product-marketing`
 │schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │           │
 │content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
 │aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │           │
+│          │ │          │ │sms       │ │            │ │          │ │             │ │           │
 └────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
      │            │            │              │             │              │              │
      └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘
@@ -93,6 +94,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [seo-audit](skills/seo-audit/) | When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO... |
 | [signup](skills/signup/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
 | [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
+| [sms](skills/sms/) | When the user wants to plan, build, or optimize SMS or MMS marketing — including welcome flows, abandoned cart texts,... |
 | [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
 | [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
 <!-- SKILLS:END -->

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -42,10 +42,15 @@ Current versions of all skills. Agents can compare against local versions to che
 | seo-audit | 2.0.0 | 2026-05-05 |
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
+| sms | 1.0.0 | 2026-05-15 |
 | social | 2.0.0 | 2026-05-05 |
 | video | 2.0.0 | 2026-05-05 |
 
 ## Recent Changes
+
+### 2.1.0 (2026-05-15)
+- Added `sms` skill for SMS/MMS marketing — welcome flows, abandoned cart, post-purchase, win-back, promotional sends, and transactional/auth. Includes compliance reference (TCPA, A2P 10DLC, GDPR, CASL), sequence templates with character counts, and platform comparison (Klaviyo, Postscript, Attentive, Twilio, Brevo, SimpleTexting, Customer.io).
+- Total skills: 41
 
 ### 2.0.0 (2026-05-05)
 

--- a/skills/sms/SKILL.md
+++ b/skills/sms/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: sms
+description: When the user wants to plan, build, or optimize SMS or MMS marketing — including welcome flows, abandoned cart texts, post-purchase, win-back, promotional sends, or transactional/auth SMS. Also use when the user mentions "SMS marketing," "text message campaigns," "SMS sequence," "SMS automation," "abandoned cart text," "post-purchase SMS," "Klaviyo SMS," "Postscript," "Attentive," "Twilio," "A2P 10DLC," "TCPA," "SMS compliance," "short code," "toll-free SMS," "MMS campaign," "should I do SMS," or "SMS vs email." For email sequences, see emails. For SMS copy framing, see copywriting. For opt-in popups that capture phone numbers, see popups.
+metadata:
+  version: 1.0.0
+---
+
+# SMS Marketing
+
+You are an expert in SMS and MMS marketing for direct-to-consumer brands, mobile apps, and SaaS products with high-engagement use cases. Your goal is to help plan, build, and optimize SMS programs that drive measurable revenue or activation while staying fully compliant with TCPA and carrier rules.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or the legacy `product-marketing-context.md` filename, in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Business Type
+- B2C ecom / DTC, B2B SaaS, mobile app, services, fintech
+- Order volume or list size (SMS economics depend on scale)
+- Geographic mix (US, EU, both — compliance differs dramatically)
+
+### 2. Current State
+- Existing SMS program (platform, list size, opt-in rate, opt-out rate, revenue/send)
+- Email program (SMS works best as a layer on top, not a replacement)
+- Phone number type: short code, toll-free, long code (10DLC)
+
+### 3. Compliance Posture
+- US: A2P 10DLC registration complete? (Required since 2022 — without it, your messages get filtered)
+- Opt-in mechanism in use? (Checkbox, keyword opt-in, double opt-in)
+- Privacy policy + terms include SMS disclosures?
+
+### 4. Goal
+- Drive revenue (promotional, cart recovery, post-purchase)
+- Drive activation (welcome, onboarding, milestone nudges)
+- Transactional (order updates, auth codes, alerts)
+
+---
+
+## When SMS Beats Email
+
+SMS is not "another email." Use it where the channel's properties win:
+
+| Use Case | SMS or Email? | Why |
+|----------|---------------|-----|
+| Abandoned cart recovery | **SMS first** | 98% open rate within 3 min vs 20% for email in 24h |
+| Order/shipping updates | **SMS** | Customers want it now, on their phone |
+| Flash sale / limited drop | **SMS** | Urgency channel; immediate read |
+| Auth codes / 2FA | **SMS** (or app) | Latency-sensitive, must arrive in seconds |
+| Welcome series | **Email primary, SMS layer** | Email carries the long-form content |
+| Educational nurture | **Email** | Too much text for SMS, costs add up |
+| Newsletter | **Email** | Wrong channel for SMS |
+| Win-back lapsed customers | **Both** | SMS for the strong nudge, email for the offer detail |
+| Post-purchase upsell | **SMS** | High open rate, ride the purchase momentum |
+
+**General rule**: SMS earns the right to interrupt because of opt-in. Use it for messages that genuinely benefit from immediacy. If it could wait 24 hours, send it via email.
+
+---
+
+## Compliance — Read First
+
+**Compliance is the foundation, not an afterthought.** A single TCPA class-action settlement runs $5M–$40M. The basics:
+
+### US — TCPA (Telephone Consumer Protection Act)
+
+1. **Express written consent** required for marketing SMS. Implied consent doesn't count.
+2. **Clear disclosure at opt-in** must include: program name, frequency expectation ("up to 4 msgs/month"), STOP/HELP instructions, "Msg & data rates may apply," link to terms.
+3. **Honor STOP/UNSUBSCRIBE within seconds**, every time, no exceptions, on every keyword variant (STOP, END, CANCEL, UNSUBSCRIBE, QUIT).
+4. **Honor HELP** with a response containing brand name + STOP info + support contact.
+5. **Quiet hours**: no marketing sends before 8am or after 9pm in the recipient's local time. Carrier rules and state laws (e.g., Florida, Oklahoma, Washington) are stricter than federal — default to 9am–8pm recipient-local.
+6. **Keep written consent records** with timestamp, opt-in source, and exact disclosure text shown. Auditable.
+
+### US — A2P 10DLC Registration (required since 2022)
+
+Application-to-Person 10-digit long codes must be registered through The Campaign Registry (TCR) via your SMS platform. Without registration:
+- Throughput is throttled (or zero)
+- Carriers filter your messages
+- You'll see "delivered" status but recipients won't get them
+
+**Registration covers**: brand identity verification, campaign use case (marketing, account notification, OTP, etc.), sample messages, opt-in mechanism, opt-out language. Sample message text from registration must match what you actually send.
+
+### EU/UK — GDPR-derived consent
+
+- Explicit opt-in required (no pre-checked boxes)
+- Right to withdraw consent must be as easy as giving it
+- Data subject access requests apply to SMS records
+- ePrivacy Directive layered on top of GDPR
+
+### Canada — CASL
+
+- Express consent + sender identification + unsubscribe in every message
+- Implied consent allowed for existing business relationships within 24 months
+- Penalties up to CAD $10M per violation
+
+**For full compliance details, edge cases, opt-in copy templates, and STOP/HELP response templates**: see [references/compliance.md](references/compliance.md).
+
+---
+
+## Phone Number Types (US)
+
+| Type | Throughput | Cost | Use Case | Trust |
+|------|-----------|------|----------|-------|
+| **Short code (5-6 digit)** | 100+ msg/sec | $500–$1,000/mo + setup | High-volume marketing | Highest (carrier-vetted) |
+| **Toll-free (1-8XX)** | ~3 msg/sec | $10–$30/mo | Mid-volume, B2C support | Medium-high (carrier-verified) |
+| **10DLC (regular long code)** | 1–250 msg/sec | $2–$10/mo | SMB, conversational, transactional | Medium (requires A2P 10DLC reg) |
+
+**Rule of thumb**: list <10K = 10DLC. List 10K–100K = toll-free. List 100K+ = short code.
+
+---
+
+## Core Principles
+
+### 1. Every send has a real cost
+SMS isn't free. At $0.0075–$0.04 per send + carrier fees, a 100K send costs $750–$4,000. This forces relevance — you can't "blast." Segment hard.
+
+### 2. Opt-in is your most valuable asset
+Opt-in rate from email → SMS is typically 5–25%. A high-quality SMS list of 10K beats a low-quality list of 100K. Optimize opt-in quality, not volume.
+
+### 3. Each message must justify itself
+The recipient gave you their phone number. Every send should pass: "would I be glad I got this text?" If no, don't send.
+
+### 4. Brevity + clarity
+160 GSM-7 characters = 1 SMS segment. 161+ chars = 2 segments (you're billed for 2). Emojis force UCS-2 encoding (70 chars per segment). Plan for segment count.
+
+### 5. One CTA, one link
+Short links are mandatory (`klvy.co`, `txt.attn.tv`, branded short domain). Track UTM params on every link.
+
+### 6. Sender identity, every send
+"From [Brand]:" or branded short code at the start of every message. Even on automated flows. Recipients can't see "from" address — they need it inline.
+
+---
+
+## SMS Sequence Types
+
+### Welcome / Opt-In Confirmation (immediate)
+
+Send 1: Confirmation + reward (immediate)
+> From Acme: Thanks for joining! Here's 10% off: ACME10. Use at checkout: acme.co/sale. Reply STOP to opt out.
+
+Optional Send 2 (24h later): Reminder + best-seller showcase
+
+### Abandoned Cart (highest-ROI flow for ecom)
+
+- Send 1 (30 min after abandon): "Forget something? Your cart's still here: [short link]"
+- Send 2 (4 hours later): Soft urgency + social proof
+- Send 3 (24 hours later, optional): Discount offer (only if margin allows)
+
+**Note**: Discount on first message trains customers to abandon. Reserve discount for Send 2 or 3.
+
+### Browse Abandonment
+
+- Send 1 (1 hour after browse): Product + "Thinking it over?" + link
+
+### Post-Purchase
+
+- Send 1 (immediate): Order confirmation + delivery ETA (transactional, separate consent OK)
+- Send 2 (after delivery + 2 days): "How are you liking [product]?" + review prompt + cross-sell
+
+### Win-Back (lapsed)
+
+- Send 1 (60–90 days after last purchase): "We miss you" + curated picks
+- Send 2 (14 days later): Discount offer
+- Send 3 (final, 14 days later): Opt-out warning + last chance
+
+### Promotional / Campaign Sends
+
+- Flash sales, drops, launches, BFCM
+- 1–2 sends max per campaign
+- Stack against email send schedule to avoid same-day double-tap
+
+### Transactional (separate compliance bucket)
+
+- Order updates, shipping, delivery, auth codes, account alerts
+- Generally OK without separate marketing consent if directly related to a transaction the user initiated
+- Still subject to A2P 10DLC registration in US
+
+**For full sequence templates with copy and timing**: see [references/sequence-templates.md](references/sequence-templates.md).
+
+---
+
+## SMS Copy Guidelines
+
+### Structure
+1. **Sender ID** ("From Acme:" or brand short code) — required
+2. **Hook** — first 5 words decide if they read on
+3. **Value** — what's in it for them, specifically
+4. **CTA + short link** — single action, single URL
+5. **Compliance footer** — "Reply STOP to opt out" (required on opt-in confirmation and at least quarterly thereafter; carrier-recommended on every promotional message)
+
+### Length
+
+- **160 chars (GSM-7)** = 1 segment. Aim here.
+- **70 chars (UCS-2)** if you use emojis, accented characters, or curly quotes — you'll pay for more segments.
+- **161–306 chars** = 2 segments (concatenated SMS). Acceptable for richer messages, but you're paying double per send.
+- **MMS** (image + up to 1,600 chars) = 3–5× the SMS cost. Use sparingly for high-impact moments.
+
+### Voice
+
+- Conversational, not corporate. SMS feels personal — write like you're texting a friend.
+- No subject line, no formatting, no marketing-speak.
+- Emojis are fine in moderation (one per message, situationally).
+- ALL CAPS reads as shouting. Avoid except for explicit codes (e.g., "Use ACME10").
+
+### Personalization
+
+- First name token if available (boosts CTR ~20%)
+- Recent product/category browse-based
+- Location-based offers (where applicable)
+- Don't fake intimacy ("Hey friend!") — it backfires
+
+**For complete copy patterns by sequence type with character counts**: see [references/sequence-templates.md](references/sequence-templates.md).
+
+---
+
+## Platform Selection
+
+| Platform | Best For | Native MCP | Cost Tier |
+|----------|----------|:---:|-----------|
+| **Klaviyo SMS** | DTC ecom already on Klaviyo email | ✓ | $$ |
+| **Postscript** | DTC Shopify ecom, deep integration | - | $$ |
+| **Attentive** | Mid-market+ ecom, full-service | - | $$$ |
+| **Twilio** | Custom builds, transactional, devs | - | $ (raw API) |
+| **Brevo SMS** | EU-focused, email + SMS combo | ✓ | $ |
+| **SimpleTexting** | SMB, simple needs, ease of use | - | $ |
+| **Customer.io** | Behavior-based automation + SMS | - | $$ |
+
+**Quick picks**:
+- Already on Klaviyo for email + DTC/ecom → **Klaviyo SMS** (no second platform to learn)
+- Shopify ecom, want deeper SMS-specific features → **Postscript**
+- Building custom SMS into a product → **Twilio**
+- B2B SaaS doing transactional/auth → **Twilio** or **Customer.io**
+
+**For platform deep-dives (features, pricing, integration paths, A2P registration)**: see [references/platforms.md](references/platforms.md).
+
+---
+
+## Measurement
+
+### Key Metrics
+
+| Metric | What it tells you | Healthy range (ecom DTC) |
+|--------|-------------------|--------------------------|
+| **Opt-in rate** | Top of funnel health | 5–25% of email subscribers |
+| **CTR** | Message relevance | 8–15% (vs ~3% email) |
+| **Conversion rate (per send)** | Revenue impact | 1–5% per promotional send |
+| **Revenue per send (RPS)** | Channel economics | $0.20–$2.00 |
+| **Opt-out rate per send** | Audience fatigue | <2% per send, <0.5% for promotional |
+| **Cost per send** | Channel cost discipline | $0.0075–$0.04 |
+| **List growth rate** | Audience momentum | 5–15%/month early, 1–3% steady-state |
+
+### What to track in analytics
+
+- UTM tag every link: `utm_source=sms&utm_medium=sms&utm_campaign=[campaign-name]`
+- Conversion attribution: SMS-driven sessions, last-click revenue, assisted conversions
+- LTV impact: SMS subscribers vs email-only subscribers (typically 1.5–3× LTV for SMS opt-ins)
+
+### What to A/B test
+
+- Send time (afternoon vs evening, local time)
+- Copy length (short SMS vs MMS with image)
+- Discount amount and trigger (immediate vs delayed)
+- Personalization tokens (with first name vs without)
+- CTA copy ("Shop now" vs "See it" vs "Last chance")
+
+Cross-reference **ab-testing** skill for proper test design and **analytics** for attribution setup.
+
+---
+
+## Output Format
+
+When the user asks for an SMS plan, return:
+
+1. **Compliance check**: Are they registered for A2P 10DLC (if US)? Is the opt-in mechanism compliant? Flag blockers first.
+2. **Strategy**: Which SMS flows to build first, ranked by ROI for their business model.
+3. **Sequence designs**: For each priority flow, specify trigger, delay, copy with character counts, CTA, segmentation.
+4. **Platform recommendation**: Based on stack, list size, and complexity.
+5. **Measurement plan**: KPIs, benchmarks, A/B test queue.
+6. **Compliance footer**: Required disclosures, STOP/HELP response templates.
+
+Keep recommendations specific. Don't say "send an SMS at the right time" — say "send 30 min after cart abandon, 4 hours later if no purchase, 24 hours later with discount."
+
+---
+
+## Task-Specific Questions
+
+1. Are you US, EU, or both? (Changes compliance approach entirely.)
+2. Is A2P 10DLC registration complete (US)?
+3. What platform are you on or considering?
+4. Email list size and SMS opt-in rate (if any)?
+5. What sequences do you already have running?
+6. Are you DTC ecom, mobile app, B2B SaaS, services?
+7. What's the primary goal: revenue, activation, retention, or transactional?
+
+---
+
+## Common Mistakes
+
+1. **Skipping A2P 10DLC registration** — your messages get filtered into oblivion. Register first, send second.
+2. **Treating SMS like email** — sending daily promotional blasts. Opt-out rates spike, list dies.
+3. **Discount on first abandoned cart message** — trains customers to always abandon. Reserve for second or third send.
+4. **Generic "From: [shortcode]"** — recipients need brand name in the message itself.
+5. **Forgetting quiet hours** — sending at 6 AM local time gets opt-outs and TCPA complaints.
+6. **No STOP/HELP handling** — non-negotiable. Every platform handles this; verify yours does.
+7. **Emojis everywhere** — pushes you into UCS-2 encoding, halves segment size, doubles cost.
+8. **Mismatching A2P sample messages and actual sends** — carriers flag and block.
+9. **Not tracking conversions** — you can't justify channel ROI without attribution.
+10. **No throttling on bulk sends** — burst sends trigger carrier filtering. Use platform throttling.
+
+---
+
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key SMS tools:
+
+| Tool | Best For | MCP | Guide |
+|------|----------|:---:|-------|
+| **Klaviyo** | E-commerce email + SMS combined | ✓ | [klaviyo.md](../../tools/integrations/klaviyo.md) |
+| **Postscript** | Shopify DTC SMS, deepest Shopify integration | - | [postscript.md](../../tools/integrations/postscript.md) |
+| **Attentive** | Mid-market+ DTC SMS, full-service | - | [attentive.md](../../tools/integrations/attentive.md) |
+| **Twilio** | Raw API for custom builds, transactional, dev-first | - | [twilio.md](../../tools/integrations/twilio.md) |
+| **Plivo** | Twilio alternative, lower per-send cost | - | [plivo.md](../../tools/integrations/plivo.md) |
+| **AudienceTap** | AI-forward DTC, on-pack QR opt-in | - | [audiencetap.md](../../tools/integrations/audiencetap.md) |
+| **Brevo** | EU email + SMS, SMB-friendly | ✓ | [brevo.md](../../tools/integrations/brevo.md) |
+| **Customer.io** | Behavior-based SMS automation | - | [customer-io.md](../../tools/integrations/customer-io.md) |
+
+---
+
+## Related Skills
+
+- **emails**: Sister channel — almost always run together. Email carries the long-form content; SMS carries the urgent nudges.
+- **copywriting**: For SMS copy at scale and the longer-form pages/emails that SMS links to.
+- **popups**: For phone number capture popups on-site.
+- **churn-prevention**: For win-back flows that combine SMS + email.
+- **onboarding**: For post-signup SMS milestone nudges.
+- **analytics**: For attribution and RPS measurement.
+- **ab-testing**: For SMS-specific test design.
+- **lead-magnets**: For incentivizing opt-in (the "10% off for joining" offer).

--- a/skills/sms/evals/evals.json
+++ b/skills/sms/evals/evals.json
@@ -1,0 +1,100 @@
+{
+  "skill_name": "sms",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're a Shopify DTC brand doing $5M/year in skincare. We have 80K email subscribers but no SMS program yet. Where do we start?",
+      "expected_output": "Should check for product-marketing.md first. Should run Phase 0 compliance check: are they US-based, is A2P 10DLC registration started, is the opt-in mechanism planned. Should recommend Klaviyo SMS or Postscript given Shopify + DTC ecom (Klaviyo if already on Klaviyo email, Postscript for SMS-first depth). Should rank flows by ROI for skincare: (1) abandoned cart sequence first (highest-ROI flow), (2) post-purchase + replenishment (skincare has predictable cycles), (3) welcome opt-in flow with capture incentive, (4) win-back at 60-90 days. Should warn about treating SMS like email (frequency cap, relevance bar, real per-send cost ~$0.0075-$0.04). Should reference compliance.md for opt-in disclosure language and quiet hours.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Runs compliance/A2P 10DLC readiness check",
+        "Recommends Klaviyo SMS or Postscript with rationale",
+        "Prioritizes abandoned cart as highest-ROI flow",
+        "Mentions replenishment for skincare specifically",
+        "Warns about treating SMS like email",
+        "References compliance.md or opt-in disclosure requirements",
+        "Mentions per-send cost economics"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Write me an abandoned cart SMS sequence. We sell custom apparel, average order $80.",
+      "expected_output": "Should output a 3-message sequence following references/sequence-templates.md pattern. Should specify timing: Send 1 at 30 min after abandon (no discount, gentle reminder), Send 2 at 4 hours (soft urgency, no discount), Send 3 at 24 hours (discount allowed). Should include actual SMS copy with character counts (target 160 GSM-7 for 1 segment). Each message must start with sender ID 'From [Brand]:', have a single CTA + short link, and the first message should include 'Reply STOP to opt out' compliance footer. Should warn against discount on first send (trains customers to abandon). Should mention exclusion rules: stop sequence on purchase, opt-out, or 48 hours elapsed. Should recommend UTM tagging for attribution and cross-reference analytics skill for measurement.",
+      "assertions": [
+        "Outputs 3-message sequence with timing",
+        "Send 1 at 30 min, Send 2 at 4 hours, Send 3 at 24 hours",
+        "No discount on Send 1",
+        "Each message has sender ID + single CTA + short link",
+        "Character counts shown, target ~160 GSM-7",
+        "Compliance footer on first send (STOP to opt out)",
+        "Warns about discount on first send",
+        "Mentions exclusion rules",
+        "Mentions UTM tagging or attribution"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Can I just send SMS without any opt-in if customers gave me their phone number at checkout?",
+      "expected_output": "Should refuse and explain TCPA requires express written consent for marketing SMS. Should distinguish marketing SMS (requires express written consent) from transactional/account SMS (order updates, auth — implied consent during transaction OK if directly related). Should explain the express written consent requirements: clear disclosure adjacent to the phone field, frequency expectation, msg & data rates notice, STOP/HELP instructions, terms link, electronically captured with timestamp. Should mention penalty exposure: $500-$1,500 per message, class actions reach 7-8 figures. Should recommend implementing a compliant opt-in flow: checkbox + disclosure text, double opt-in optional but cleaner. Should reference compliance.md for the full disclosure template. Should warn that 'customers gave their number at checkout' is NOT sufficient for marketing SMS — it's only sufficient for the specific transaction's communications.",
+      "assertions": [
+        "Refuses the no-opt-in approach",
+        "Distinguishes marketing SMS from transactional SMS",
+        "Lists express written consent requirements",
+        "Mentions TCPA penalty exposure ($500-$1,500 per message)",
+        "Mentions class action risk",
+        "Recommends compliant opt-in flow",
+        "References compliance.md",
+        "Clarifies checkout phone capture is not marketing consent"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Our SMS list is 50K subscribers. We send 3 promotional messages per week. Opt-out rate has crept up to 4% per send. What's wrong?",
+      "expected_output": "Should diagnose this as audience fatigue from over-sending. Should reference healthy benchmarks: opt-out rate should be <2% per send and <0.5% for promotional sends — 4% is significantly elevated. Should review send frequency: 3 promotional sends/week is on the high side; recommend reducing to 1-2/week, especially for newer subscribers. Should audit relevance: are sends segmented or going to entire list? Generic blasts to a 50K list will burn out the inactive 30K. Should recommend segmenting by engagement (recently engaged vs cold), purchase recency, and opt-in source. Should suggest reactivating cold subscribers with a re-engagement flow before sending more promos. Should warn that 4% opt-out per send means the list is being destroyed at the rate of ~2K/week. Should cross-reference analytics for proper measurement and the principle 'every send must justify itself.'",
+      "assertions": [
+        "Diagnoses as over-sending / audience fatigue",
+        "Cites healthy benchmark (<2% opt-out per send, <0.5% promotional)",
+        "Recommends reducing send frequency",
+        "Recommends segmentation by engagement",
+        "Suggests reactivation flow for cold subscribers",
+        "Calculates list erosion impact",
+        "Mentions 'every send must justify itself' principle"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "We just submitted our A2P 10DLC registration and our sends are working. Can we start scaling to 100K+ messages per day?",
+      "expected_output": "Should ask about phone number type currently in use: 10DLC, toll-free, or short code. Should explain throughput limits: 10DLC standard brand ~4-10 msg/sec, verified brand ~75-100+ msg/sec, toll-free ~3 msg/sec, short code 100+ msg/sec. Should calculate: 100K msgs at 10 msg/sec = ~2.8 hours of continuous send time, may run into quiet hour cutoff. Should recommend short code lease for 100K+/day sustained volume. Should warn about carrier filtering on burst sends — use platform throttling. Should mention that sample message text from A2P registration must match actual sends or carriers will flag. Should recommend monitoring trust score and deliverability dashboards. Should reference platforms.md for short code provisioning details.",
+      "assertions": [
+        "Asks about phone number type (10DLC vs toll-free vs short code)",
+        "Explains throughput limits with specific msg/sec numbers",
+        "Calculates time-to-send for 100K volume",
+        "Mentions quiet hour considerations",
+        "Recommends short code for high sustained volume",
+        "Warns about carrier filtering / throttling",
+        "Mentions A2P sample text alignment requirement",
+        "References platforms.md or trust score monitoring"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Should we put emojis in our SMS messages? Other brands seem to use them a lot.",
+      "expected_output": "Should explain the cost trade-off: emojis force UCS-2 encoding, which cuts segment size from 160 GSM-7 chars to 70 chars. A 100-char message with one emoji becomes 2 segments billed instead of 1 — effectively doubling the per-send cost. Should advise: 1 emoji per message max, situationally relevant, only when the emoji genuinely earns its segment cost (high-energy promotional, brand-personality fit, etc.). Should warn against emoji clutter — it signals 'mass send' rather than personal. Should note that some accented characters (curly quotes, em dashes) also force UCS-2 — copy-pasting from Word/Google Docs is a common silent cause of doubled costs. Should recommend testing in the platform's preview to verify segment count before scheduling. Should remind that segment count matters at scale: 100K sends at 2 segments instead of 1 = $750-$4,000 in extra cost per campaign.",
+      "assertions": [
+        "Explains UCS-2 encoding cost",
+        "Specifies 160 GSM-7 vs 70 UCS-2 segment sizes",
+        "Recommends max 1 emoji per message",
+        "Warns about doubled per-send cost",
+        "Mentions accented characters / curly quotes also trigger UCS-2",
+        "Recommends previewing segment count",
+        "Calculates cost impact at scale"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/sms/references/compliance.md
+++ b/skills/sms/references/compliance.md
@@ -1,0 +1,202 @@
+# SMS Compliance Reference
+
+Comprehensive compliance reference for SMS marketing across major jurisdictions, opt-in copy templates, and STOP/HELP response templates.
+
+> This is operational guidance, not legal advice. For high-volume programs (50K+ subscribers) or any program with non-trivial revenue, run your compliance setup past a TCPA-experienced attorney.
+
+---
+
+## United States — TCPA
+
+### What it is
+
+The Telephone Consumer Protection Act (1991, amended) regulates marketing calls and texts. The FCC enforces it; private plaintiffs sue under it. Statutory damages: $500–$1,500 **per message**. Class actions easily reach 7–8 figures.
+
+### Consent tiers
+
+| Type | What it covers | How to capture |
+|------|---------------|----------------|
+| **Express written consent** | Marketing SMS (sales, promotions, offers) | Checkbox + clear disclosure language, captured electronically with timestamp |
+| **Express consent (non-written)** | Informational/transactional (delivery, account alerts) | Phone number provided during transaction with awareness it'll be used to text |
+| **Established business relationship** | NOT sufficient for marketing SMS | Doesn't apply |
+
+### Express written consent requirements
+
+The opt-in flow must capture all of:
+
+1. The recipient agreed to receive marketing SMS from your brand
+2. The recipient understands consent is not a condition of purchase
+3. The disclosure showed frequency expectation, message and data rate notice, STOP/HELP instructions, terms link
+4. The agreement was electronically recorded with timestamp
+
+### Opt-in disclosure template (compliant)
+
+```
+By signing up via text, you agree to receive recurring automated promotional and
+personalized marketing text messages (e.g., cart reminders) from [Brand] at the
+cell number used when signing up. Consent is not a condition of any purchase.
+Reply HELP for help and STOP to cancel. Msg frequency varies. Msg & data rates
+may apply. View [Terms](link) and [Privacy](link).
+```
+
+Place this **directly adjacent** to the phone number field and submit button. Do not bury it in a footer.
+
+### Quiet hours
+
+- **Federal**: 8am–9pm in the recipient's local time zone
+- **Stricter states**: Florida (8am–8pm), Oklahoma (8am–8pm), Washington (8am–8pm)
+- **Carrier-recommended**: 9am–8pm recipient-local
+- **Practical default**: 9am–8pm recipient-local for safety
+
+Time zone is determined by area code, but area codes lie (people move). Major platforms (Klaviyo, Postscript, Attentive) handle this automatically; verify yours does.
+
+### STOP/HELP handling
+
+**STOP variants you must honor**: STOP, END, CANCEL, UNSUBSCRIBE, QUIT, STOPALL, OPTOUT
+
+**STOP response** (after STOP received):
+```
+You're unsubscribed from [Brand] alerts. No more messages will be sent. Reply HELP for help.
+```
+
+**HELP variants**: HELP, INFO
+
+**HELP response**:
+```
+[Brand] alerts: For help, visit [URL] or email [support@brand.com]. Msg & data rates may apply. Reply STOP to cancel.
+```
+
+**Critical rules**:
+- Honor STOP **within seconds**, every time, every keyword variant
+- Do not require the recipient to log in or visit a website to opt out
+- One STOP confirmation is allowed; do not send additional messages after
+- HELP responses do not count as marketing messages and are not subject to quiet hours
+
+### Sample TCPA-compliant footer language by sequence type
+
+- **Opt-in confirmation**: "Reply HELP for help, STOP to cancel. Msg & data rates may apply." — required
+- **Recurring promotional**: "Reply STOP to opt out" — required quarterly minimum; carrier-recommended every send
+- **Transactional**: Not required by TCPA but carriers expect it; include for safety
+
+---
+
+## United States — A2P 10DLC
+
+### What it is
+
+Application-to-Person 10-Digit Long Code registration, run by The Campaign Registry (TCR). Required for businesses sending SMS through 10DLC numbers (regular long codes) since 2022. Carriers (T-Mobile, AT&T, Verizon) enforce this; unregistered traffic gets throttled or blocked.
+
+### Registration components
+
+1. **Brand registration**
+   - Legal entity name, EIN, business type
+   - Trust score assigned (Standard or Verified)
+   - Higher trust = better throughput, lower fees
+
+2. **Campaign registration** (one per use case)
+   - Use case: Marketing, Account Notification, Customer Care, Public Service, Higher Education, Polling and Voting, 2FA, Delivery Notification, etc.
+   - Sample message text (must match what you actually send)
+   - Opt-in flow description and screenshot
+   - Opt-out language
+   - Help message language
+   - Volume estimate
+
+3. **Phone number assignment** to campaigns
+
+### Throughput tiers (varies by carrier and trust score)
+
+| Trust score + use case | Throughput |
+|------------------------|-----------|
+| Verified brand, marketing | 75–100+ msg/sec |
+| Standard brand, marketing | 4–10 msg/sec |
+| Unregistered | 0.1 msg/sec or blocked |
+
+### Common rejections
+
+- Sample message text doesn't match actual sends
+- Opt-in flow screenshot doesn't show required disclosure language
+- "SHAFT" content (Sex, Hate, Alcohol, Firearms, Tobacco) without explicit use case
+- Generic or vague campaign descriptions
+
+**Process time**: 1–7 business days. Plan for this in launch timelines.
+
+---
+
+## EU / UK — GDPR + ePrivacy Directive
+
+### Consent requirements
+
+- **Explicit opt-in**: clear affirmative action (no pre-checked boxes)
+- **Specific**: opt-in must be for marketing SMS specifically, separate from generic ToS
+- **Informed**: data subject must know who's processing and why
+- **Freely given**: can't be bundled with service access
+
+### Mandatory provisions
+
+- Sender identity in every message
+- Easy opt-out in every message
+- Right to access data (DSARs)
+- Right to deletion
+- Records of consent kept for the duration of processing + statute of limitations
+
+### Penalty exposure
+
+GDPR fines up to €20M or 4% of global revenue, whichever is higher.
+
+---
+
+## Canada — CASL
+
+### Consent
+
+- **Express consent**: explicit opt-in (same standard as US TCPA express written consent)
+- **Implied consent**: existing business relationship within 24 months — limited use, expires
+
+### Every message must include
+
+- Sender identification (legal name + any operating names)
+- Mailing address
+- Phone, email, or website contact
+- Unsubscribe mechanism that works within 10 business days
+
+### Penalty exposure
+
+Up to CAD $10M per violation. Enforced by the CRTC.
+
+---
+
+## Australia — Spam Act 2003
+
+- Express or inferred consent (inferred has narrow application)
+- Sender ID required
+- Functional unsubscribe required
+- Enforced by ACMA
+
+---
+
+## Multi-jurisdictional programs
+
+If you send across US + EU + Canada simultaneously:
+
+- Default to the **strictest** standard across all jurisdictions (US TCPA express written consent + GDPR explicit opt-in)
+- Track consent jurisdiction per subscriber
+- Default quiet hours to recipient-local 9am–8pm
+- Include all required identifiers in every message
+
+---
+
+## Audit-ready compliance checklist
+
+- [ ] A2P 10DLC registration complete (US, if applicable)
+- [ ] Opt-in flow includes all required disclosures, adjacent to phone field
+- [ ] Disclosure text matches A2P registered sample messages
+- [ ] Opt-in event captures: timestamp, IP, page URL, exact disclosure shown
+- [ ] STOP/HELP keywords honored across all variants
+- [ ] Quiet hours enforced at platform level (recipient-local time)
+- [ ] Privacy policy includes SMS section
+- [ ] Terms of service include SMS terms
+- [ ] Consent records retained per applicable law (typically 4+ years US, longer EU)
+- [ ] Process for handling DSARs (EU) and consent revocation
+- [ ] Sender identity in every message
+- [ ] Compliance footer on every promotional message (recommended) or quarterly minimum (required)
+- [ ] Test STOP/HELP from a real phone number quarterly to verify it still works

--- a/skills/sms/references/platforms.md
+++ b/skills/sms/references/platforms.md
@@ -1,0 +1,318 @@
+# SMS Platform Reference
+
+Deep-dive on the major SMS marketing platforms — features, pricing, A2P 10DLC support, and integration paths.
+
+> Pricing is approximate and changes regularly. Always confirm at the vendor's site before committing.
+
+---
+
+## Klaviyo SMS
+
+**Best for**: DTC ecom brands already using Klaviyo for email.
+
+### Key features
+- Native integration with Klaviyo email and segmentation
+- Shared subscriber profile across email + SMS
+- Built-in A2P 10DLC registration
+- Flow builder shared with email flows
+- Conversational SMS (two-way) supported
+
+### Pricing
+- Bundled with Klaviyo plans, billed per SMS credit
+- US: ~$0.0075–$0.015 per SMS; MMS ~$0.04
+- Free tier: 150 SMS credits/month on lower email tiers
+
+### Integration paths
+- Direct Shopify, WooCommerce, BigCommerce, Magento integration
+- API for custom platforms
+- MCP server available
+
+### Compliance
+- A2P 10DLC registration handled in-platform
+- Toll-free and short code provisioning available (short code adds $1,000+/mo)
+- Quiet hours enforced per recipient time zone (configurable)
+
+### Watch out for
+- Email + SMS combined billing can spike fast on large lists
+- Short code costs are real overhead; only worthwhile for 100K+ active SMS subscribers
+
+---
+
+## Postscript
+
+**Best for**: Shopify-native DTC brands wanting SMS-specific tooling and onboarding support.
+
+### Key features
+- Deep Shopify integration (the deepest of any SMS platform)
+- Strong abandoned cart and browse abandonment automations
+- AI Reply (auto-reply trained on brand voice)
+- Conversational SMS / live agent
+- Audiences pulled from Shopify customer data
+
+### Pricing
+- Tiered plans: Starter (free, 1K msgs/mo), Growth ($100+/mo), Professional, Enterprise
+- Pay-per-send adds on top: ~$0.015 per SMS, ~$0.04 per MMS
+
+### Integration paths
+- Shopify-first; limited support for non-Shopify
+- API + webhooks available
+
+### Compliance
+- A2P 10DLC handled in-platform
+- Strong opt-in compliance tools (popup builder, keyword opt-in)
+- Quiet hours enforced
+
+### Watch out for
+- Steep cost increase past Starter tier
+- Less useful if you're not on Shopify
+
+---
+
+## Attentive
+
+**Best for**: Mid-market and enterprise DTC brands wanting full-service SMS.
+
+### Key features
+- Full-service: dedicated CSM, copy support, strategy
+- Conversational SMS at scale
+- Concierge sales-via-SMS
+- Strong analytics and attribution
+- Identity resolution (matching anon site visitors to phone numbers)
+
+### Pricing
+- Custom contracts; typically $1K–$10K+/mo + per-send fees
+- Annual contracts standard
+- Pricing rarely makes sense for <50K SMS subscribers
+
+### Integration paths
+- Shopify, BigCommerce, Salesforce Commerce Cloud, custom
+- Robust API
+
+### Compliance
+- Full A2P 10DLC managed
+- Best-in-class compliance tooling and audit support
+- Short code provisioning included on most plans
+
+### Watch out for
+- Contract terms can lock you in for 12+ months
+- Overkill for early-stage brands
+
+---
+
+## Twilio
+
+**Best for**: Custom builds, transactional SMS, B2B SaaS embedding SMS into products, developers.
+
+### Key features
+- Raw SMS API
+- Pay-per-send pricing, no platform fees
+- Massive global coverage (200+ countries)
+- Programmable Voice, WhatsApp Business, RCS available alongside
+- Studio (visual flow builder) for non-code automation
+
+### Pricing
+- US 10DLC SMS: $0.0079 per message
+- US toll-free SMS: $0.0079 per message
+- US short code SMS: $0.0079 per message + $1,000/mo lease
+- MMS: ~$0.02
+- Carrier surcharges layered on top (~$0.005 per US 10DLC)
+- A2P 10DLC registration: ~$15 brand + $10/mo per campaign
+
+### Integration paths
+- API-first (REST + SDKs in Node, Python, Ruby, Go, etc.)
+- No native ecom integrations — you build them
+
+### Compliance
+- A2P 10DLC registration in-platform but you do the work
+- TwilioSendGrid (separate product) handles email-side compliance
+- Quiet hours and STOP/HELP handling must be implemented by you
+
+### Watch out for
+- You're responsible for compliance — no hand-holding
+- No native segmentation, deliverability dashboards, or marketing UI
+- Best paired with Customer.io, Segment, or a custom orchestration layer
+
+---
+
+## Brevo (formerly Sendinblue)
+
+**Best for**: EU-based brands, email + SMS combo, SMB-friendly.
+
+### Key features
+- Combined email + SMS + WhatsApp on one platform
+- EU-headquartered, GDPR-native
+- Generous free tier for email; SMS pay-per-send
+- Marketing automation flows
+- CRM included
+
+### Pricing
+- Free tier: 300 emails/day; SMS pay-per-send
+- US SMS: ~$0.015 per message
+- EU SMS: varies by country, ~€0.04–€0.07
+
+### Integration paths
+- Direct integrations: Shopify, WooCommerce, WordPress, Magento
+- API + Zapier
+- MCP server available
+
+### Compliance
+- GDPR + ePrivacy built-in
+- A2P 10DLC for US (less polished than dedicated US platforms)
+
+### Watch out for
+- US SMS features lag behind Klaviyo/Postscript
+- Best if you're EU-first or already on Brevo for email
+
+---
+
+## SimpleTexting
+
+**Best for**: SMB, services businesses, simple campaign blasts, low-volume.
+
+### Key features
+- Easy-to-use UI
+- Keyword opt-in for grassroots list building
+- Built-in landing pages for opt-in
+- Simple automation
+
+### Pricing
+- Plans start ~$30/mo for 500 credits, scaling up
+- US SMS only
+
+### Integration paths
+- Zapier, Make, native to a few apps
+- API available but basic
+
+### Compliance
+- A2P 10DLC handled
+- TCPA tooling
+
+### Watch out for
+- Limited automation depth vs Klaviyo/Postscript
+- Best for low-complexity, low-volume use cases (gyms, salons, real estate)
+
+---
+
+## Plivo
+
+**Best for**: Custom SMS builds where per-send cost matters; Twilio-style API at a lower price point.
+
+### Key features
+- Direct Twilio competitor with similar surface area
+- Powerpack for bulk sending with sticky sender across number pools
+- A2P 10DLC handled in-platform
+- WhatsApp, voice available alongside SMS
+- SDKs for major languages
+
+### Pricing
+- US 10DLC SMS: ~$0.0055/msg (typically 20–30% under Twilio)
+- US short code SMS: similar + monthly lease
+- MMS: ~$0.02
+- Phone number rental: ~$0.80/mo local, ~$1/mo toll-free
+
+### Integration paths
+- API-first (REST + SDKs)
+- No native ecom integrations — you build them
+
+### Compliance
+- A2P 10DLC managed in-platform
+- Compliance plumbing (STOP/HELP, quiet hours) is your responsibility — same model as Twilio
+
+### Watch out for
+- Smaller ecosystem than Twilio (fewer ancillary products, integrations, community resources)
+- WhatsApp tooling less mature
+
+---
+
+## AudienceTap
+
+**Best for**: DTC brands wanting AI-forward creative tooling or on-pack QR opt-in as a primary acquisition channel.
+
+> Newer platform — verify current capabilities, pricing, and API surface before committing.
+
+### Key features
+- SMS + email on one platform (similar combined model to Klaviyo)
+- AI creative generation (SMS copy, subject lines, image variants)
+- On-pack QR code opt-in: insert cards in shipped orders that drive SMS list growth
+- Shopify, BigCommerce, headless commerce integrations
+- A2P 10DLC managed in-platform
+- Identity resolution and segmentation
+
+### Pricing
+- Tiered by subscriber count + send volume
+- Per-send pricing comparable to other DTC SMS platforms
+
+### Integration paths
+- API access on Growth+ tiers
+- Direct ecom integrations
+- Webhooks for events
+
+### Compliance
+- A2P 10DLC handled in-platform
+- TCPA tooling — verify enterprise-scale depth before committing for large lists
+
+### Watch out for
+- Newer entrant — fewer reference customers, less battle-tested at high volume than incumbents
+- Some features rolled out recently — confirm what's GA vs beta before relying on them
+
+---
+
+## Customer.io
+
+**Best for**: B2B SaaS, behavior-based automation, multi-channel orchestration (email + SMS + push).
+
+### Key features
+- Trigger SMS off product events (signup, milestone, churn risk)
+- Powerful audience segmentation
+- Workflow builder
+- Real-time data sync via API/webhooks
+
+### Pricing
+- Plans start ~$150/mo, scaling with profile count
+- SMS via Twilio integration or native (varies)
+
+### Integration paths
+- API-first
+- Direct integrations with Segment, Heap, Mixpanel, etc.
+
+### Compliance
+- A2P 10DLC via Twilio if using native integration
+- Granular subscription/consent management
+
+### Watch out for
+- Less ecom-tailored than Klaviyo/Postscript
+- Best for product-led SaaS or apps with deep event tracking
+
+---
+
+## Quick selection table
+
+| Stack / Goal | Recommended | Why |
+|--------------|------------|-----|
+| Shopify ecom, already on Klaviyo | **Klaviyo SMS** | One platform, one subscriber profile |
+| Shopify ecom, SMS-first focus | **Postscript** | Deepest Shopify + SMS-specific features |
+| Mid-market ecom, want concierge support | **Attentive** | Full-service team + tooling |
+| Custom platform, B2B SaaS, transactional | **Twilio** | API-first, full control |
+| Custom build, cost-sensitive | **Plivo** | ~20–30% cheaper than Twilio per send |
+| DTC wanting AI creative or on-pack QR opt-in | **AudienceTap** | AI-forward; insert-card opt-in is unique |
+| EU-based SMB | **Brevo** | GDPR-native, EU-friendly pricing |
+| Local services SMB, simple campaigns | **SimpleTexting** | Easy UI, low overhead |
+| Product-led SaaS with event tracking | **Customer.io** | Behavior-based triggers |
+
+---
+
+## A2P 10DLC: what your platform should handle
+
+Whatever you pick, confirm your platform handles:
+
+- [ ] Brand and campaign registration with TCR
+- [ ] Sample message text aligned with what you actually send
+- [ ] Opt-in flow documentation submitted to carriers
+- [ ] Trust score visibility (and a path to improve it)
+- [ ] Throughput appropriate to your list size and send frequency
+- [ ] STOP/HELP keyword handling
+- [ ] Quiet hours by recipient time zone
+- [ ] Suppression list management
+- [ ] Consent record retention with timestamps
+
+All major platforms above handle these. Twilio does the lowest-level work and pushes more responsibility onto you.

--- a/skills/sms/references/sequence-templates.md
+++ b/skills/sms/references/sequence-templates.md
@@ -1,0 +1,282 @@
+# SMS Sequence Templates
+
+Full copy templates with character counts, timing, and segmentation logic for every major SMS flow.
+
+> Character counts shown assume GSM-7 encoding. Emojis force UCS-2 (70 chars/segment instead of 160). All templates use `[Brand]`, `[FirstName]`, and `[short.link]` as substitution tokens.
+
+---
+
+## Welcome / Opt-In Confirmation
+
+### Send 1 — Immediate (after opt-in)
+
+```
+From [Brand]: Welcome! Here's your 10% off code: WELCOME10. Shop now: [short.link]
+Reply STOP to opt out, HELP for help. Msg & data rates may apply.
+```
+~155 chars / 1 segment (just). Footer required on first send.
+
+### Send 2 — 24 hours later (optional)
+
+```
+From [Brand]: Don't forget your code WELCOME10 — expires in 48hrs. Top picks: [short.link]
+```
+~108 chars / 1 segment.
+
+### Send 3 — 7 days later (optional, conditional on no purchase)
+
+```
+From [Brand]: Last chance for 10% off with WELCOME10. Expires tonight at midnight: [short.link]
+```
+~107 chars / 1 segment.
+
+---
+
+## Abandoned Cart (highest-ROI flow for ecom)
+
+### Send 1 — 30 minutes after abandon
+
+```
+From [Brand]: Hey [FirstName], you left something behind! Your cart's here: [short.link]
+```
+~95 chars / 1 segment.
+
+### Send 2 — 4 hours after abandon (if no purchase)
+
+```
+From [Brand]: Items in your cart are selling fast. Reserved for you for 24hrs: [short.link]
+```
+~98 chars / 1 segment.
+
+### Send 3 — 24 hours after abandon (if no purchase, discount allowed)
+
+```
+From [Brand]: Still thinking? Here's 10% off to seal the deal: SAVE10. Shop: [short.link]
+```
+~99 chars / 1 segment.
+
+**Notes**:
+- Discount on Send 1 trains customers to abandon. Reserve for Send 2 or 3.
+- Exclude customers who abandoned <$X in cart value or repeat abandoners (gaming the discount).
+- Stop sequence on purchase, opt-out, or 48 hours elapsed.
+
+---
+
+## Browse Abandonment
+
+### Send 1 — 1 hour after browse (single product or category)
+
+```
+From [Brand]: Still thinking about [product]? Take another look: [short.link]
+```
+~84 chars / 1 segment.
+
+**Notes**:
+- Trigger only after meaningful browse signal (3+ product views or 2+ min on product page).
+- Exclude if a purchase happened on a different product.
+
+---
+
+## Post-Purchase Flow
+
+### Send 1 — Immediately after purchase (transactional, separate consent)
+
+```
+From [Brand]: Order #12345 confirmed! We'll text shipping updates here. Track: [short.link]
+```
+~95 chars / 1 segment.
+
+### Send 2 — Day of shipment
+
+```
+From [Brand]: Your order's on the way. Estimated delivery: [date]. Track: [short.link]
+```
+~92 chars / 1 segment.
+
+### Send 3 — Day of delivery
+
+```
+From [Brand]: Your order should arrive today! Questions? Reply or visit [short.link]
+```
+~88 chars / 1 segment.
+
+### Send 4 — 2 days after delivery (marketing consent required)
+
+```
+From [Brand]: How are you liking your [product]? Share a review for 15% off next order: [short.link]
+```
+~108 chars / 1 segment.
+
+### Send 5 — 14 days after delivery (cross-sell, marketing consent)
+
+```
+From [Brand]: Goes great with your [product]: [related-item]. 10% off bundle: [short.link]
+```
+~99 chars / 1 segment.
+
+---
+
+## Win-Back (Lapsed Customers)
+
+### Send 1 — 60-90 days after last purchase
+
+```
+From [Brand]: [FirstName], we miss you! Picks we think you'll love: [short.link]
+```
+~84 chars / 1 segment.
+
+### Send 2 — 14 days later (if no purchase)
+
+```
+From [Brand]: Come back for 15% off your next order: COMEBACK15. Expires in 7 days: [short.link]
+```
+~106 chars / 1 segment.
+
+### Send 3 — 14 days after Send 2 (final, if no purchase)
+
+```
+From [Brand]: Last chance — 20% off ends tonight: COMEBACK20. We'll stop texting if you'd rather: reply STOP. [short.link]
+```
+~130 chars / 1 segment.
+
+**Notes**:
+- After Send 3 with no engagement, suppress for 90 days minimum.
+- After two full win-back cycles with no engagement, sunset (remove from active list).
+
+---
+
+## Promotional / Campaign Sends
+
+### Flash sale (single send)
+
+```
+From [Brand]: 24-HOUR FLASH: 25% off everything with FLASH25. Ends midnight: [short.link]
+```
+~94 chars / 1 segment.
+
+### Limited drop / launch
+
+```
+From [Brand]: New drop just landed: [product-name]. Limited stock, members get early access: [short.link]
+```
+~115 chars / 1 segment.
+
+### Holiday / BFCM (2-send sequence)
+
+Send 1 — Day of launch:
+```
+From [Brand]: Black Friday is LIVE — up to 50% off sitewide. Shop now: [short.link]
+```
+~92 chars / 1 segment.
+
+Send 2 — Day of (or evening, expiration push):
+```
+From [Brand]: Last 6 hours of BFCM savings. Don't miss out: [short.link]
+```
+~73 chars / 1 segment.
+
+---
+
+## Transactional / Account Notifications
+
+### Order confirmation
+
+```
+[Brand]: Order #12345 confirmed. Total $XX.XX. Track at [short.link]. Reply HELP for help.
+```
+
+### Shipping update
+
+```
+[Brand]: Your order #12345 shipped! Track: [short.link]. ETA [date].
+```
+
+### Delivery confirmation
+
+```
+[Brand]: Order #12345 delivered. Enjoy! Issues? Reply or [support-link].
+```
+
+### Auth code (2FA)
+
+```
+[Brand] verification code: 123456. Expires in 10 min. Do not share.
+```
+
+### Account alert
+
+```
+[Brand]: Sign-in from new device in [location]. Wasn't you? Secure: [short.link]
+```
+
+---
+
+## Re-Engagement / Reactivation (Subscribers Who've Gone Cold)
+
+For SMS subscribers who haven't engaged with any send in 60+ days.
+
+### Send 1 — Soft reactivation
+
+```
+From [Brand]: We've missed you, [FirstName]! Here's what's new: [short.link]
+```
+~80 chars / 1 segment.
+
+### Send 2 — Confirm interest (if no engagement)
+
+```
+From [Brand]: Want to keep hearing from us? Reply YES to stay on the list, or STOP to opt out.
+```
+~98 chars / 1 segment.
+
+After no reply: suppress for 60 days, then remove from active list. This protects opt-out rate metrics and reduces wasted spend.
+
+---
+
+## Replenishment (Consumables Ecom)
+
+For products with predictable usage cycles (skincare, supplements, coffee, pet food).
+
+### Send 1 — At expected reorder window (e.g., 28 days for a 30-day supply)
+
+```
+From [Brand]: Running low on [product]? Reorder in one tap: [short.link]
+```
+~73 chars / 1 segment.
+
+### Send 2 — 7 days later (if no purchase)
+
+```
+From [Brand]: Don't run out! 10% off your reorder of [product]: REFILL10 [short.link]
+```
+~92 chars / 1 segment.
+
+---
+
+## VIP / Loyalty Members
+
+Higher frequency, exclusive offers, early access — different cadence rules apply but quiet hours and STOP still required.
+
+### Early access
+
+```
+From [Brand]: VIPs get the new drop 24hrs early. Yours now: [short.link]
+```
+~72 chars / 1 segment.
+
+### Loyalty milestone
+
+```
+From [Brand]: You've reached Gold status! Your perks: 15% off + free shipping. [short.link]
+```
+~95 chars / 1 segment.
+
+---
+
+## Segmentation rules across all flows
+
+- **Suppress** customers in active sequences from promotional sends (no double-tap)
+- **Suppress** opted-out subscribers from everything (platform handles this)
+- **Frequency cap**: max 4–6 marketing sends/week per subscriber (lower for newer subscribers)
+- **Quiet hours**: 9am–8pm recipient-local time
+- **Cool-off**: After a discount-driven purchase, suppress promotional sends for 14 days

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -53,6 +53,11 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | postmark | Email | ✓ | - | [✓](clis/postmark.js) | ✓ | [postmark.md](integrations/postmark.md) |
 | brevo | Email/SMS | ✓ | - | [✓](clis/brevo.js) | ✓ | [brevo.md](integrations/brevo.md) |
 | activecampaign | Email/CRM | ✓ | - | [✓](clis/activecampaign.js) | ✓ | [activecampaign.md](integrations/activecampaign.md) |
+| twilio | SMS/Voice | ✓ | - | ✓ | ✓ | [twilio.md](integrations/twilio.md) |
+| plivo | SMS/Voice | ✓ | - | - | ✓ | [plivo.md](integrations/plivo.md) |
+| postscript | SMS | ✓ | - | - | - | [postscript.md](integrations/postscript.md) |
+| attentive | SMS | ✓ | - | - | - | [attentive.md](integrations/attentive.md) |
+| audiencetap | SMS/Email | ✓ | - | - | - | [audiencetap.md](integrations/audiencetap.md) |
 | hunter | Email Outreach | ✓ | - | [✓](clis/hunter.js) | - | [hunter.md](integrations/hunter.md) |
 | snov | Email Outreach | ✓ | - | [✓](clis/snov.js) | - | [snov.md](integrations/snov.md) |
 | lemlist | Email Outreach | ✓ | - | [✓](clis/lemlist.js) | - | [lemlist.md](integrations/lemlist.md) |
@@ -184,6 +189,23 @@ Email marketing, transactional email, and automation platforms.
 | **activecampaign** | Email automation + CRM | - |
 
 **Agent recommendation**: Resend for transactional (dev-friendly). Postmark for deliverability. Customer.io for advanced automation. Kit for creators. Beehiiv for newsletters. Klaviyo for e-commerce email/SMS. ActiveCampaign for email + CRM combo.
+
+### SMS / Messaging
+
+SMS and MMS marketing platforms and programmable messaging APIs.
+
+| Tool | Best For | MCP Available |
+|------|----------|:-------------:|
+| **klaviyo** | DTC ecom already on Klaviyo email | - |
+| **postscript** | Shopify DTC, SMS-first depth | - |
+| **attentive** | Mid-market+ DTC, full-service | - |
+| **twilio** | Custom API builds, transactional, dev-first | - |
+| **plivo** | Twilio alternative, lower per-send cost | - |
+| **audiencetap** | DTC with AI-forward creative + on-pack QR opt-in | - |
+| **brevo** | EU SMB email + SMS combo | - |
+| **customer-io** | Behavior-based SMS automation | - |
+
+**Agent recommendation**: Klaviyo SMS for ecom already on Klaviyo email. Postscript for Shopify-first depth. Attentive for mid-market+ wanting concierge support. Twilio (or Plivo for lower cost) for custom builds and transactional/auth. AudienceTap when AI creative or on-pack QR opt-in matters.
 
 ### Advertising
 

--- a/tools/integrations/attentive.md
+++ b/tools/integrations/attentive.md
@@ -1,0 +1,152 @@
+# Attentive
+
+Full-service SMS marketing platform for mid-market and enterprise direct-to-consumer brands. Combines tooling with dedicated success teams.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API |
+| MCP | - | Not available |
+| CLI | - | None |
+| SDK | - | Use API directly |
+
+## Authentication
+
+- **Type**: OAuth 2.0 or API Key (depending on integration type)
+- **Header**: `Authorization: Bearer {access_token}`
+- **Get credentials**: Account-level provisioning through Attentive integrations team
+- **Note**: API access requires partnership or eligible plan
+
+## Common Agent Operations
+
+### Subscribe a user
+
+```bash
+POST https://api.attentivemobile.com/v1/subscriptions
+
+{
+  "user": {
+    "phone": "+15551234567",
+    "email": "user@example.com"
+  },
+  "signUpSourceId": "...",
+  "subscriptionType": "MARKETING"
+}
+```
+
+Sign-up source ID determines opt-in attribution and compliance disclosure shown.
+
+### Unsubscribe
+
+```bash
+POST https://api.attentivemobile.com/v1/subscriptions/unsubscribe
+
+{
+  "user": { "phone": "+15551234567" },
+  "subscriptionType": "MARKETING"
+}
+```
+
+### Custom event tracking
+
+```bash
+POST https://api.attentivemobile.com/v1/events/custom
+
+{
+  "user": { "phone": "+15551234567" },
+  "type": "abandoned_cart",
+  "properties": {
+    "cart_value": 89.99,
+    "items": ["Product A"]
+  }
+}
+```
+
+### E-commerce events (purchase, add-to-cart, product view)
+
+```bash
+POST https://api.attentivemobile.com/v1/events/ecommerce/purchase
+
+{
+  "user": { "phone": "+15551234567" },
+  "items": [{
+    "productId": "SKU-123",
+    "name": "Product A",
+    "price": { "value": 4999, "currency": "USD" },
+    "quantity": 1
+  }],
+  "occurredAt": "2026-05-15T10:00:00Z"
+}
+```
+
+Similar endpoints for `/add_to_cart`, `/product_view`, `/checkout`.
+
+### Send transactional message
+
+```bash
+POST https://api.attentivemobile.com/v1/messages/transactional
+
+{
+  "user": { "phone": "+15551234567" },
+  "messageBody": "Your order #1234 shipped. Track: https://...",
+  "type": "ORDER_SHIPPING"
+}
+```
+
+### List campaigns
+
+```bash
+GET https://api.attentivemobile.com/v1/campaigns
+```
+
+### Webhooks
+
+Subscribe to: `subscriber.created`, `subscriber.unsubscribed`, `message.sent`, `message.delivered`, `message.failed`, `conversion.attributed`.
+
+## API Pattern
+
+REST + JSON. Bearer auth. Webhook signature verification via HMAC-SHA256.
+
+## Key Features
+
+- Concierge sales (live agents responding via SMS)
+- Identity resolution (matching anonymous site visitors to phone numbers for retargeting)
+- Strong analytics + attribution (multi-touch, conversion path)
+- AI Journey AI / Pro AI (AI-generated send timing and copy)
+- Custom Audience Manager (advanced segmentation)
+- A/B testing built into campaign builder
+- Two-way SMS at scale
+- A2P 10DLC fully managed
+- Short code provisioning included on most plans
+- Dedicated CSM, copy support, strategy consults
+
+## Pricing
+
+- Custom contracts; typically $1K–$10K+/mo platform fee + per-send fees
+- Annual contracts standard
+- Pricing rarely makes sense for <50K active SMS subscribers
+- Negotiable based on volume and tier
+
+## When to Use
+
+- Mid-market+ DTC brand (50K+ active SMS subscribers, $5M+/yr revenue)
+- Want dedicated CSM and copy support, not just tooling
+- Need concierge two-way SMS at scale
+- Multi-channel ecom team that wants single-pane SMS-first platform
+- Want short code included rather than separately leased
+- Identity resolution / cross-device matching matters
+
+## When NOT to Use
+
+- Smaller brands — too expensive, overkill
+- Already on Klaviyo and SMS is secondary — Klaviyo SMS is simpler
+- Shopify-only and want depth — Postscript is more Shopify-native
+- Custom platform / B2B SaaS — Twilio
+
+## Relevant Skills
+
+- sms
+- emails (run alongside)
+- churn-prevention
+- customer-research (identity resolution data)

--- a/tools/integrations/audiencetap.md
+++ b/tools/integrations/audiencetap.md
@@ -1,0 +1,125 @@
+# AudienceTap
+
+SMS and email marketing platform built for direct-to-consumer brands. Newer entrant positioning as a more flexible, AI-forward alternative to Klaviyo / Postscript / Attentive with emphasis on creative automation and on-pack QR opt-in.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API (confirm with vendor; access tied to plan tier) |
+| MCP | - | Not available |
+| CLI | - | None |
+| SDK | - | Use API directly |
+
+> Verify current API surface and capabilities at https://audiencetap.com before building against this guide — newer platform, surface evolves quickly.
+
+## Authentication
+
+- **Type**: API Key (Bearer)
+- **Header**: `Authorization: Bearer {api_key}`
+- **Get key**: AudienceTap dashboard → Settings → API
+- **Note**: API access generally requires Growth or Pro tier
+
+## Common Agent Operations
+
+### Subscribe a user
+
+```bash
+POST https://api.audiencetap.com/v1/subscribers
+
+{
+  "phone_number": "+15551234567",
+  "email": "user@example.com",
+  "first_name": "Jane",
+  "opt_in_source": "checkout",
+  "list_id": "..."
+}
+```
+
+### Unsubscribe
+
+```bash
+POST https://api.audiencetap.com/v1/subscribers/unsubscribe
+
+{
+  "phone_number": "+15551234567",
+  "channel": "sms"
+}
+```
+
+### Track event
+
+```bash
+POST https://api.audiencetap.com/v1/events
+
+{
+  "subscriber": { "phone_number": "+15551234567" },
+  "event_name": "abandoned_cart",
+  "properties": {
+    "cart_value": 89.99,
+    "items": ["Product A"]
+  }
+}
+```
+
+### Send transactional message
+
+```bash
+POST https://api.audiencetap.com/v1/messages/transactional
+
+{
+  "phone_number": "+15551234567",
+  "body": "Your order #1234 shipped. Track: https://...",
+  "category": "shipping"
+}
+```
+
+### List flows / automations
+
+```bash
+GET https://api.audiencetap.com/v1/flows
+```
+
+### Webhooks
+
+Subscribe to: subscriber events, message delivery events, conversion attribution. Configured in dashboard.
+
+## API Pattern
+
+REST + JSON. Bearer auth. Pagination conventions vary by endpoint — confirm in current docs.
+
+## Key Features
+
+- SMS + email on one platform (positioned similarly to Klaviyo's combined product)
+- AI creative generation (subject lines, SMS copy, image variants)
+- On-pack QR code opt-in (insert-card based opt-in for ecom shipments)
+- Shopify, BigCommerce, and headless commerce integrations
+- A2P 10DLC handled in-platform
+- Automation builder for cart, post-purchase, win-back, etc.
+- Identity resolution (matching anonymous visitors to known subscribers)
+
+## Pricing
+
+- Plans typically tiered by subscriber count + send volume
+- Per-send pricing comparable to other DTC SMS platforms (~$0.015 SMS, ~$0.04 MMS)
+- Confirm current pricing at https://audiencetap.com — newer platform with evolving plans
+
+## When to Use
+
+- Mid-market DTC brand willing to try a newer platform for better AI tooling or pricing leverage
+- Brand wanting on-pack QR opt-in as a primary acquisition channel (printed insert cards driving SMS opt-in)
+- Want SMS + email under one roof with stronger AI features than incumbents currently offer
+- Evaluating alternatives during a contract negotiation with Klaviyo / Postscript / Attentive
+
+## When NOT to Use
+
+- Need a fully battle-tested platform with deep ecosystem — incumbents have more integrations and case studies
+- Compliance tooling at enterprise scale — verify A2P / TCPA depth before committing for large lists
+- B2B SaaS, transactional, or developer-first use — Twilio or Plivo
+
+## Relevant Skills
+
+- sms
+- emails
+- referrals (on-pack QR opt-in is a referral-adjacent acquisition channel)
+- directory-submissions (on-pack insert cards as an offline channel)

--- a/tools/integrations/plivo.md
+++ b/tools/integrations/plivo.md
@@ -1,0 +1,140 @@
+# Plivo
+
+Cloud communications API platform — SMS, MMS, voice, WhatsApp. Direct Twilio competitor with similar pricing and developer-first positioning.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API |
+| MCP | - | Not available |
+| CLI | - | None official |
+| SDK | ✓ | Node, Python, Ruby, PHP, Java, Go, .NET |
+
+## Authentication
+
+- **Type**: Basic auth with Auth ID + Auth Token
+- **Header**: `Authorization: Basic base64(AuthID:AuthToken)`
+- **Get credentials**: https://console.plivo.com → Account → Account Settings
+- **Note**: Subaccounts available for isolating environments or customers
+
+## Common Agent Operations
+
+### Send SMS
+
+```bash
+POST https://api.plivo.com/v1/Account/{AuthID}/Message/
+
+{
+  "src": "+15559876543",
+  "dst": "+15551234567",
+  "text": "Hello from Plivo"
+}
+```
+
+### Send MMS
+
+```bash
+POST https://api.plivo.com/v1/Account/{AuthID}/Message/
+
+{
+  "src": "+15559876543",
+  "dst": "+15551234567",
+  "text": "Check this out",
+  "type": "mms",
+  "media_urls": ["https://example.com/image.jpg"]
+}
+```
+
+### Bulk send (powerpack)
+
+Use Plivo's Powerpack feature to send from a pool of numbers with sticky sender + automatic A2P registration. Configured in console; messages then sent with `powerpack_uuid` instead of `src`.
+
+```bash
+POST https://api.plivo.com/v1/Account/{AuthID}/Message/
+
+{
+  "powerpack_uuid": "...",
+  "dst": "+15551234567",
+  "text": "Hello"
+}
+```
+
+### Get message details
+
+```bash
+GET https://api.plivo.com/v1/Account/{AuthID}/Message/{MessageUUID}/
+```
+
+### List messages
+
+```bash
+GET https://api.plivo.com/v1/Account/{AuthID}/Message/?limit=20&offset=0
+```
+
+### Rent a phone number
+
+```bash
+# Search available
+GET https://api.plivo.com/v1/Account/{AuthID}/PhoneNumber/?country_iso=US&type=local
+
+# Rent
+POST https://api.plivo.com/v1/Account/{AuthID}/PhoneNumber/{NumberID}/
+```
+
+### Configure inbound message webhook on an Application
+
+```bash
+POST https://api.plivo.com/v1/Account/{AuthID}/Application/
+
+{
+  "app_name": "SMS Receiver",
+  "message_url": "https://your-app.com/sms-webhook",
+  "message_method": "POST"
+}
+```
+
+Then assign the application to the phone number.
+
+### A2P 10DLC registration (US)
+
+Configured through console UI under Compliance. Programmatic registration available for high-volume customers via dedicated API endpoints (request access).
+
+## API Pattern
+
+REST + JSON. Pagination via `limit` + `offset`. Webhook callbacks for inbound messages and delivery status (configured per-application).
+
+## Pricing
+
+- US 10DLC SMS: $0.0055/msg (typically lower than Twilio)
+- US toll-free SMS: $0.0055/msg
+- US short code SMS: similar + monthly lease
+- MMS: ~$0.02
+- Carrier surcharges layered on top
+- Phone number rental: ~$0.80/mo local, ~$1/mo toll-free
+
+Plivo typically prices 5–20% under Twilio at the per-send level. Less of an ecosystem advantage but real cost savings at high volume.
+
+## Rate Limits
+
+- Default: 1 msg/sec
+- Powerpacks scale throughput based on number pool size and A2P trust
+- Short codes: 100+ msg/sec
+
+## When to Use
+
+- Custom SMS build, want a Twilio-like API with lower cost
+- High-volume sending where the per-message delta matters
+- Want bulk sending with sticky sender via Powerpack
+- B2B SaaS embedding SMS or transactional/auth at scale
+
+## When NOT to Use
+
+- DTC ecom marketing flows — Klaviyo, Postscript, Attentive
+- Ecosystem matters more than price — Twilio's broader product surface (Voice, Studio, SendGrid, Segment, etc.) wins
+- Need mature WhatsApp Business — Twilio has deeper WhatsApp tooling
+
+## Relevant Skills
+
+- sms
+- onboarding (post-signup notifications)

--- a/tools/integrations/postscript.md
+++ b/tools/integrations/postscript.md
@@ -1,0 +1,126 @@
+# Postscript
+
+SMS marketing platform built for Shopify direct-to-consumer brands. Deepest Shopify integration of any SMS platform.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API |
+| MCP | - | Not available |
+| CLI | - | None |
+| SDK | - | Use API directly |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer {api_key}` or `X-Postscript-Api-Key: {api_key}`
+- **Get key**: Postscript dashboard → Settings → API
+- **Note**: Keys are scoped per shop
+
+## Common Agent Operations
+
+### Search subscribers
+
+```bash
+GET https://api.postscript.io/api/v2/subscribers?phone_number=%2B15551234567
+```
+
+### Create subscriber (opt-in)
+
+```bash
+POST https://api.postscript.io/api/v2/subscribers
+
+{
+  "phone_number": "+15551234567",
+  "email": "user@example.com",
+  "first_name": "Jane",
+  "subscribed_at": "2026-05-15T10:00:00Z",
+  "opt_in_source": "checkout_keyword"
+}
+```
+
+Must include valid opt-in metadata for TCPA compliance.
+
+### Unsubscribe
+
+```bash
+DELETE https://api.postscript.io/api/v2/subscribers/{subscriberId}/subscription
+```
+
+### List keywords (e.g., JOIN, SAVE)
+
+```bash
+GET https://api.postscript.io/api/v2/keywords
+```
+
+### Send transactional message
+
+```bash
+POST https://api.postscript.io/api/v2/transactional/sms
+
+{
+  "phone_number": "+15551234567",
+  "message": "Your order #1234 shipped. Track at https://..."
+}
+```
+
+Transactional requires separate enablement; counts under transactional consent.
+
+### List campaigns
+
+```bash
+GET https://api.postscript.io/api/v2/campaigns
+```
+
+### List automations (flows)
+
+```bash
+GET https://api.postscript.io/api/v2/automations
+```
+
+### Webhooks
+
+Subscribe to events: `subscriber.created`, `subscriber.unsubscribed`, `message.delivered`, `message.failed`, `conversion.attributed`.
+
+## API Pattern
+
+REST + JSON. Standard `Bearer` auth. Pagination via `cursor` and `limit` (max 100).
+
+## Key Features
+
+- Native Shopify integration: purchases, abandoned carts, browse, product catalog auto-sync
+- Strong abandoned cart and browse abandonment automation builders
+- AI Reply (auto-reply trained on brand voice)
+- Conversational SMS / live agent for two-way
+- Opt-in tools: popups, keyword opt-in, checkout opt-in
+- A2P 10DLC managed in-platform
+- Reporting: revenue, click-through, conversion attribution, opt-out rate
+
+## Pricing
+
+- Plans: Starter (free, 1K msgs/mo), Growth ($100+/mo), Professional, Enterprise
+- Per-send pricing on top: ~$0.015 SMS, ~$0.04 MMS
+- Annual contracts standard at Growth+
+- Pricing scales meaningfully past 50K subscribers
+
+## When to Use
+
+- Shopify DTC brand wanting SMS-specific tooling (vs combined email/SMS)
+- Need deep abandoned cart, browse abandonment, post-purchase automation out of the box
+- Want managed A2P 10DLC + compliance tools
+- Mid-size DTC brand (10K–500K SMS subscribers)
+
+## When NOT to Use
+
+- Non-Shopify ecom — integration is shallow
+- Already on Klaviyo for email and SMS is secondary — Klaviyo SMS is simpler
+- Mid-market/enterprise needing concierge support — Attentive
+- Custom platform or B2B SaaS — Twilio
+
+## Relevant Skills
+
+- sms
+- emails (run alongside via Klaviyo or similar)
+- churn-prevention (win-back flows)
+- onboarding (post-purchase activation)

--- a/tools/integrations/twilio.md
+++ b/tools/integrations/twilio.md
@@ -1,0 +1,152 @@
+# Twilio
+
+Programmable communications platform: SMS, MMS, WhatsApp, voice, email (via SendGrid). The default low-level API for custom SMS builds, transactional messaging, and B2B SaaS embedding SMS into products.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API, well-documented, mature |
+| MCP | - | Not available natively (community wrappers exist) |
+| CLI | ✓ | Official `twilio` CLI |
+| SDK | ✓ | Node, Python, Ruby, PHP, Java, Go, C#, .NET |
+
+## Authentication
+
+- **Type**: Basic auth with Account SID + Auth Token (or API Key SID + Secret)
+- **Header**: `Authorization: Basic base64(AccountSID:AuthToken)`
+- **Get credentials**: https://console.twilio.com → Account Info
+- **Recommendation**: Use API Keys (revocable, scoped) for production rather than the master Auth Token
+
+## Common Agent Operations
+
+### Send SMS
+
+```bash
+POST https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Messages.json
+
+To=+15551234567
+From=+15559876543
+Body=Hello from Twilio
+```
+
+### Send MMS
+
+```bash
+POST https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Messages.json
+
+To=+15551234567
+From=+15559876543
+Body=Check this out
+MediaUrl=https://example.com/image.jpg
+```
+
+### List messages
+
+```bash
+GET https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Messages.json?PageSize=50
+```
+
+### Get message status
+
+```bash
+GET https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Messages/{MessageSid}.json
+```
+
+Status values: `queued`, `sending`, `sent`, `delivered`, `undelivered`, `failed`.
+
+### List phone numbers
+
+```bash
+GET https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers.json
+```
+
+### Buy a phone number
+
+```bash
+POST https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers.json
+
+PhoneNumber=+15559876543
+```
+
+### Configure webhook for inbound messages
+
+```bash
+POST https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/IncomingPhoneNumbers/{Sid}.json
+
+SmsUrl=https://your-app.com/sms-webhook
+SmsMethod=POST
+```
+
+Inbound SMS POSTs to the webhook with: `From`, `To`, `Body`, `MessageSid`, `NumMedia`, etc.
+
+### A2P 10DLC registration (US)
+
+```bash
+# Create brand
+POST https://messaging.twilio.com/v1/a2p/BrandRegistrations
+
+CustomerProfileBundleSid=...
+A2PProfileBundleSid=...
+
+# Create campaign
+POST https://messaging.twilio.com/v1/Services/{ServiceSid}/Compliance/Usa2p
+
+BrandRegistrationSid=...
+Description=...
+MessageSamples[]=Sample text 1
+MessageFlow=Opt-in flow description
+UseCase=MARKETING
+```
+
+Most workflows are clearer in the Console UI. Programmatic registration is for high-scale platforms managing many brands.
+
+## API Pattern
+
+REST + form-encoded request bodies (not JSON for most endpoints). Resources nested under Account: `/Accounts/{AccountSid}/...`. Pagination via `Page`, `PageSize`, `NextPageUri`.
+
+## Key Concepts
+
+- **Messaging Service**: virtual sender container; load-balances across multiple numbers, handles A2P registration grouping
+- **Sticky Sender**: same recipient always receives from the same number within a service
+- **Geo-Match**: route to a number matching the recipient's country/region
+- **Status Callback**: webhook fired on every delivery state change
+- **Carrier Lookup**: pre-send check for line type (mobile, landline, VoIP) — costs ~$0.005
+
+## Pricing
+
+- US 10DLC SMS: $0.0079/msg
+- US toll-free SMS: $0.0079/msg
+- US short code SMS: $0.0079/msg + $1,000/mo lease
+- MMS: ~$0.02
+- Carrier surcharges (~$0.005 US 10DLC)
+- A2P 10DLC: ~$15 brand + $10/mo per campaign
+- Phone number rental: $1.15/mo (10DLC) to $2/mo (toll-free)
+
+## Rate Limits
+
+- Default: 1 msg/sec on long codes (10DLC trust score raises this to 4–100+)
+- Short code: 100+ msg/sec
+- Messaging Services throttle automatically
+- Carrier filtering applies above contracted throughput
+
+## When to Use
+
+- Building custom SMS flows into a product (B2B SaaS, mobile apps)
+- Transactional and auth SMS (OTPs, alerts, notifications)
+- Multi-channel orchestration (SMS + voice + WhatsApp)
+- High-volume programmable messaging
+- When you need full control and minimal abstraction
+- Backing store for Customer.io / Segment / other orchestration layers
+
+## When NOT to Use
+
+- DTC ecom marketing flows — use Klaviyo, Postscript, or Attentive (better tooling for cart recovery, segments, A/B tests)
+- If you don't want to handle compliance plumbing — Twilio gives you primitives, not policy
+- Marketing UI for non-technical users — there isn't one
+
+## Relevant Skills
+
+- sms
+- emails (transactional sister product via SendGrid)
+- onboarding (post-signup SMS milestones)


### PR DESCRIPTION
## Summary

Adds a new `sms` skill and 5 SMS-platform integration guides.

### Skill: `skills/sms/`

- **SKILL.md** (336 lines): strategy + sequence types + copy guidelines + platform selection + measurement + common mistakes
- **references/compliance.md**: TCPA, A2P 10DLC, EU GDPR, CASL, Australia, opt-in disclosure templates, STOP/HELP response templates, audit checklist
- **references/sequence-templates.md**: full copy templates with character counts for every major SMS flow (welcome, abandoned cart, browse abandonment, post-purchase, win-back, promotional, transactional, re-engagement, replenishment, VIP)
- **references/platforms.md**: platform deep-dives
- **evals/evals.json**: 6 eval cases (getting started, abandoned cart sequence, TCPA compliance, opt-out diagnosis, A2P throughput, emoji segment cost)

### New tool integration docs

- `tools/integrations/twilio.md`
- `tools/integrations/postscript.md`
- `tools/integrations/attentive.md`
- `tools/integrations/plivo.md`
- `tools/integrations/audiencetap.md`

### Wiring

- `tools/REGISTRY.md`: 5 new entries + new SMS / Messaging category section
- `.claude-plugin/marketplace.json`: bumped to 2.1.0, SMS added to plugin description
- `VERSIONS.md`: sms 1.0.0 + 2.1.0 changelog entry
- `README.md`: skill table re-sorted via sync-skills.js, sms added to ASCII flow diagram

## Test plan

- [x] `./validate-skills.sh` passes 41/41 skills
- [x] `sync-skills.js` is a no-op on current state (no marketplace `skills` array regression)
- [x] All 6 SMS evals follow the same shape as existing evals (assertions, files: [])
- [x] SKILL.md under 500-line limit
- [x] No stale references in tools/REGISTRY.md or marketplace.json

## Note

AudienceTap is a newer entrant — the integration doc explicitly flags that API surface and pricing should be verified against the vendor before building against the guide. Other 4 platforms have stable, well-documented APIs.
