### PR TITLE
fix: refresh image + video model lists to current May 2026 releases

### DIFF
--- a/skills/image/SKILL.md
+++ b/skills/image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image
-description: "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video."
+description: "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Flux Kontext,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'ChatGPT Images,' 'Ideogram,' 'Gemini image,' 'Nano Banana,' 'Recraft,' 'Stable Diffusion,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video."
 metadata:
   version: 2.0.0
 ---
@@ -55,36 +55,41 @@ Generate original images from text prompts. The fastest way to create unique mar
 
 | Model | Best For | Text in Images | API | Cost |
 |-------|----------|:-:|-----|------|
-| **Gemini Image** (Google) | All-around, editing, text rendering | Good | [Gemini API](https://ai.google.dev/gemini-api/docs/image-generation) | Check [pricing](https://ai.google.dev/gemini-api/docs/pricing) |
-| **Flux** (Black Forest Labs) | Photorealism, brand consistency, batch | Limited | [BFL API](https://docs.bfl.ai/), Replicate, fal.ai | Check [pricing](https://docs.bfl.ai/quick_start/pricing) |
-| **Ideogram** | Typography, branded graphics | Best | [Ideogram API](https://developer.ideogram.ai/) | Check [pricing](https://about.ideogram.ai/api-pricing) |
-| **GPT Image** (OpenAI) | General purpose, ChatGPT integration | Good | [OpenAI API](https://platform.openai.com/docs/guides/image-generation) | Check [pricing](https://platform.openai.com/docs/pricing) |
-| **Midjourney** | Artistic, high-aesthetic | Poor | No official API | Subscription-based |
-| **Stable Diffusion** | Self-hosted, customizable | Varies | Open source | Free (GPU costs) |
+| **Gemini Image** (Google, "Nano Banana" / Nano Banana Pro) | All-around, editing, multi-image reference, text rendering | Good | [Gemini API](https://ai.google.dev/gemini-api/docs/image-generation) | Check [pricing](https://ai.google.dev/gemini-api/docs/pricing) |
+| **Flux** (Black Forest Labs — Pro 1.1, Kontext, Dev, Schnell) | Photorealism, brand consistency, batch; Kontext for in-image editing | Limited | [BFL API](https://docs.bfl.ai/), Replicate, fal.ai | Check [pricing](https://docs.bfl.ai/quick_start/pricing) |
+| **Ideogram 3.0** | Typography, branded graphics, accurate text rendering | Best | [Ideogram API](https://developer.ideogram.ai/) | Check [pricing](https://about.ideogram.ai/api-pricing) |
+| **ChatGPT Images 2.0 / GPT Image** (OpenAI) | General purpose, ChatGPT integration, native editing | Good | [OpenAI API](https://platform.openai.com/docs/guides/image-generation) | Check [pricing](https://platform.openai.com/docs/pricing) |
+| **Midjourney v7** | Artistic, high-aesthetic, art-directed visuals | Improved | No official API; Discord + Web | Subscription-based |
+| **Recraft V3** | Vector + brand-consistent illustrations, design assets | Strong | [Recraft API](https://www.recraft.ai/docs) | Per-credit |
+| **Stable Diffusion 3.5 / SDXL** | Self-hosted, customizable, fine-tunable | Varies | Open source | Free (GPU costs) |
 
-**Note:** DALL-E 3 is deprecated. OpenAI's current image models are the GPT Image family (`gpt-image-1`, etc.).
+**Note:** DALL-E 3 is fully deprecated. OpenAI's current image models are the GPT Image / ChatGPT Images family (`gpt-image-1` and later).
 
 ### When to Use Which
 
 ```
 Need text/headlines in the image?
-├── Yes → Ideogram (best), Gemini (good), GPT Image (decent)
+├── Yes → Ideogram 3.0 (best), Gemini (good), GPT Image / ChatGPT Images (decent)
 └── No ↓
 
-Need product/brand consistency across images?
-├── Yes → Flux (multi-image reference)
+Need product/brand consistency across many images?
+├── Yes → Flux (multi-image reference), Gemini Nano Banana Pro, Recraft V3
 └── No ↓
 
-Need to edit an existing image?
-├── Yes → Gemini (native editing), Flux Flex
+Need to edit an existing image (in-place)?
+├── Yes → Gemini (native editing), Flux Kontext, ChatGPT Images
 └── No ↓
 
-Need highest visual quality?
-├── Yes → Flux Pro, Midjourney
+Need vector / illustrative brand assets?
+├── Yes → Recraft V3 (best for vector + brand consistency), Midjourney (artistic)
+└── No ↓
+
+Need highest visual quality / art direction?
+├── Yes → Flux Pro 1.1, Midjourney v7
 └── No ↓
 
 Need volume at low cost?
-└── Flux Klein, Gemini Flash
+└── Flux Schnell, Gemini Flash, Stable Diffusion (self-hosted)
 ```
 
 ### Prompting Basics

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video
-description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
+description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
 metadata:
   version: 2.0.0
 ---
@@ -41,7 +41,7 @@ Pick the right tool for the job:
 | Approach | Best For | Tools | When to Use |
 |----------|----------|-------|-------------|
 | **Programmatic** | Templated, data-driven, batch video | Remotion, Hyperframes | Product updates, personalized videos, recurring content |
-| **AI Generation** | Original footage from text/image prompts | Veo, Runway, Kling, Pika | B-roll, hero shots, creative visuals you can't film |
+| **AI Generation** | Original footage from text/image prompts | Veo 3, Sora 2, Runway, Kling, Seedance | B-roll, hero shots, creative visuals you can't film |
 | **AI Avatars** | Talking-head presenter without filming | HeyGen, Synthesia | Explainers, tutorials, multilingual content |
 | **Editing/Repurposing** | Cutting long-form into short clips | Descript, Opus Clip, CapCut | Podcast/webinar → social clips |
 
@@ -130,12 +130,22 @@ Generate original footage from text or image prompts. Use for B-roll, hero visua
 
 | Model | Resolution | Max Duration | Best For | Cost |
 |-------|-----------|-------------|----------|------|
-| **Veo 3** (Google) | Up to 1080p (4K varies) | Variable | Highest quality, synced audio | API-based |
-| **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency | $12-76/mo |
-| **Kling 3.0** | Up to 1080p | Up to 2 min | Volume production, lowest cost | $0.029/sec |
-| **Pika** | 1080p | Short clips | Fast generation, effects | Per-credit |
+| **Veo 3** (Google) | Up to 1080p (4K varies) | Variable | Top overall quality, synced audio | API-based |
+| **Sora 2** (OpenAI) | Up to 1080p | Up to ~20 sec | Cinematic + synced audio, ChatGPT/API integration | API + ChatGPT |
+| **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency, edit-style workflows | $12-76/mo |
+| **Kling 2.5/3.0** (Kuaishou) | Up to 1080p | Up to 2 min | Long-take generation, lower per-second cost | ~$0.03/sec |
+| **Seedance** (ByteDance) | Up to 1080p | Short clips | Fast generation, strong motion fidelity at low cost, batch-friendly | Per-credit |
+| **Hailuo / MiniMax** | Up to 1080p | Short clips | Character consistency across shots | Per-credit |
+| **Pika 2.x** | 1080p | Short clips | Quick effects, image-to-video, lower bar to entry | Per-credit |
+| **Hunyuan Video / Wan 2** | 720p–1080p | Variable | Open-source self-hosted; full control, no API fees | Free (GPU) |
 
-**Sora (OpenAI)** has had limited availability and reliability issues. Check current status before recommending.
+**Quick picks**:
+- **Highest quality + audio**: Veo 3 or Sora 2
+- **Batch / volume / cost**: Kling, Seedance
+- **Character consistency across multiple shots**: Hailuo
+- **Self-hosted, brand-controlled**: Hunyuan Video or Wan 2 (open weights)
+- **Storyboard → video workflow**: Runway, LTX Studio
+- **Image-to-video from a still you already have**: Kling, Pika, Runway
 
 ### Prompting for Video Models
 


### PR DESCRIPTION
## Summary

Refresh the `image` and `video` skills to surface the actual latest model lineup as of May 2026.

### Video updates
- **Sora 2** promoted from a "limited availability" caveat to a first-class model
- **Kling** updated to 2.5/3.0 (Kuaishou)
- **Seedance** (ByteDance) added — fast generation, strong motion fidelity, low cost
- **Hailuo / MiniMax** added — character consistency across shots
- **Pika** bumped to 2.x
- **Hunyuan Video / Wan 2** added for open-weight self-hosted use cases
- New "Quick picks" guide grouped by use case (cinematic + audio / batch / character consistency / self-hosted / storyboard / image-to-video)
- Trigger phrases in the description expanded to match

### Image updates
- **Gemini Image** entry now names Nano Banana / Nano Banana Pro family
- **Flux** entry annotates Pro 1.1, Kontext (in-image editing), Dev, Schnell
- **Ideogram** bumped to 3.0
- **GPT Image** entry renamed to **ChatGPT Images 2.0 / GPT Image** (the newer OpenAI family)
- **Midjourney** bumped to v7
- **Recraft V3** added for vector + brand illustration
- Stable Diffusion 3.5 / SDXL specifics noted
- "When to Use Which" decision tree updated to match
- Trigger phrases expanded: Flux Kontext, ChatGPT Images, Nano Banana, Recraft

## Test plan

- [x] `./validate-skills.sh` — 40/40 passing
- [x] Description lengths still under 1024 chars
- [x] Trigger phrases follow the existing comma-separated quoted-string convention
- [x] No removed models that other skill references still mention
