### PR TITLE
Release v2.0.1: ai-seo Google guide alignment + image/video model refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ Current versions of all skills. Agents can compare against local versions to che
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
 | ad-creative | 2.0.0 | 2026-05-05 |
-| ai-seo | 2.0.0 | 2026-05-05 |
+| ai-seo | 2.0.1 | 2026-05-18 |
 | analytics | 2.0.0 | 2026-05-05 |
 | aso | 2.0.0 | 2026-05-05 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
@@ -23,7 +23,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
-| image | 2.0.0 | 2026-05-05 |
+| image | 2.0.1 | 2026-05-18 |
 | launch | 2.0.0 | 2026-05-05 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
@@ -43,9 +43,19 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | social | 2.0.0 | 2026-05-05 |
-| video | 2.0.0 | 2026-05-05 |
+| video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.0.1 (2026-05-18)
+
+Content patch — no breaking changes, no new skills.
+
+- **ai-seo** (2.0.0 → 2.0.1): aligned with Google's official AI features optimization guide. Added sections for Google's stance on AI optimization, query fan-out, agentic experiences (including UCP), explicit "what NOT to do" (scaled content abuse, etc.), and Search Console expectations. Reframed llms.txt / pricing.md / schema markup recommendations as "Google says not required, helpful for non-Google AI engines." Moved content-type tactics to `references/content-types.md` (added local/ecom Merchant Center + Business Profile guidance per Google).
+- **image** (2.0.0 → 2.0.1): refreshed model lineup to current May 2026 releases — Nano Banana / Nano Banana Pro family naming, Flux Pro 1.1 + Kontext + Dev + Schnell variants, Ideogram 3.0, ChatGPT Images 2.0 / GPT Image, Midjourney v7, Recraft V3, SD 3.5 / SDXL. Updated decision tree and trigger phrases.
+- **video** (2.0.0 → 2.0.1): refreshed model lineup — Sora 2 promoted from limited-availability caveat, Kling 2.5/3.0, added Seedance (ByteDance), Hailuo / MiniMax (character consistency), Hunyuan Video / Wan 2 (open-weight self-hosted), Pika 2.x. New "Quick picks" guide.
+
+Total skills: 40 (unchanged).
 
 ### 2.0.0 (2026-05-05)
 

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -66,6 +66,45 @@ In traditional search, you need to rank on page 1. In AI search, a well-structur
 - Optimized content gets cited 3x more often than non-optimized
 - Statistics and citations boost visibility by 40%+ across queries
 
+### Google's Official Stance vs. Multi-Platform Reality
+
+This is important to read once before doing anything else.
+
+**Google's position** ([AI features optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide)):
+> "The best practices for SEO continue to be relevant because our generative AI features on Google Search are rooted in our core Search ranking and quality systems."
+
+Google explicitly says:
+- **No special markup or files are required** for AI Overviews or AI Mode
+- **Don't chunk content for AI** — write for people, organize with normal headings and paragraphs
+- **Don't write separate content for AI** — that risks "scaled content abuse" spam policy
+- **Helpful, reliable, people-first content** wins — same E-E-A-T standards as regular Search
+- **No AI-specific Search Console reporting** — use standard SEO metrics
+
+**Other AI engines (ChatGPT, Claude, Perplexity, Copilot) behave differently:**
+- They actively reward extractable structure — passages, FAQs, comparison tables, definition blocks
+- They parse `llms.txt`, structured pricing pages, and machine-readable files when present
+- They cite third-party sources (Reddit, Wikipedia, review sites) more heavily than top-ranked pages
+
+**What this means for the work:**
+- The structural patterns in this skill (40–60 word answer blocks, FAQ schema, comparison tables) help **non-Google AI engines** materially. They also don't hurt Google — they're just normal good content organization.
+- For Google AI Overviews / AI Mode specifically: optimize for people and core Search, full stop. Strong E-E-A-T, original information, semantic HTML, clean indexability.
+- For ChatGPT/Claude/Perplexity: layer on the extractable structure + llms.txt + machine-readable files.
+
+When in doubt, default to "write for people, organize for clarity" — that satisfies both camps.
+
+### Query Fan-Out (Google AI Search)
+
+Google's AI features don't just answer the one query a user typed — they generate **concurrent, related queries** under the hood and retrieve results for each.
+
+Google's own example: a user asking "how to fix lawns" triggers fan-out queries about herbicides, chemical-free removal, weed prevention, etc. The AI synthesizes across all of them.
+
+**Implications:**
+- Single-page-per-keyword targeting is less effective. Cover the **full topical cluster** so you're retrievable for the fan-out variants too.
+- Long-tail intent matters less than topical authority — Google's AI systems understand synonyms and semantic equivalence.
+- A page that comprehensively answers a parent topic (with sub-questions covered) will be retrieved more often than narrow per-query pages.
+
+**Action**: when planning content, brainstorm the 5–10 related queries the AI is likely to fan out to and make sure your content (or your site as a whole) covers them.
+
 ---
 
 ## AI Visibility Audit
@@ -228,6 +267,10 @@ AI systems don't just cite your website — they cite where you appear.
 
 ### Machine-Readable Files for AI Agents
 
+> **Google's stance**: not required for AI Overviews or AI Mode. Their guide explicitly says you don't need new markup, AI files, or markdown to appear in generative AI search.
+>
+> **Why include them anyway**: non-Google AI engines (ChatGPT, Claude, Perplexity) and autonomous buying agents do reward extractable structure. The files below help with those engines without harming Google.
+
 AI agents aren't just answering questions — they're becoming buyers. When an AI agent evaluates tools on behalf of a user, it needs structured, parseable information. If your pricing is locked in a JavaScript-rendered page or a "contact sales" wall, agents will skip you and recommend competitors whose information they can actually read.
 
 Add these machine-readable files to your site root:
@@ -284,7 +327,32 @@ Structured data helps AI systems understand your content. Key schemas:
 | Reviews | `Review`, `AggregateRating` | Trust signals |
 | Organization | `Organization` | Entity recognition |
 
-Content with proper schema shows 30-40% higher AI visibility. For implementation, use the **schema** skill.
+Content with proper schema shows 30-40% higher AI visibility on non-Google AI engines. **Google's note**: structured data is "not required for generative AI search" but is recommended for overall SEO strategy. For implementation, use the **schema** skill.
+
+---
+
+## Agentic Experiences
+
+Beyond AI search engines summarizing content, autonomous agents are starting to access sites directly — clicking, reading, comparing, even buying on behalf of users. Google's guide flags this as an emerging category to plan for.
+
+**How agents access your site:**
+- **Visual rendering** — they screenshot/read the page like a user would
+- **DOM inspection** — they parse the page's HTML structure
+- **Accessibility tree** — they rely on the same semantic information assistive tech uses (labels, roles, landmarks, headings)
+
+**What to do:**
+- **Render meaningful content without heavy JS gymnastics** — if the page is blank until 4 frameworks finish loading, agents see blank
+- **Semantic HTML** — use `<main>`, `<nav>`, `<article>`, `<button>`, proper heading hierarchy, `alt` text on images
+- **Clean accessibility tree** — every interactive element labelled; ARIA used correctly (or not at all when native HTML suffices)
+- **Stable selectors / predictable layouts** — agents struggle with sites that re-render every interaction
+- **Visible pricing, specs, contact info** — anything an agent would need to make a buying recommendation should be on a public, indexable page (this is where `/pricing.md` and similar files help)
+
+**Emerging — Universal Commerce Protocol (UCP):**
+Google references UCP as a forthcoming protocol that will give agents standardized hooks for commerce interactions (catalog discovery, pricing, checkout). Watch for adoption; for now, the structural recommendations above are the precursor.
+
+For ecom and local business specifically, Google highlights:
+- **Merchant Center feeds** + **Google Business Profile** for product/service visibility in AI Search
+- **Business Agent** for conversational customer engagement (where applicable)
 
 ---
 
@@ -340,55 +408,29 @@ Monthly manual check:
 3. Record: Are you cited? Who is? What page?
 4. Log in a spreadsheet, track month-over-month
 
+### Search Console expectations
+
+Google's guide is explicit: **there is no AI-specific Search Console reporting**. AI Overviews and AI Mode use core Search ranking, so the standard Search Console reports (Performance, Coverage, Core Web Vitals) are still what you measure with for Google. The third-party tools above are the only way to see cross-platform AI citation behavior.
+
 ---
 
-## AI SEO for Different Content Types
+## What NOT to Do
 
-### SaaS Product Pages
+Google's guide calls these out explicitly — they hurt across both traditional Search and AI features.
 
-**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+1. **Write separate content "for AI"**. Same content should serve people and AI. Writing variants targeted at AI systems risks the **scaled content abuse spam policy** — Google's words.
+2. **Chunk pages into AI-bait fragments**. Google's guide is direct: *"Don't break your content into tiny pieces for AI to better understand it."* Use normal paragraph + heading structure.
+3. **Generate at scale for ranking manipulation**. AI-generated content is fine *if* it meets Search Essentials and spam policies. Mass-producing thin variations does not.
+4. **Pursue inauthentic mentions**. Don't fabricate citations or bulk-spam Reddit/Wikipedia for AI visibility. Real participation only.
+5. **Block AI crawlers if you want citation**. Blocking GPTBot, PerplexityBot, ClaudeBot, Google-Extended means those engines literally cannot cite you. Block training-only crawlers (CCBot) if you must, not the search-and-cite ones.
+6. **Hide your main content behind JS that doesn't render**. Both core Search and AI agents need to see your content; JS-only rendering loses both audiences.
+7. **Skip E-E-A-T fundamentals**. Author identity, first-hand experience, expertise signals, transparent sourcing — Google's guide leans heavily on these for AI features.
 
-**Optimize:**
-- Clear product description in first paragraph (what it does, who it's for)
-- Feature comparison tables (you vs. category, not just competitors)
-- Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
-- Customer count or social proof with numbers
-- Pricing transparency (AI cites pages with visible pricing) — add a `/pricing.md` file so AI agents can parse your plans without rendering your page (see "Machine-Readable Files" above)
-- FAQ section addressing common buyer questions
+---
 
-### Blog Content
+## AI SEO by Content Type
 
-**Goal:** Get cited as an authoritative source on topics in your space.
-
-**Optimize:**
-- One clear target query per post (match heading to query)
-- Definition in first paragraph for "What is" queries
-- Original data, research, or expert quotes
-- "Last updated" date visible
-- Author bio with relevant credentials
-- Internal links to related product/feature pages
-
-### Comparison/Alternative Pages
-
-**Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
-
-**Optimize:**
-- Structured comparison tables (not just prose)
-- Fair and balanced (AI penalizes obviously biased comparisons)
-- Specific criteria with ratings or scores
-- Updated pricing and feature data
-- Cite the competitors skill for building these pages
-
-### Documentation / Help Content
-
-**Goal:** Get cited in "How to [X] with [your product]" queries.
-
-**Optimize:**
-- Step-by-step format with numbered lists
-- Code examples where relevant
-- HowTo schema markup
-- Screenshots with descriptive alt text
-- Clear prerequisites and expected outcomes
+For tactical guidance on SaaS product pages, blog content, comparison/alternative pages, documentation, and local/ecom (Google's emphasis on Merchant Center + Business Profile), see [references/content-types.md](references/content-types.md).
 
 ---
 

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -2,7 +2,7 @@
 name: ai-seo
 description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # AI SEO

--- a/skills/ai-seo/references/content-types.md
+++ b/skills/ai-seo/references/content-types.md
@@ -1,0 +1,71 @@
+# AI SEO by Content Type
+
+Tactical guidance for optimizing specific content types for AI search citation. These tactics work for non-Google AI engines (ChatGPT, Claude, Perplexity, Copilot) and don't hurt Google AI Overviews / AI Mode.
+
+For the cross-cutting strategy, see [SKILL.md](../SKILL.md).
+
+---
+
+## SaaS Product Pages
+
+**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+
+**Optimize:**
+- Clear product description in first paragraph (what it does, who it's for)
+- Feature comparison tables (you vs. category, not just competitors)
+- Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
+- Customer count or social proof with numbers
+- Pricing transparency (AI cites pages with visible pricing) — add a `/pricing.md` file so AI agents can parse your plans without rendering your page (see "Machine-Readable Files" in the main skill)
+- FAQ section addressing common buyer questions
+
+---
+
+## Blog Content
+
+**Goal:** Get cited as an authoritative source on topics in your space.
+
+**Optimize:**
+- One clear target query per post (match heading to query)
+- Definition in first paragraph for "What is" queries
+- Original data, research, or expert quotes
+- "Last updated" date visible
+- Author bio with relevant credentials
+- Internal links to related product/feature pages
+
+---
+
+## Comparison / Alternative Pages
+
+**Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
+
+**Optimize:**
+- Structured comparison tables (not just prose)
+- Fair and balanced (AI penalizes obviously biased comparisons)
+- Specific criteria with ratings or scores
+- Updated pricing and feature data
+- Cite the `competitors` skill for building these pages
+
+---
+
+## Documentation / Help Content
+
+**Goal:** Get cited in "How to [X] with [your product]" queries.
+
+**Optimize:**
+- Step-by-step format with numbered lists
+- Code examples where relevant
+- HowTo schema markup
+- Screenshots with descriptive alt text
+- Clear prerequisites and expected outcomes
+
+---
+
+## Local Business / Ecom (Google emphasis)
+
+Google's AI features pull from product feeds and business profiles for local + ecom queries. Optimize:
+
+- **Merchant Center feeds** kept current with accurate inventory, pricing, attributes
+- **Google Business Profile** complete with hours, services, photos, posts, Q&A answered
+- **Reviews** — recent + sufficient volume; respond to reviews to signal active management
+- **Service area schema** for local services
+- **Business Agent** (where available) for conversational customer engagement

--- a/skills/image/SKILL.md
+++ b/skills/image/SKILL.md
@@ -2,7 +2,7 @@
 name: image
 description: "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Flux Kontext,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'ChatGPT Images,' 'Ideogram,' 'Gemini image,' 'Nano Banana,' 'Recraft,' 'Stable Diffusion,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Image

--- a/skills/image/SKILL.md
+++ b/skills/image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image
-description: "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'Ideogram,' 'Gemini image,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video."
+description: "When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product mockups, profile banners, listing visuals, or brand assets. Also use when the user mentions 'AI image generation,' 'generate an image,' 'create a graphic,' 'product mockup,' 'hero image,' 'social media graphic,' 'banner image,' 'cover photo,' 'profile banner,' 'listing screenshot,' 'Flux,' 'Flux Kontext,' 'Midjourney,' 'DALL-E,' 'GPT Image,' 'ChatGPT Images,' 'Ideogram,' 'Gemini image,' 'Nano Banana,' 'Recraft,' 'Stable Diffusion,' 'Canva,' 'Figma,' 'image optimization,' 'compress images,' 'WebP,' or 'OG image.' Use this for general-purpose marketing image creation and optimization. For paid ad image creative and platform-specific ad specs, see ad-creative. For video production, see video."
 metadata:
   version: 2.0.0
 ---
@@ -55,36 +55,41 @@ Generate original images from text prompts. The fastest way to create unique mar
 
 | Model | Best For | Text in Images | API | Cost |
 |-------|----------|:-:|-----|------|
-| **Gemini Image** (Google) | All-around, editing, text rendering | Good | [Gemini API](https://ai.google.dev/gemini-api/docs/image-generation) | Check [pricing](https://ai.google.dev/gemini-api/docs/pricing) |
-| **Flux** (Black Forest Labs) | Photorealism, brand consistency, batch | Limited | [BFL API](https://docs.bfl.ai/), Replicate, fal.ai | Check [pricing](https://docs.bfl.ai/quick_start/pricing) |
-| **Ideogram** | Typography, branded graphics | Best | [Ideogram API](https://developer.ideogram.ai/) | Check [pricing](https://about.ideogram.ai/api-pricing) |
-| **GPT Image** (OpenAI) | General purpose, ChatGPT integration | Good | [OpenAI API](https://platform.openai.com/docs/guides/image-generation) | Check [pricing](https://platform.openai.com/docs/pricing) |
-| **Midjourney** | Artistic, high-aesthetic | Poor | No official API | Subscription-based |
-| **Stable Diffusion** | Self-hosted, customizable | Varies | Open source | Free (GPU costs) |
+| **Gemini Image** (Google, "Nano Banana" / Nano Banana Pro) | All-around, editing, multi-image reference, text rendering | Good | [Gemini API](https://ai.google.dev/gemini-api/docs/image-generation) | Check [pricing](https://ai.google.dev/gemini-api/docs/pricing) |
+| **Flux** (Black Forest Labs — Pro 1.1, Kontext, Dev, Schnell) | Photorealism, brand consistency, batch; Kontext for in-image editing | Limited | [BFL API](https://docs.bfl.ai/), Replicate, fal.ai | Check [pricing](https://docs.bfl.ai/quick_start/pricing) |
+| **Ideogram 3.0** | Typography, branded graphics, accurate text rendering | Best | [Ideogram API](https://developer.ideogram.ai/) | Check [pricing](https://about.ideogram.ai/api-pricing) |
+| **ChatGPT Images 2.0 / GPT Image** (OpenAI) | General purpose, ChatGPT integration, native editing | Good | [OpenAI API](https://platform.openai.com/docs/guides/image-generation) | Check [pricing](https://platform.openai.com/docs/pricing) |
+| **Midjourney v7** | Artistic, high-aesthetic, art-directed visuals | Improved | No official API; Discord + Web | Subscription-based |
+| **Recraft V3** | Vector + brand-consistent illustrations, design assets | Strong | [Recraft API](https://www.recraft.ai/docs) | Per-credit |
+| **Stable Diffusion 3.5 / SDXL** | Self-hosted, customizable, fine-tunable | Varies | Open source | Free (GPU costs) |
 
-**Note:** DALL-E 3 is deprecated. OpenAI's current image models are the GPT Image family (`gpt-image-1`, etc.).
+**Note:** DALL-E 3 is fully deprecated. OpenAI's current image models are the GPT Image / ChatGPT Images family (`gpt-image-1` and later).
 
 ### When to Use Which
 
 ```
 Need text/headlines in the image?
-├── Yes → Ideogram (best), Gemini (good), GPT Image (decent)
+├── Yes → Ideogram 3.0 (best), Gemini (good), GPT Image / ChatGPT Images (decent)
 └── No ↓
 
-Need product/brand consistency across images?
-├── Yes → Flux (multi-image reference)
+Need product/brand consistency across many images?
+├── Yes → Flux (multi-image reference), Gemini Nano Banana Pro, Recraft V3
 └── No ↓
 
-Need to edit an existing image?
-├── Yes → Gemini (native editing), Flux Flex
+Need to edit an existing image (in-place)?
+├── Yes → Gemini (native editing), Flux Kontext, ChatGPT Images
 └── No ↓
 
-Need highest visual quality?
-├── Yes → Flux Pro, Midjourney
+Need vector / illustrative brand assets?
+├── Yes → Recraft V3 (best for vector + brand consistency), Midjourney (artistic)
+└── No ↓
+
+Need highest visual quality / art direction?
+├── Yes → Flux Pro 1.1, Midjourney v7
 └── No ↓
 
 Need volume at low cost?
-└── Flux Klein, Gemini Flash
+└── Flux Schnell, Gemini Flash, Stable Diffusion (self-hosted)
 ```
 
 ### Prompting Basics

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -2,7 +2,7 @@
 name: video
 description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Video

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video
-description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Runway,' 'Kling,' 'Pika,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
+description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
 metadata:
   version: 2.0.0
 ---
@@ -41,7 +41,7 @@ Pick the right tool for the job:
 | Approach | Best For | Tools | When to Use |
 |----------|----------|-------|-------------|
 | **Programmatic** | Templated, data-driven, batch video | Remotion, Hyperframes | Product updates, personalized videos, recurring content |
-| **AI Generation** | Original footage from text/image prompts | Veo, Runway, Kling, Pika | B-roll, hero shots, creative visuals you can't film |
+| **AI Generation** | Original footage from text/image prompts | Veo 3, Sora 2, Runway, Kling, Seedance | B-roll, hero shots, creative visuals you can't film |
 | **AI Avatars** | Talking-head presenter without filming | HeyGen, Synthesia | Explainers, tutorials, multilingual content |
 | **Editing/Repurposing** | Cutting long-form into short clips | Descript, Opus Clip, CapCut | Podcast/webinar → social clips |
 
@@ -130,12 +130,22 @@ Generate original footage from text or image prompts. Use for B-roll, hero visua
 
 | Model | Resolution | Max Duration | Best For | Cost |
 |-------|-----------|-------------|----------|------|
-| **Veo 3** (Google) | Up to 1080p (4K varies) | Variable | Highest quality, synced audio | API-based |
-| **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency | $12-76/mo |
-| **Kling 3.0** | Up to 1080p | Up to 2 min | Volume production, lowest cost | $0.029/sec |
-| **Pika** | 1080p | Short clips | Fast generation, effects | Per-credit |
+| **Veo 3** (Google) | Up to 1080p (4K varies) | Variable | Top overall quality, synced audio | API-based |
+| **Sora 2** (OpenAI) | Up to 1080p | Up to ~20 sec | Cinematic + synced audio, ChatGPT/API integration | API + ChatGPT |
+| **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency, edit-style workflows | $12-76/mo |
+| **Kling 2.5/3.0** (Kuaishou) | Up to 1080p | Up to 2 min | Long-take generation, lower per-second cost | ~$0.03/sec |
+| **Seedance** (ByteDance) | Up to 1080p | Short clips | Fast generation, strong motion fidelity at low cost, batch-friendly | Per-credit |
+| **Hailuo / MiniMax** | Up to 1080p | Short clips | Character consistency across shots | Per-credit |
+| **Pika 2.x** | 1080p | Short clips | Quick effects, image-to-video, lower bar to entry | Per-credit |
+| **Hunyuan Video / Wan 2** | 720p–1080p | Variable | Open-source self-hosted; full control, no API fees | Free (GPU) |
 
-**Sora (OpenAI)** has had limited availability and reliability issues. Check current status before recommending.
+**Quick picks**:
+- **Highest quality + audio**: Veo 3 or Sora 2
+- **Batch / volume / cost**: Kling, Seedance
+- **Character consistency across multiple shots**: Hailuo
+- **Self-hosted, brand-controlled**: Hunyuan Video or Wan 2 (open weights)
+- **Storyboard → video workflow**: Runway, LTX Studio
+- **Image-to-video from a still you already have**: Kling, Pika, Runway
 
 ### Prompting for Video Models
 


### PR DESCRIPTION
## Release v2.0.1 → main

Promotes the v2.0.1 patch release to production. Content-only patch — no new skills, no breaking changes.

### What's in v2.0.1

**ai-seo** (2.0.0 → 2.0.1) — aligned with Google's official [AI features optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide):
- Added Google's stance vs. multi-platform reality framing
- Added query fan-out concept
- Added agentic experiences section (browser agents, DOM/a11y tree, UCP)
- Added "What NOT to Do" with explicit Google guidance (scaled content abuse, don't chunk for AI, etc.)
- Added Search Console expectations clarification
- Reframed llms.txt / `/pricing.md` / schema as "Google says not required, but helps non-Google AI engines"
- Moved content-type tactics to `references/content-types.md` (added local/ecom Merchant Center + Business Profile guidance)

**image** (2.0.0 → 2.0.1) — refreshed model lineup to current May 2026 releases:
- Nano Banana / Nano Banana Pro family naming
- Flux Pro 1.1 + Kontext + Dev + Schnell variants
- Ideogram 3.0
- ChatGPT Images 2.0 / GPT Image
- Midjourney v7
- Recraft V3
- SD 3.5 / SDXL
- Updated decision tree and trigger phrases

**video** (2.0.0 → 2.0.1) — refreshed model lineup:
- Sora 2 promoted from limited-availability caveat
- Kling 2.5/3.0
- Added Seedance (ByteDance)
- Added Hailuo / MiniMax (character consistency)
- Added Hunyuan Video / Wan 2 (open-weight self-hosted)
- Pika 2.x
- New "Quick picks" guide

### Also rolled into this release

Vendor PRs that landed directly on main were synced back into development first (PR #315) so this release PR doesn't delete them:
- #275 Cogny (MCP gateway)
- #304 RankParse (SEO tool)
- #266 Exa (AI search)
- #269 ad-creative tool names update (added ChatGPT Images 2.0)

### Version bumps

- `marketplace.json`: 2.0.0 → 2.0.1
- `VERSIONS.md`: ai-seo, image, video rows bumped; 2.0.1 changelog entry added
- `skills/{ai-seo,image,video}/SKILL.md`: `metadata.version` → 2.0.1
- Other 37 skills stay at 2.0.0

### How to merge

Use **"Create a merge commit"** (not squash) so the v2.0.1 ancestry is preserved on main for future releases.

### Upgrade path

No reinstall required. Skills with bumped versions will show as "update available" via VERSIONS.md.

## Test plan

- [x] `./validate-skills.sh` — 40/40 passing
- [x] `sync-skills.js` is a no-op
- [x] Per-skill SKILL.md versions match VERSIONS.md table rows
- [x] No `skills` array regression in marketplace.json
- [x] Vendor PR files (cogny.md, exa.md, rankparse.md, exa.js, rankparse.js) preserved
