### PR TITLE
fix(ai-seo): align with Google's official AI features optimization guide

### DIFF
--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -66,6 +66,45 @@ In traditional search, you need to rank on page 1. In AI search, a well-structur
 - Optimized content gets cited 3x more often than non-optimized
 - Statistics and citations boost visibility by 40%+ across queries
 
+### Google's Official Stance vs. Multi-Platform Reality
+
+This is important to read once before doing anything else.
+
+**Google's position** ([AI features optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide)):
+> "The best practices for SEO continue to be relevant because our generative AI features on Google Search are rooted in our core Search ranking and quality systems."
+
+Google explicitly says:
+- **No special markup or files are required** for AI Overviews or AI Mode
+- **Don't chunk content for AI** — write for people, organize with normal headings and paragraphs
+- **Don't write separate content for AI** — that risks "scaled content abuse" spam policy
+- **Helpful, reliable, people-first content** wins — same E-E-A-T standards as regular Search
+- **No AI-specific Search Console reporting** — use standard SEO metrics
+
+**Other AI engines (ChatGPT, Claude, Perplexity, Copilot) behave differently:**
+- They actively reward extractable structure — passages, FAQs, comparison tables, definition blocks
+- They parse `llms.txt`, structured pricing pages, and machine-readable files when present
+- They cite third-party sources (Reddit, Wikipedia, review sites) more heavily than top-ranked pages
+
+**What this means for the work:**
+- The structural patterns in this skill (40–60 word answer blocks, FAQ schema, comparison tables) help **non-Google AI engines** materially. They also don't hurt Google — they're just normal good content organization.
+- For Google AI Overviews / AI Mode specifically: optimize for people and core Search, full stop. Strong E-E-A-T, original information, semantic HTML, clean indexability.
+- For ChatGPT/Claude/Perplexity: layer on the extractable structure + llms.txt + machine-readable files.
+
+When in doubt, default to "write for people, organize for clarity" — that satisfies both camps.
+
+### Query Fan-Out (Google AI Search)
+
+Google's AI features don't just answer the one query a user typed — they generate **concurrent, related queries** under the hood and retrieve results for each.
+
+Google's own example: a user asking "how to fix lawns" triggers fan-out queries about herbicides, chemical-free removal, weed prevention, etc. The AI synthesizes across all of them.
+
+**Implications:**
+- Single-page-per-keyword targeting is less effective. Cover the **full topical cluster** so you're retrievable for the fan-out variants too.
+- Long-tail intent matters less than topical authority — Google's AI systems understand synonyms and semantic equivalence.
+- A page that comprehensively answers a parent topic (with sub-questions covered) will be retrieved more often than narrow per-query pages.
+
+**Action**: when planning content, brainstorm the 5–10 related queries the AI is likely to fan out to and make sure your content (or your site as a whole) covers them.
+
 ---
 
 ## AI Visibility Audit
@@ -228,6 +267,10 @@ AI systems don't just cite your website — they cite where you appear.
 
 ### Machine-Readable Files for AI Agents
 
+> **Google's stance**: not required for AI Overviews or AI Mode. Their guide explicitly says you don't need new markup, AI files, or markdown to appear in generative AI search.
+>
+> **Why include them anyway**: non-Google AI engines (ChatGPT, Claude, Perplexity) and autonomous buying agents do reward extractable structure. The files below help with those engines without harming Google.
+
 AI agents aren't just answering questions — they're becoming buyers. When an AI agent evaluates tools on behalf of a user, it needs structured, parseable information. If your pricing is locked in a JavaScript-rendered page or a "contact sales" wall, agents will skip you and recommend competitors whose information they can actually read.
 
 Add these machine-readable files to your site root:
@@ -284,7 +327,32 @@ Structured data helps AI systems understand your content. Key schemas:
 | Reviews | `Review`, `AggregateRating` | Trust signals |
 | Organization | `Organization` | Entity recognition |
 
-Content with proper schema shows 30-40% higher AI visibility. For implementation, use the **schema** skill.
+Content with proper schema shows 30-40% higher AI visibility on non-Google AI engines. **Google's note**: structured data is "not required for generative AI search" but is recommended for overall SEO strategy. For implementation, use the **schema** skill.
+
+---
+
+## Agentic Experiences
+
+Beyond AI search engines summarizing content, autonomous agents are starting to access sites directly — clicking, reading, comparing, even buying on behalf of users. Google's guide flags this as an emerging category to plan for.
+
+**How agents access your site:**
+- **Visual rendering** — they screenshot/read the page like a user would
+- **DOM inspection** — they parse the page's HTML structure
+- **Accessibility tree** — they rely on the same semantic information assistive tech uses (labels, roles, landmarks, headings)
+
+**What to do:**
+- **Render meaningful content without heavy JS gymnastics** — if the page is blank until 4 frameworks finish loading, agents see blank
+- **Semantic HTML** — use `<main>`, `<nav>`, `<article>`, `<button>`, proper heading hierarchy, `alt` text on images
+- **Clean accessibility tree** — every interactive element labelled; ARIA used correctly (or not at all when native HTML suffices)
+- **Stable selectors / predictable layouts** — agents struggle with sites that re-render every interaction
+- **Visible pricing, specs, contact info** — anything an agent would need to make a buying recommendation should be on a public, indexable page (this is where `/pricing.md` and similar files help)
+
+**Emerging — Universal Commerce Protocol (UCP):**
+Google references UCP as a forthcoming protocol that will give agents standardized hooks for commerce interactions (catalog discovery, pricing, checkout). Watch for adoption; for now, the structural recommendations above are the precursor.
+
+For ecom and local business specifically, Google highlights:
+- **Merchant Center feeds** + **Google Business Profile** for product/service visibility in AI Search
+- **Business Agent** for conversational customer engagement (where applicable)
 
 ---
 
@@ -340,55 +408,29 @@ Monthly manual check:
 3. Record: Are you cited? Who is? What page?
 4. Log in a spreadsheet, track month-over-month
 
+### Search Console expectations
+
+Google's guide is explicit: **there is no AI-specific Search Console reporting**. AI Overviews and AI Mode use core Search ranking, so the standard Search Console reports (Performance, Coverage, Core Web Vitals) are still what you measure with for Google. The third-party tools above are the only way to see cross-platform AI citation behavior.
+
 ---
 
-## AI SEO for Different Content Types
+## What NOT to Do
 
-### SaaS Product Pages
+Google's guide calls these out explicitly — they hurt across both traditional Search and AI features.
 
-**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+1. **Write separate content "for AI"**. Same content should serve people and AI. Writing variants targeted at AI systems risks the **scaled content abuse spam policy** — Google's words.
+2. **Chunk pages into AI-bait fragments**. Google's guide is direct: *"Don't break your content into tiny pieces for AI to better understand it."* Use normal paragraph + heading structure.
+3. **Generate at scale for ranking manipulation**. AI-generated content is fine *if* it meets Search Essentials and spam policies. Mass-producing thin variations does not.
+4. **Pursue inauthentic mentions**. Don't fabricate citations or bulk-spam Reddit/Wikipedia for AI visibility. Real participation only.
+5. **Block AI crawlers if you want citation**. Blocking GPTBot, PerplexityBot, ClaudeBot, Google-Extended means those engines literally cannot cite you. Block training-only crawlers (CCBot) if you must, not the search-and-cite ones.
+6. **Hide your main content behind JS that doesn't render**. Both core Search and AI agents need to see your content; JS-only rendering loses both audiences.
+7. **Skip E-E-A-T fundamentals**. Author identity, first-hand experience, expertise signals, transparent sourcing — Google's guide leans heavily on these for AI features.
 
-**Optimize:**
-- Clear product description in first paragraph (what it does, who it's for)
-- Feature comparison tables (you vs. category, not just competitors)
-- Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
-- Customer count or social proof with numbers
-- Pricing transparency (AI cites pages with visible pricing) — add a `/pricing.md` file so AI agents can parse your plans without rendering your page (see "Machine-Readable Files" above)
-- FAQ section addressing common buyer questions
+---
 
-### Blog Content
+## AI SEO by Content Type
 
-**Goal:** Get cited as an authoritative source on topics in your space.
-
-**Optimize:**
-- One clear target query per post (match heading to query)
-- Definition in first paragraph for "What is" queries
-- Original data, research, or expert quotes
-- "Last updated" date visible
-- Author bio with relevant credentials
-- Internal links to related product/feature pages
-
-### Comparison/Alternative Pages
-
-**Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
-
-**Optimize:**
-- Structured comparison tables (not just prose)
-- Fair and balanced (AI penalizes obviously biased comparisons)
-- Specific criteria with ratings or scores
-- Updated pricing and feature data
-- Cite the competitors skill for building these pages
-
-### Documentation / Help Content
-
-**Goal:** Get cited in "How to [X] with [your product]" queries.
-
-**Optimize:**
-- Step-by-step format with numbered lists
-- Code examples where relevant
-- HowTo schema markup
-- Screenshots with descriptive alt text
-- Clear prerequisites and expected outcomes
+For tactical guidance on SaaS product pages, blog content, comparison/alternative pages, documentation, and local/ecom (Google's emphasis on Merchant Center + Business Profile), see [references/content-types.md](references/content-types.md).
 
 ---
 

--- a/skills/ai-seo/references/content-types.md
+++ b/skills/ai-seo/references/content-types.md
@@ -1,0 +1,71 @@
+# AI SEO by Content Type
+
+Tactical guidance for optimizing specific content types for AI search citation. These tactics work for non-Google AI engines (ChatGPT, Claude, Perplexity, Copilot) and don't hurt Google AI Overviews / AI Mode.
+
+For the cross-cutting strategy, see [SKILL.md](../SKILL.md).
+
+---
+
+## SaaS Product Pages
+
+**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+
+**Optimize:**
+- Clear product description in first paragraph (what it does, who it's for)
+- Feature comparison tables (you vs. category, not just competitors)
+- Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
+- Customer count or social proof with numbers
+- Pricing transparency (AI cites pages with visible pricing) — add a `/pricing.md` file so AI agents can parse your plans without rendering your page (see "Machine-Readable Files" in the main skill)
+- FAQ section addressing common buyer questions
+
+---
+
+## Blog Content
+
+**Goal:** Get cited as an authoritative source on topics in your space.
+
+**Optimize:**
+- One clear target query per post (match heading to query)
+- Definition in first paragraph for "What is" queries
+- Original data, research, or expert quotes
+- "Last updated" date visible
+- Author bio with relevant credentials
+- Internal links to related product/feature pages
+
+---
+
+## Comparison / Alternative Pages
+
+**Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
+
+**Optimize:**
+- Structured comparison tables (not just prose)
+- Fair and balanced (AI penalizes obviously biased comparisons)
+- Specific criteria with ratings or scores
+- Updated pricing and feature data
+- Cite the `competitors` skill for building these pages
+
+---
+
+## Documentation / Help Content
+
+**Goal:** Get cited in "How to [X] with [your product]" queries.
+
+**Optimize:**
+- Step-by-step format with numbered lists
+- Code examples where relevant
+- HowTo schema markup
+- Screenshots with descriptive alt text
+- Clear prerequisites and expected outcomes
+
+---
+
+## Local Business / Ecom (Google emphasis)
+
+Google's AI features pull from product feeds and business profiles for local + ecom queries. Optimize:
+
+- **Merchant Center feeds** kept current with accurate inventory, pricing, attributes
+- **Google Business Profile** complete with hours, services, photos, posts, Q&A answered
+- **Reviews** — recent + sufficient volume; respond to reviews to signal active management
+- **Service area schema** for local services
+- **Business Agent** (where available) for conversational customer engagement


### PR DESCRIPTION
## Summary

Align the `ai-seo` skill with Google's official [AI features optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide).

The skill was framed as "optimize for AI systems," which mis-states Google's explicit position: **AI Overviews and AI Mode are powered by core Search ranking, so SEO best practices ARE the optimization strategy.** The structural patterns the skill recommends still help non-Google AI engines materially — the skill now calls out the platform split explicitly rather than implying universal benefit.

## What changed

### Added

- **Google's Official Stance vs. Multi-Platform Reality** — quotes Google directly, then explains why FAQ schema / comparison tables / llms.txt / `/pricing.md` still earn citations from ChatGPT, Claude, Perplexity, and Copilot
- **Query Fan-Out** — Google's documented behavior of generating concurrent related queries; reframes strategy from per-query targeting to topical cluster coverage
- **Agentic Experiences** — browser agents accessing sites via visual rendering, DOM, accessibility tree; semantic HTML, JS-free meaningful render, clean a11y tree; emerging Universal Commerce Protocol (UCP) mention
- **What NOT to Do** — explicit Google guidance: don't write for AI, don't chunk for AI, don't scale variations (scaled content abuse spam policy), don't pursue inauthentic mentions, don't block AI crawlers if you want citation
- **Search Console expectations** — there is no AI-specific Search Console reporting; standard SEO metrics + third-party tools are the only measurement path
- **Local/Ecom subsection** (in new references file) — Merchant Center + Google Business Profile + Business Agent per Google's emphasis

### Reframed (not removed)

- **Machine-readable files section** (llms.txt, `/pricing.md`) — now opens with Google's "not required" stance, then explains why we still recommend them for non-Google AI
- **Schema markup section** — notes Google's position that schema is "not required for generative AI search" while still recommending it for overall SEO

### Moved to references

- "AI SEO for Different Content Types" moved to `references/content-types.md` to keep SKILL.md under 500 lines (now 485)

### Kept

- llms.txt + `/pricing.md` recommendations (per earlier direction)
- Princeton GEO research, three-pillar framework, citation patterns
- All existing trigger phrases and platform-specific guidance

## Test plan

- [x] `./validate-skills.sh` — 40/40 passing
- [x] SKILL.md under 500-line limit (485 lines)
- [x] Description length still within frontmatter limits
- [x] References file (`content-types.md`) follows existing references pattern
- [x] Cross-references to other skills (`competitors`, `schema`) still resolve
