### PR TITLE
Release v2.2.0: prospecting skill + ads RSA spec + plugin.json fix + community PRs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "41 marketing skills for technical marketers and founders: CRO, copywriting, cold email, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
+      "description": "42 marketing skills for technical marketers and founders: CRO, copywriting, cold email, prospecting, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, and more",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "1.9.0",
+  "version": "2.1.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/.github/scripts/sync-skills.js
+++ b/.github/scripts/sync-skills.js
@@ -11,6 +11,7 @@ const path = require("path");
 
 const SKILLS_DIR = "skills";
 const MARKETPLACE_FILE = ".claude-plugin/marketplace.json";
+const PLUGIN_FILE = ".claude-plugin/plugin.json";
 const README_FILE = "README.md";
 
 /**
@@ -157,13 +158,36 @@ function updateMarketplace(skills) {
   return { updated: true, removedSkillsArray: hadStaleSkillsArray };
 }
 
+/**
+ * Update plugin.json's `version` field to match marketplace.json's
+ * `metadata.version`. Claude Code uses plugin.json's version for the update
+ * check (`claude plugin update`); if it drifts from marketplace.json the
+ * update path silently breaks.
+ */
+function updatePluginVersion() {
+  if (!fs.existsSync(PLUGIN_FILE)) return { updated: false };
+
+  const marketplace = JSON.parse(fs.readFileSync(MARKETPLACE_FILE, "utf8"));
+  const plugin = JSON.parse(fs.readFileSync(PLUGIN_FILE, "utf8"));
+  const marketplaceVersion = marketplace.metadata && marketplace.metadata.version;
+
+  if (!marketplaceVersion) return { updated: false };
+  if (plugin.version === marketplaceVersion) return { updated: false };
+
+  const oldVersion = plugin.version;
+  plugin.version = marketplaceVersion;
+  fs.writeFileSync(PLUGIN_FILE, JSON.stringify(plugin, null, 2) + "\n");
+  return { updated: true, oldVersion, newVersion: marketplaceVersion };
+}
+
 function main() {
   const skills = getSkillsWithMetadata();
 
   const marketplaceResult = updateMarketplace(skills);
   const readmeUpdated = updateReadme(skills);
+  const pluginResult = updatePluginVersion();
 
-  if (!marketplaceResult.updated && !readmeUpdated) {
+  if (!marketplaceResult.updated && !readmeUpdated && !pluginResult.updated) {
     console.log("Everything is already in sync");
     return;
   }
@@ -173,6 +197,10 @@ function main() {
       console.log("Stripped stale `skills` array from marketplace.json");
     }
     console.log(`Updated marketplace.json (${skills.length} skills)`);
+  }
+
+  if (pluginResult.updated) {
+    console.log(`Bumped plugin.json version: ${pluginResult.oldVersion} → ${pluginResult.newVersion}`);
   }
 
   if (readmeUpdated) {

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+      - '.claude-plugin/marketplace.json'
 
 jobs:
   sync:
@@ -26,5 +27,5 @@ jobs:
         with:
           commit_user_name: Coreybot
           commit_user_email: coreybot+github-actions[bot]@users.noreply.github.com
-          commit_message: "chore: sync skills with marketplace.json and README"
-          file_pattern: ".claude-plugin/marketplace.json README.md"
+          commit_message: "chore: sync skills with marketplace.json, plugin.json, and README"
+          file_pattern: ".claude-plugin/marketplace.json .claude-plugin/plugin.json README.md"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Skills reference each other and build on shared context. The `product-marketing`
 │schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │           │
 │content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
 │aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │           │
-│          │ │          │ │sms       │ │            │ │          │ │             │ │           │
+│          │ │          │ │sms       │ │            │ │          │ │prospecting  │ │           │
 └────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
      │            │            │              │             │              │              │
      └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘
@@ -87,6 +87,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [pricing](skills/pricing/) | When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions... |
 | [product-marketing](skills/product-marketing/) | When the user wants to create or update their product marketing context document. Also use when the user mentions... |
 | [programmatic-seo](skills/programmatic-seo/) | When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions... |
+| [prospecting](skills/prospecting/) | When the user wants to find, qualify, and build a list of prospects to reach out to — across B2B SaaS, general B2B, or... |
 | [referrals](skills/referrals/) | When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy.... |
 | [revops](skills/revops/) | When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes.... |
 | [sales-enablement](skills/sales-enablement/) | When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also... |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -29,12 +29,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-ideas | 2.0.0 | 2026-05-05 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | onboarding | 2.0.0 | 2026-05-05 |
-| ads | 2.0.0 | 2026-05-05 |
+| ads | 2.0.1 | 2026-05-26 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
 | pricing | 2.0.0 | 2026-05-05 |
 | product-marketing | 2.0.0 | 2026-05-05 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
+| prospecting | 1.0.0 | 2026-05-26 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.0 | 2026-05-05 |
@@ -47,6 +48,17 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.2.0 (2026-05-26)
+
+- Added `prospecting` skill for building qualified prospect lists across SaaS, B2B, and local SMB motions. Includes shared 5-phase framework (ICP → discovery → qualify → score → output) plus branch-specific references (saas-prospecting, b2b-prospecting, local-prospecting), data-sources guide covering Apollo / Clay / ZoomInfo / Clearbit / Hunter / Snov / Truelist / RB2B / Sales Nav / BuiltWith / Crunchbase / GitHub, and compliance reference (CAN-SPAM, GDPR, CASL, platform ToS).
+- Added `tools/clis/github-prospects.js` CLI for pulling GitHub stargazers, forkers, and watchers as a developer-intent signal — with pagination, enrichment, filter-based early termination, and CSV output.
+- Added new tool integration docs: `truelist` (email deliverability validation, OpenAPI-aligned), `github` (REST API for prospecting), `firecrawl` (single-target page scraping), `browserbase` (real Chromium for JS-heavy pages or interaction).
+- **ads** (2.0.0 → 2.0.1): added Google RSA Output Spec section enforcing 15 headlines × 30 chars, 4 descriptions × 90 chars, ad group structure labels, ≥8 negative keywords, ≥4 sitelinks/callouts, output ordering to avoid truncation, and a self-check before responding. Includes optional Brazilian medical (CFM) compliance rules when product context indicates that vertical.
+- Added `sequenzy` tool integration (email marketing platform with MCP support).
+- Fixed plugin.json version drift (was stuck at 1.9.0 across three releases) — `sync-skills.js` now auto-syncs `plugin.json` version to `marketplace.json` on every change. Closes #323.
+- Added skill install artifacts (`.agents/`, `.claude/`, `skills-lock.json`) to `.gitignore`.
+- Total skills: 42.
 
 ### 2.1.0 (2026-05-21)
 - Added `sms` skill for SMS/MMS marketing — welcome flows, abandoned cart, post-purchase, win-back, promotional sends, and transactional/auth. Includes compliance reference (TCPA, A2P 10DLC, GDPR, CASL), sequence templates with character counts, and platform comparison (Klaviyo, Postscript, Attentive, Twilio, Brevo, SimpleTexting, Customer.io).

--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -2,7 +2,7 @@
 name: ads
 description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see cro."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Paid Ads

--- a/skills/cold-email/SKILL.md
+++ b/skills/cold-email/SKILL.md
@@ -151,6 +151,7 @@ Use this data to inform your writing — not as a checklist to satisfy.
 
 ## Related Skills
 
+- **prospecting**: For building and qualifying the prospect list that this skill writes outreach against — the natural upstream step before cold-email
 - **copywriting**: For landing pages and web copy
 - **emails**: For lifecycle/nurture email sequences (not cold outreach)
 - **social**: For LinkedIn and social posts

--- a/skills/competitor-profiling/SKILL.md
+++ b/skills/competitor-profiling/SKILL.md
@@ -403,6 +403,7 @@ Only ask if not answered by context or input:
 ## Related Skills
 
 - **competitors**: For creating comparison/alternative pages from these profiles
+- **prospecting**: For broader list-building qualification (this skill does deep research on specific accounts; prospecting builds the initial list)
 - **customer-research**: For mining reviews and community sentiment in depth
 - **content-strategy**: For using competitor content gaps to plan your own content
 - **seo-audit**: For auditing your own site relative to competitors

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -267,4 +267,5 @@ Don't ask all five at once — lead with #1 and #2, then follow up as needed.
 | Creating a churn prevention strategy from churn research | `churn-prevention` |
 | Planning paid ads informed by research | `ads` |
 | Writing cold email using research on pain/trigger | `cold-email` |
+| Translating customer research into an ICP for outbound | `prospecting` |
 | Planning content based on discovered topics | `content-strategy` |

--- a/skills/prospecting/SKILL.md
+++ b/skills/prospecting/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: prospecting
+description: When the user wants to find, qualify, and build a list of prospects to reach out to — across B2B SaaS, general B2B, or local small businesses. Also use when the user mentions "prospecting," "build a prospect list," "find prospects," "find leads," "lead gen list," "find SaaS companies that," "find B2B companies," "find local businesses," "ICP-fit accounts," "who should we go after," "outbound list," "target account list," "find clients near me," "businesses without websites," "prospect research," or "qualified leads." Use this for the list-building and qualification phase. For writing the outbound copy after the list is built, see cold-email. For deep competitive research on specific accounts, see competitor-profiling.
+metadata:
+  version: 1.0.0
+---
+
+# Prospecting
+
+You are an expert at building qualified prospect lists across three motions: B2B SaaS, general B2B, and local small businesses. Your goal is to turn an ICP definition into a verified, scored, ready-to-outreach lead sheet — using the right data sources, qualification signals, and compliance posture for each motion.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or the legacy `product-marketing-context.md` filename, in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+## Pick the Branch
+
+Prospecting motions differ enough that the workflow forks at intake. Pick **one** branch based on who the user is selling to:
+
+| Branch | Sell to | What "qualified" looks like | Primary sources |
+|--------|---------|----------------------------|----------------|
+| **SaaS** | Other SaaS companies / digital businesses | ICP fit + tech stack match + growth signals (funding, hiring, product velocity) | LinkedIn, BuiltWith, Crunchbase, Apollo, Clay, Clearbit, ProductHunt |
+| **B2B** | Non-SaaS B2B (services, manufacturers, enterprises, mid-market) | Industry + size + geographic fit + buying signals (trigger events, vendor changes) | Apollo, ZoomInfo, Clay, Clearbit, LinkedIn Sales Nav, industry directories |
+| **Local SMB** | Local small businesses (shops, gyms, restaurants, clinics, salons, services) | Active business + website status + proximity + decision-maker access | Google Maps, Yelp, local directories, Facebook, business websites |
+
+If the user describes a hybrid motion (e.g., "SMBs that are also SaaS"), pick the dominant branch and pull in qualification signals from the other.
+
+For the branch-specific deep dives:
+- **SaaS** → see [references/saas-prospecting.md](references/saas-prospecting.md)
+- **B2B** → see [references/b2b-prospecting.md](references/b2b-prospecting.md)
+- **Local SMB** → see [references/local-prospecting.md](references/local-prospecting.md)
+
+---
+
+## Shared Framework (all branches)
+
+Every prospecting engagement follows the same five phases. Tools and qualification signals change per branch; the phases don't.
+
+### Phase 1 — Define the ICP
+
+Pull from `product-marketing.md` if available. Otherwise, gather:
+
+1. **Firmographic fit** — industry, company size, revenue band, geography, business model
+2. **Technographic fit** (SaaS branch) — what tools they already use, what they're missing
+3. **Buying signal** — why now? (trigger event, funding, hiring, new initiative, dissatisfaction with current vendor, recent move/expansion)
+4. **Decision-maker profile** — role, seniority, what they care about
+5. **Disqualifiers** — what makes a prospect a clear "skip"
+
+Output the ICP as a one-paragraph statement plus a checklist of pass/fail criteria. Don't move to discovery without this.
+
+### Phase 2 — Build the candidate list (discovery)
+
+Source 2–3× more candidates than the user wants in the final list — qualification will cull aggressively.
+
+- **SaaS / B2B**: combine 2–3 sources for cross-verification. Apollo or ZoomInfo for firmographics; Clearbit or Clay for enrichment; LinkedIn Sales Nav for decision-maker mapping.
+- **Local SMB**: browser-assisted research starting with Google Maps for the target category in the target area; cross-check with Yelp, the business website, social pages, and public directories.
+
+If the user's list quality bar is high, smaller is better. 25 verified leads beats 250 mostly-junk ones.
+
+### Phase 3 — Qualify each candidate
+
+Score every candidate against the ICP checklist. Add **evidence** (a source URL or two) for each qualification — never assert without backing.
+
+**Confidence levels** (used across all branches):
+- **High**: confirmed by at least two independent sources or official business page
+- **Medium**: one credible source plus consistent search evidence
+- **Low**: incomplete or ambiguous evidence — flag what remains uncertain
+
+For email contacts (B2B / SaaS branches), **always verify deliverability before adding to the final list** — see Truelist integration in [references/data-sources.md](references/data-sources.md). Don't ship leads with invalid or risky emails.
+
+### Phase 4 — Score and prioritize
+
+Apply this rubric across all branches:
+
+| Score | Definition |
+|-------|------------|
+| **Hot** | Strong ICP fit + clear buying signal + decision-maker accessible + verified contact |
+| **Warm** | ICP fit + softer or older signal + contact verifiable |
+| **Cold** | Loose ICP fit OR no clear signal OR contact unverified |
+| **Skip** | Disqualifier hit (out of ICP, closed business, duplicate, irrelevant, low confidence) |
+
+Branch-specific signals refine the scoring — see each reference file. Default ratio target: ~20% Hot, ~30% Warm, rest Cold/Skip.
+
+### Phase 5 — Output the lead sheet
+
+Default to a markdown table in chat. Switch to CSV when the list is >25 rows or the user explicitly asks for a file.
+
+After the table, always add **"Top outreach targets"** — the top 3–5 hot leads with one sentence each on why this lead should be reached out to first.
+
+Columns vary by branch (see reference files), but every lead sheet includes:
+- score, business/company name, contact (where applicable), why-it's-a-prospect, source(s), confidence, last verified date
+
+---
+
+## Compliance Guardrails
+
+These apply to every branch. **Read first, every engagement.**
+
+1. **No bulk scraping** of LinkedIn, Google Maps, paywalled sites, or rate-limited APIs. Browser is an assisted research tool, not a scraper.
+2. **No CAPTCHA, login wall, or bot protection bypass.** If a site requires it, work with what's publicly visible.
+3. **Public business contact channels only.** Use info@, hello@, contact@, and named-role emails (founder, owner) where they're published on the business's own site. Personal/private emails require a lawful basis (existing relationship, opt-in, etc.).
+4. **GDPR / CAN-SPAM / CASL aware.** Capture and retain the source URL and date for every contact you add to a list — required for downstream outreach compliance.
+5. **No reselling extracted data** from Google Maps, LinkedIn, or any platform whose terms prohibit it. List building for the user's own outreach is fine; productizing the list to sell is not.
+6. **Rate limit yourself.** Even on public sources, space requests. Don't fingerprint as a bot.
+
+For the full compliance reference (GDPR, CAN-SPAM, CASL, LinkedIn ToS, Google Maps ToS, Clay/Apollo/ZoomInfo use restrictions): see [references/compliance.md](references/compliance.md).
+
+---
+
+## Inputs to Collect
+
+If missing, ask once, then infer reasonable defaults and continue:
+
+- **Branch** (SaaS / B2B / Local SMB) — usually inferable from context
+- **ICP description** — pull from `product-marketing.md` if present
+- **Target count** — default 25 for SaaS / B2B, 15 for Local SMB
+- **Geography** (essential for Local SMB; useful for B2B; less critical for SaaS)
+- **Tools the user has access to** — Apollo? Clay? ZoomInfo? Hunter? Truelist? Defaults to what's free + browser
+- **Output format** — chat table (default) or CSV
+- **Buying signal preference** — what triggers should they prioritize? (funding rounds, hiring, recent move, etc.)
+
+---
+
+## Tool Selection Quick Picks
+
+Full breakdown in [references/data-sources.md](references/data-sources.md). Quick picks:
+
+| If the user has access to... | Use it for |
+|------------------------------|------------|
+| **Apollo** | B2B / SaaS firmographic + contact discovery |
+| **Clay** | Multi-source enrichment, waterfall lookups, custom scoring |
+| **Clearbit** | Email-to-company and company enrichment |
+| **ZoomInfo** | Enterprise B2B contact + intent data |
+| **Hunter or Snov** | Email pattern guessing and verification |
+| **Truelist** | Email deliverability validation (before adding to outreach list) |
+| **LinkedIn Sales Navigator** | Decision-maker mapping (manual, no scraping) |
+| **BuiltWith / Wappalyzer** | Tech stack qualification (SaaS branch) |
+| **Crunchbase** | Funding signals (SaaS branch) |
+| **GitHub** | Stargazers / forks of competitor or adjacent repos (dev-tool SaaS branch) |
+| **Google Maps + browser** | Local SMB discovery |
+| **Firecrawl / Browserbase** | Programmatic extraction from individual prospect websites — never from platforms |
+
+**If the user has no enrichment tools**: lean on browser-assisted research with public sources — company website, About page, LinkedIn company page, news mentions. Slower but works.
+
+---
+
+## Output Formats
+
+### Default — chat table
+
+For SaaS / B2B (≤25 rows):
+
+```
+| Score | Company | Industry | Size | Signal | Contact | Email status | Source | Confidence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+```
+
+For Local SMB (≤15 rows) — port from the local-prospector reference:
+
+```
+| Score | Business | Category | Area | Website status | Website/Social | Phone | Why it's a prospect | Confidence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+```
+
+### CSV — when >25 rows or user requests a file
+
+SaaS / B2B columns:
+
+```csv
+score,company,domain,industry,size_band,country,signal,contact_name,contact_title,contact_email,email_status,linkedin,source_urls,why_prospect,confidence,verified_date,notes
+```
+
+Local SMB columns:
+
+```csv
+score,business,category,area,distance_km,website_status,website_url,social_urls,phone,email,source_urls,why_prospect,confidence,verified_date,notes
+```
+
+### Always include after the table
+
+- **Top outreach targets**: top 3–5 hot leads with one-sentence outreach rationale each
+- **Search parameters**: branch, ICP, location/radius, target count, date generated
+- **Open questions**: anything you couldn't verify and the user should look at
+
+---
+
+## Quality Checks (before finalizing)
+
+- [ ] Remove duplicates (by domain for SaaS/B2B, by business + address for Local SMB)
+- [ ] Every "Hot" lead has a verified contact + at least one source URL
+- [ ] No lead has an email that failed Truelist (or your validator) verification — move to a separate "invalid" bucket and flag for the user
+- [ ] No lead labeled "Hot" lacks a clear buying signal
+- [ ] Confidence levels honest — "High" requires 2 independent sources, not just two of your own searches
+- [ ] No leads sourced from prohibited scraping (LinkedIn at scale, Google Maps bulk extract, etc.)
+- [ ] Source URL + date captured for every contact (GDPR / CAN-SPAM lineage)
+- [ ] Final count matches user's request, or you've explained why it's smaller (quality bar)
+
+---
+
+## Common Mistakes
+
+1. **Starting discovery without an ICP**. Build candidates against vague criteria and you'll qualify the wrong things.
+2. **Treating data sources as authoritative without cross-checks**. Apollo and ZoomInfo are out of date often; verify before scoring as "Hot."
+3. **Adding contacts without email verification**. Cold email reputation tanks fast with bounces — always validate.
+4. **Bulk scraping LinkedIn or Google Maps**. Real risk: account suspension + ToS violation. Browser as an assisted tool only.
+5. **Mixing branches**. Don't apply Local SMB scoring (website status) to a B2B SaaS prospect, or vice versa.
+6. **"Hot" labels without buying signals**. ICP fit alone is not enough — the signal is what makes the timing right.
+7. **No source URLs**. Every claim should be traceable to a public source. Future outreach depends on this lineage.
+8. **Ignoring quiet hours / time zone** when scheduling the downstream outreach (handoff to cold-email).
+9. **Forgetting to retain consent / lineage records**. Required for GDPR DSARs and CAN-SPAM audits.
+
+---
+
+## Task-Specific Questions
+
+1. Which branch — SaaS, B2B, or Local SMB?
+2. What's your ICP? (Or: should I pull from your product-marketing context?)
+3. How many qualified leads do you want?
+4. What tools do you have access to (Apollo / Clay / ZoomInfo / Hunter / Truelist / browser only)?
+5. What's the triggering buying signal you care most about?
+6. Geography or radius (Local SMB / B2B)?
+7. Chat table or CSV?
+
+---
+
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md). Key prospecting tools:
+
+| Tool | Best For | MCP | Guide |
+|------|----------|:---:|-------|
+| **Apollo** | B2B / SaaS firmographic + contact discovery | - | [apollo.md](../../tools/integrations/apollo.md) |
+| **Clay** | Multi-source enrichment + waterfall | ✓ | [clay.md](../../tools/integrations/clay.md) |
+| **Clearbit** | Email-to-company enrichment | - | [clearbit.md](../../tools/integrations/clearbit.md) |
+| **ZoomInfo** | Enterprise B2B contact + intent | ✓ | [zoominfo.md](../../tools/integrations/zoominfo.md) |
+| **Hunter** | Email pattern + verification | - | [hunter.md](../../tools/integrations/hunter.md) |
+| **Snov** | Email finder + verifier | - | [snov.md](../../tools/integrations/snov.md) |
+| **Truelist** | Email deliverability validation | - | [truelist.md](../../tools/integrations/truelist.md) |
+| **Outreach** | Sales engagement (post-list) | ✓ | [outreach.md](../../tools/integrations/outreach.md) |
+| **RB2B** | Visitor identification (warm intent) | - | [rb2b.md](../../tools/integrations/rb2b.md) |
+| **GitHub** | Stargazers/forks/watchers as developer-intent signal | - | [github.md](../../tools/integrations/github.md) |
+| **Firecrawl** | Single-target site extraction (prospect's own website) | ✓ | [firecrawl.md](../../tools/integrations/firecrawl.md) |
+| **Browserbase** | Real-browser site research when rendering or interaction needed | ✓ | [browserbase.md](../../tools/integrations/browserbase.md) |
+
+---
+
+## Related Skills
+
+- **cold-email**: For writing outbound sequences against the qualified list (the natural next step after prospecting)
+- **customer-research**: For understanding why current customers buy — informs the ICP definition
+- **competitor-profiling**: For deeper research on individual accounts (different from list-building qualification)
+- **revops**: For lead routing, lifecycle, and CRM handoff after prospecting
+- **sales-enablement**: For battle cards and one-pagers used in the outreach
+- **directory-submissions**: For inbound discovery surfaces (the prospects might find you back)
+- **product-marketing**: For the ICP definition that anchors every prospecting engagement

--- a/skills/prospecting/evals/evals.json
+++ b/skills/prospecting/evals/evals.json
@@ -1,0 +1,107 @@
+{
+  "skill_name": "prospecting",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're a B2B SaaS selling RevOps tooling at $30K ACV. Build me a list of 25 prospects.",
+      "expected_output": "Should check for product-marketing.md first. Should identify this as the SaaS branch. Should run Phase 1 ICP definition pulling from product-marketing context or asking targeted questions (target industry, headcount range, tech stack signals, funding stage). Should propose discovery sources appropriate for SaaS at $30K ACV: Apollo for breadth, Clay for waterfall enrichment, Crunchbase for funding signals, BuiltWith/Wappalyzer for tech stack, LinkedIn Sales Nav for decision-mapping (manual). Should ask about user's tool access before assuming. Should source 50-75 candidates (2-3x target) before qualifying. Should flag that email validation via Truelist or similar is non-negotiable before final list. Should output SaaS-branch chat table columns (Score | Company | Industry | Size | Signal | Contact | Email status | Confidence) followed by top 3-5 hot leads with one-sentence rationale each. Should reference references/saas-prospecting.md.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Identifies SaaS branch",
+        "Runs Phase 1 ICP definition",
+        "Recommends multi-source discovery (Apollo, Clay, Crunchbase, BuiltWith)",
+        "Asks about user's tool access",
+        "Sources 2-3x candidates before qualifying",
+        "Requires email validation before final list",
+        "Outputs SaaS-branch chat table columns",
+        "Includes top 3-5 outreach targets with rationale",
+        "References saas-prospecting.md"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Find me 25 SaaS companies that just raised a Series B in the last 60 days and use HubSpot.",
+      "expected_output": "Should recognize this as a SaaS branch prospecting task with very specific signals. Should identify the trigger event (Series B in last 60 days) and the technographic filter (uses HubSpot). Should recommend a workflow: (1) Crunchbase or Pitchbook for funding signal filter (Series B + date), (2) BuiltWith or Clay's waterfall for tech stack verification (uses HubSpot), (3) cross-check via business websites and LinkedIn. Should note this is a tight ICP that should yield high-confidence matches if data sources are current. Should flag freshness concerns: Crunchbase data depends on self-reporting, BuiltWith refresh cycles aren't real-time. Should recommend cross-source verification for the funding date specifically. Should output a SaaS-branch chat table with the funding round + date in the Signal column. Should include verified email validation before delivering.",
+      "assertions": [
+        "Identifies as SaaS branch",
+        "Identifies funding signal + tech stack filter",
+        "Recommends Crunchbase or Pitchbook for funding",
+        "Recommends BuiltWith or Clay for HubSpot verification",
+        "Notes data freshness concerns",
+        "Recommends cross-source verification",
+        "Outputs signal column showing round + date",
+        "Requires email validation"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I run a marketing agency. Find me 25 mid-market manufacturers in the Midwest US who recently hired a new CMO.",
+      "expected_output": "Should identify this as the B2B branch (manufacturers, not SaaS). Should run Phase 1 ICP definition: industry (manufacturing, with NAICS code if precision matters), size (mid-market = typically 200-2000 employees), geography (Midwest US states), trigger event (CMO hire in last 90-180 days). Should propose discovery: Apollo or ZoomInfo for firmographic filter, LinkedIn Sales Nav for CMO hire detection (job changes), Google Alerts on press releases for trigger events. Should warn that CMO hires aren't always in public databases — LinkedIn Sales Nav alerts on job changes is the most reliable source. Should output B2B-branch chat table with the CMO trigger as the signal. Should reference references/b2b-prospecting.md. Should mention compliance: GDPR less likely (US-only), CAN-SPAM applies, capture source URL + date for every contact.",
+      "assertions": [
+        "Identifies B2B branch (not SaaS)",
+        "Runs Phase 1 ICP definition with NAICS or industry classification",
+        "Specifies mid-market size band",
+        "Specifies Midwest US geography",
+        "Identifies trigger event (CMO hire)",
+        "Recommends Apollo/ZoomInfo + LinkedIn Sales Nav",
+        "Notes CMO hires often only on LinkedIn",
+        "Outputs B2B-branch chat table",
+        "Mentions CAN-SPAM and source URL capture",
+        "References b2b-prospecting.md"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "We sell to industrial distributors. Build a list of 25 prospects.",
+      "expected_output": "Should identify this as the B2B branch. Should run Phase 1 ICP definition asking targeted questions: distributor size, geography, vertical specialty, buying patterns. Should propose discovery: Apollo or ZoomInfo for firmographic depth, industry-specific directories (e.g., NAW for wholesale distributors, ISA for industrial sales agencies), trade show exhibitor lists. Should note state business registries and Chamber of Commerce as verification sources. Should propose trigger events: new location, recent acquisition, leadership change, posting RFPs. Should warn that industrial distributor data is often spotty in major databases — cross-check with company website + LinkedIn for size and ownership signals. Should output B2B-branch chat table. Should note ICP fit precision matters more than initial volume for this kind of niche prospecting.",
+      "assertions": [
+        "Identifies B2B branch",
+        "Runs Phase 1 ICP definition asking targeted questions",
+        "Recommends industry-specific directories beyond Apollo/ZoomInfo",
+        "Mentions trade show exhibitor lists",
+        "Identifies relevant trigger events",
+        "Warns about data spottiness for industrial",
+        "Recommends cross-verification with business websites + LinkedIn",
+        "Notes ICP fit precision over volume"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "I build websites for local businesses. Find me 15 prospects near Austin, TX who don't have a website.",
+      "expected_output": "Should identify as Local SMB branch. Should run Phase 1 ICP definition: business category (ask user — gyms, restaurants, salons, etc. matter), radius (default 20 km from Austin), target count (15). Should run the browser research workflow: search Google Maps for category + Austin, build candidate list from visible results, cross-check via business name + city web search to verify website status. Should apply the 4-tier website status classification (No site found / Social only / Weak site / Has site) — prioritize No site + Social only as Hot. Should score: Hot (no site + active + phone + within radius), Warm (weak site), Cold (has site), Skip (closed/duplicate/out of scope). Should output Local SMB chat table (Score | Business | Category | Area | Distance | Website status | Website/Social | Phone | Why prospect | Confidence). Should add 'Best first outreach targets' top 3 with reasoning. Should reference references/local-prospecting.md. Should warn against bulk-scraping Google Maps (ToS violation) — browser-assisted research only.",
+      "assertions": [
+        "Identifies Local SMB branch",
+        "Asks about business category if not specified",
+        "Defaults radius to 20km",
+        "Runs browser research workflow",
+        "Applies 4-tier website status classification",
+        "Uses Hot/Warm/Cold/Skip scoring",
+        "Outputs Local SMB chat table columns",
+        "Adds top 3 outreach targets",
+        "References local-prospecting.md",
+        "Warns against bulk-scraping Google Maps"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I have a list of 200 prospect emails from Apollo. How do I know which ones are deliverable before I start outreach?",
+      "expected_output": "Should explain the deliverability validation step in Phase 3. Should recommend Truelist (the integration in this pack) for bulk validation. Should explain the email_state classification output: ok (deliverable), email_invalid (bounces, exclude), risky (deliverable with risk like role or disposable, include cautiously), unknown (couldn't determine, skip or re-verify), accept_all (catch-all domain, include cautiously). Should warn that Apollo data accuracy is typically 60-80% — sending without validation will tank sender reputation (bounce rate >2% triggers ISP throttling and reputation damage). Should recommend the workflow: bulk POST to /api/v1/verify or CSV upload → keep ok, include risky/accept_all cautiously, exclude email_invalid, re-verify unknown → hand off to outreach. Should note Truelist also has an official MCP server for agent-driven validation. Should note cold email reputation is hard to recover once damaged — validation is non-negotiable, not optional. Should mention Hunter and Snov as alternatives with built-in verification. Should reference truelist.md integration guide.",
+      "assertions": [
+        "Recommends Truelist for bulk validation",
+        "Explains email_state values (ok, email_invalid, risky, unknown, accept_all)",
+        "Warns Apollo accuracy is 60-80%",
+        "Cites 2% bounce rate threshold for reputation damage",
+        "Recommends workflow: validate, keep ok, exclude email_invalid",
+        "Mentions Truelist MCP server for agent workflows",
+        "Mentions cold email reputation is hard to recover",
+        "References truelist.md or data-sources.md"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/prospecting/references/b2b-prospecting.md
+++ b/skills/prospecting/references/b2b-prospecting.md
@@ -1,0 +1,106 @@
+# B2B Prospecting Reference
+
+For when the user sells to non-SaaS B2B — services, agencies, manufacturers, mid-market and enterprise companies, professional services firms.
+
+---
+
+## ICP Signals That Matter (B2B branch)
+
+### Firmographic signals
+
+- **Industry / vertical** — NAICS or SIC codes if precision matters
+- **Company size** — headcount band, revenue band, location count
+- **Geography** — relevant for time zones, regulations, on-site requirements
+- **Business model** — service vs product vs distribution; B2B vs B2B2C
+- **Ownership** — independent, PE-backed, public, family-owned — affects buying motion
+
+### Buying signals
+
+- **Trigger events**: new C-level hire, recent acquisition or divestiture, IPO/funding, opening a new location, recent rebrand, expansion announcement
+- **Vendor signals**: posting RFPs publicly, switching costs in last quarterly report, contract renewal windows
+- **Operational signals**: recent layoffs (cost pressure) or rapid hiring (capacity pressure)
+- **News mentions**: launching new initiative, entering new market, regulatory change forcing action
+- **PR / press**: anything that signals "this company is changing right now"
+
+### Decay signals
+
+- Multiple bankruptcies or PE-stripped operations
+- Negative growth + cost-cutting headlines
+- Ownership stagnation (small family-owned, no growth incentive)
+- Buyer turnover (3+ Marketing Directors in 2 years)
+
+---
+
+## Discovery Sources (B2B branch)
+
+### Tier 1 — primary discovery
+
+- **Apollo**: best general B2B firmographic + contact discovery
+- **ZoomInfo**: enterprise B2B + intent signals (mid-market+)
+- **LinkedIn Sales Navigator**: industry + role + signal search; the gold standard for decision-maker mapping (manual)
+- **Clay**: when you need custom waterfall lookups (e.g., enrich Apollo records with Hunter + Clearbit)
+
+### Tier 2 — industry-specific directories
+
+- **Crunchbase / Pitchbook**: funded businesses
+- **D&B Hoovers**: large traditional B2B firmographics
+- **State / national business registries**: for verified incorporation data
+- **Industry association membership rosters**: trade groups often publish member lists
+- **Trade show exhibitor lists**: signals active participation in a vertical
+- **Procurement databases** (Procore for construction, e.g.): vertical-specific signals
+
+### Tier 3 — trigger event monitoring
+
+- **Google Alerts / Feedly**: trigger keywords ("acquired," "hires," "expansion," "raises," "announces")
+- **PR Newswire / Business Wire**: company-controlled announcements
+- **SEC filings** (public companies): material change disclosures
+- **State filings**: new entity formation, dissolution
+
+---
+
+## Qualification Checklist (B2B branch)
+
+- [ ] Industry / vertical matches ICP (use a recognized classification if possible)
+- [ ] Company size within range (employees or revenue)
+- [ ] Geography fits
+- [ ] At least one trigger event in last 90–180 days
+- [ ] Decision-maker role exists (CEO, COO, VP Operations, Director of X — match buyer profile)
+- [ ] Email contact verifiable (named role > info@ catchall)
+- [ ] Source URLs captured for firmographic claims
+- [ ] No disqualifiers (closed, acquired-paused, multi-bankrupt, off-ICP)
+
+---
+
+## Output Columns (B2B branch)
+
+Recommended CSV columns:
+
+```csv
+score,company,domain,industry,naics_code,size_band,revenue_band,country,city,trigger_event,trigger_date,contact_name,contact_title,contact_email,email_status,linkedin_url,source_urls,why_prospect,confidence,verified_date,notes
+```
+
+For chat table, condense to: Score | Company | Industry | Size | Trigger | Contact | Email status | Confidence.
+
+---
+
+## Top Outreach Targets Selection (B2B)
+
+Prioritize for the top 3–5 hot leads:
+
+1. **Trigger event recency** — 30 days beats 6 months
+2. **Trigger event specificity** — new CMO hire in your buyer's role beats "company in the news"
+3. **Decision-maker access** — named contact with verified email + LinkedIn beats role-only
+4. **Vertical fit precision** — exact NAICS match beats "adjacent industry"
+
+Each top target rationale names the trigger and decision-maker: "Hired new VP of Marketing 14 days ago; verified email; mid-market manufacturer matching ICP."
+
+---
+
+## Common Mistakes (B2B)
+
+1. **Treating B2B like SaaS** — funding rounds matter less; PE ownership and acquisition activity matter more.
+2. **Trying to verify private company revenue precisely** — most public databases approximate. Use size bands, not point estimates.
+3. **Ignoring procurement complexity** at enterprise scale — your prospect contact list may not include the actual approver.
+4. **Cold-emailing executive assistants** — they're not the buyer and they will flag your outreach as spam.
+5. **Source URL hygiene** — without source lineage, you can't defend a contact under GDPR DSAR or CAN-SPAM challenge.
+6. **Stopping at one source** — Apollo can be 60% accurate on small businesses. Cross-verify with LinkedIn or the business website.

--- a/skills/prospecting/references/compliance.md
+++ b/skills/prospecting/references/compliance.md
@@ -1,0 +1,123 @@
+# Prospecting Compliance Reference
+
+The legal and platform-ToS constraints that apply to prospect list building. Read first, every engagement.
+
+> Operational guidance, not legal advice. For high-volume programs or programs touching EU/UK residents, run your setup past a privacy attorney.
+
+---
+
+## United States — CAN-SPAM (downstream)
+
+CAN-SPAM regulates the cold email **send**, not the list build. But the list build matters because:
+
+- You must be able to identify the source of every email address you contact (required if challenged)
+- The "from" line and email content rules apply at send time — but you can't lie about how you got the contact
+- Opt-out requests must be honored within 10 business days and tracked
+
+**For prospecting specifically**: capture and retain the source URL + date for every contact you add to a list. CAN-SPAM doesn't require it explicitly, but defending your sender practices does.
+
+---
+
+## EU / UK — GDPR
+
+The strictest applicable framework. Triggers when:
+
+- Your prospect resides in EU/UK
+- You're processing personal data (any identifiable info, including business emails tied to a named person)
+
+### Lawful bases for cold B2B outreach
+
+You have three credible options:
+
+1. **Legitimate interest** (most common for B2B). Requires:
+   - The contact is in a business role likely to be interested in your offer
+   - The data was collected from a public, business-context source
+   - You provide a clear opt-out
+   - You can articulate the legitimate interest test in writing
+
+2. **Consent** — typically not feasible for cold outreach (you don't have consent before first contact)
+
+3. **Existing customer relationship** — only applies to current customers, not prospects
+
+### What you must do
+
+- Capture **source + date + lawful basis** for every contact
+- Honor data subject access requests (DSARs) — you must be able to disclose, correct, or delete on request
+- Include a privacy notice / opt-out in the first outreach
+- Don't store personal data longer than necessary for the legitimate interest
+
+### What disqualifies a list
+
+- Bulk-scraped LinkedIn data — explicit ToS violation + GDPR risk
+- Email addresses purchased from a list broker without source provenance
+- "Anyone @ this domain" guessed emails sent without verification (multiplies risk + bounces)
+
+---
+
+## Canada — CASL
+
+Stricter than CAN-SPAM. Cold B2B outreach requires:
+
+- **Express consent** (explicit opt-in) — typically not present for cold prospecting
+- **OR implied consent** — existing business relationship within 24 months, OR business address publicly published on the company's own site for the purpose of receiving such communications
+
+**Practical implication for Canadian prospects**: relying on the publicly-published-address exception is the most defensible cold prospecting basis in Canada. You must include sender identification, mailing address, and an unsubscribe mechanism in every message.
+
+---
+
+## Platform Terms of Service
+
+### LinkedIn
+
+- **Sales Navigator** as a research tool: fine
+- **Scraping LinkedIn at any scale**: explicit ToS violation. Banned accounts are permanent. Don't.
+- **Apollo, Clay, and ZoomInfo** claim LinkedIn-overlap data through various legitimate channels — verify their data sources before assuming compliance
+- **InMail and Connection Requests**: governed by LinkedIn's own messaging rules, not by CAN-SPAM/GDPR (because LinkedIn-internal)
+
+### Google Maps
+
+- ToS prohibits bulk extraction or productizing Maps data
+- Browser-assisted research as a discovery aid: acceptable
+- Storing Place IDs or large structured Maps data in your CRM: explicit ToS prohibition
+- Use Maps to **find** local businesses, then cross-source from the business's own site for the data you retain
+
+### Apollo / ZoomInfo / Clearbit
+
+- All have their own ToS limiting reselling, downstream sharing, and use cases
+- Read your contract — typically you can use the data for your own outreach but not productize it
+- Don't share extracts publicly (e.g., on a leaderboard, in a public report)
+
+### Crunchbase
+
+- Free tier is read-only for personal use
+- Paid tier permits broader use within contractual scope
+- API access requires paid Pro+ tier
+
+---
+
+## Anti-Patterns (Don't Do These)
+
+1. **Bulk-scraping LinkedIn / Google Maps / Yelp**. Browser-assisted research is OK; automated scrapers pointed at these platforms are not. **Firecrawl and Browserbase are fine for an individual prospect's own website** (the URL you found through manual discovery) — not for the platforms hosting prospects.
+2. **Buying lists from random vendors** without source provenance. You inherit their legal exposure.
+3. **Guessing emails and sending unverified**. Bounce rates over 2% destroy sender reputation; legally, you can't claim a "legitimate interest" basis for an email you fabricated.
+4. **Harvesting personal email addresses** (Gmail, personal Outlook, etc.) from public profiles. Personal addresses raise GDPR risk significantly.
+5. **Storing data you don't need**. Minimize retention. Don't keep prospect lists forever — GDPR right to deletion applies.
+6. **Skipping the lawful basis documentation**. If challenged, you need to show your work. Capture source URL + collection date for every contact.
+7. **Reselling prospect lists**. You may not have the right to share them downstream. Read your data provider contracts.
+8. **CAPTCHA bypass / login wall bypass**. Even if technically possible, this signals bot behavior and violates virtually every ToS.
+
+---
+
+## Quick Audit Checklist
+
+Before shipping a list to the user (or downstream to cold-email):
+
+- [ ] Every contact has a source URL + collection date
+- [ ] No contacts sourced from scraped LinkedIn data
+- [ ] No Google Maps Place IDs or large Maps-structured data retained
+- [ ] Lawful basis documented (legitimate interest test for B2B, or relevant alternative)
+- [ ] Email addresses validated (deliverability check before outreach)
+- [ ] Personal addresses (Gmail, etc.) flagged or excluded
+- [ ] Source provider contracts permit the intended use case
+- [ ] Retention plan documented (when to delete)
+- [ ] First outreach will include unsubscribe + privacy notice (downstream concern for cold-email skill, but mention it now)

--- a/skills/prospecting/references/data-sources.md
+++ b/skills/prospecting/references/data-sources.md
@@ -1,0 +1,287 @@
+# Prospecting Data Sources
+
+Tool selection guide for prospecting across all three branches.
+
+---
+
+## Tool selection by goal
+
+| Goal | Primary tools | Notes |
+|------|--------------|-------|
+| **Build initial firmographic list (B2B / SaaS)** | Apollo, ZoomInfo, Clay | Apollo for breadth, ZoomInfo for enterprise + intent, Clay for custom workflows |
+| **Decision-maker mapping** | LinkedIn Sales Navigator (manual), Apollo, ZoomInfo | Sales Nav is the gold standard. Never bulk scrape it. |
+| **Tech stack qualification (SaaS)** | BuiltWith, Wappalyzer | BuiltWith has wider coverage + paid plans for bulk; Wappalyzer is lighter + free for small use |
+| **Funding signals (SaaS)** | Crunchbase, Pitchbook | Crunchbase free tier sufficient for early signals; Pitchbook for deeper investor data |
+| **Email pattern discovery** | Hunter, Snov, Apollo | Pattern guessing — followed by verification |
+| **Email deliverability verification** | Truelist, Hunter, NeverBounce, ZeroBounce | Always verify before adding to outreach lists |
+| **Visitor identification (warm intent)** | RB2B, Clearbit Reveal | Anonymous traffic → company identification |
+| **Intent data** | ZoomInfo Intent, 6sense, Bombora | Pre-warmed signals; mid-market+ pricing |
+| **Trigger event monitoring** | Google Alerts, Feedly, LinkedIn Sales Nav alerts | Free options are sufficient for most |
+| **Local business discovery** | Google Maps (manual), Yelp, Facebook Pages | Browser-assisted, not bulk-extracted |
+
+---
+
+## Apollo
+
+**Use for**: General B2B / SaaS firmographic + contact data. Best starting point if you don't already have a list.
+
+**Strengths**:
+- Large database (>200M contacts, >60M companies)
+- Strong filtering UI (industry, size, technologies, signals)
+- Integrated email + LinkedIn finder
+- Pay-as-you-go and tiered plans
+
+**Watch out for**:
+- Data freshness varies — re-verify before scoring as "Hot"
+- Email accuracy ~60–80% — always validate
+- Bulk export limits apply
+
+**Integration**: see [apollo.md](../../../tools/integrations/apollo.md)
+
+---
+
+## Clay
+
+**Use for**: Multi-source enrichment, waterfall lookups, custom scoring logic. When list quality matters more than list size.
+
+**Strengths**:
+- Waterfall logic: try Apollo first → fallback to ZoomInfo → fallback to Clearbit
+- 100+ data provider integrations
+- AI-powered enrichment (LLM-driven extraction from URLs)
+- Custom columns + scoring formulas
+- Native MCP server
+
+**Watch out for**:
+- Per-credit pricing can spike on large lists
+- Complexity overhead — easy to over-engineer workflows
+
+**Integration**: see [clay.md](../../../tools/integrations/clay.md)
+
+---
+
+## ZoomInfo
+
+**Use for**: Enterprise B2B + intent data. Mid-market+ buyer profiles.
+
+**Strengths**:
+- Enterprise-grade firmographic depth
+- Intent signals (companies searching topics relevant to your offer)
+- Best-in-class for >$50K ACV B2B sales
+- Native MCP server
+
+**Watch out for**:
+- Expensive ($15K+/yr starter)
+- Overkill for SMB prospecting
+- Locked into multi-year contracts typically
+
+**Integration**: see [zoominfo.md](../../../tools/integrations/zoominfo.md)
+
+---
+
+## Clearbit
+
+**Use for**: Email → company enrichment, anonymous visitor identification (Clearbit Reveal).
+
+**Strengths**:
+- Strong company enrichment (industry, size, funding, tech stack)
+- Email lookup by domain
+- Reveal: identify anonymous site visitors at company level
+- API-first
+
+**Watch out for**:
+- HubSpot acquisition (2023) — bundled into HubSpot Breeze Intelligence now
+- Standalone API still available but pricing/access depends on tier
+
+**Integration**: see [clearbit.md](../../../tools/integrations/clearbit.md)
+
+---
+
+## Hunter / Snov
+
+**Use for**: Email pattern discovery + lightweight verification on small lists.
+
+**Hunter strengths**:
+- Domain-based email discovery
+- Built-in deliverability verification
+- Free tier reasonable for occasional use
+
+**Snov strengths**:
+- Email finder + drip campaigns (overlap with outreach tooling)
+- Bulk verification
+- Cheaper than Hunter at scale
+
+**Watch out for**:
+- Both are pattern-guessing tools — accuracy depends on the target company's email pattern being inferable
+- Always run results through a dedicated validator (Truelist or similar) before outreach
+
+**Integrations**: see [hunter.md](../../../tools/integrations/hunter.md), [snov.md](../../../tools/integrations/snov.md)
+
+---
+
+## Truelist
+
+**Use for**: Email deliverability validation before adding contacts to outreach lists. Critical safety step.
+
+**Strengths**:
+- Single-email sync verification (`/api/v1/verify_inline`) + bulk async (`/api/v1/verify`)
+- Returns `email_state` (ok / email_invalid / risky / unknown / accept_all) + `email_sub_state` (email_ok / is_disposable / is_role / unknown_error / failed_smtp_check) + did-you-mean typo suggestions
+- Catches catch-all domains, role accounts, spam traps, disposable providers
+- Official MCP server for agent-driven workflows (Claude, Cursor, VS Code)
+- Official SDKs in 7 languages + framework integrations (Django, Laravel, Next.js, Rails, React, Svelte, Vue, WordPress)
+- Native integrations with Mailchimp, Klaviyo, HubSpot, Zapier, Make, n8n, Clay, Salesforce, more
+- Pay-per-email pricing
+
+**Why this matters**: Cold email reputation craters when bounce rates exceed 2%. Validating before sending is non-negotiable. Apollo/ZoomInfo/Hunter data is often 60–80% accurate — Truelist catches the rest.
+
+**Integration**: see [truelist.md](../../../tools/integrations/truelist.md)
+
+---
+
+## LinkedIn Sales Navigator
+
+**Use for**: Manual decision-maker discovery. The gold standard for B2B / SaaS prospecting but only when used as a research tool.
+
+**Strengths**:
+- Most accurate decision-maker data in the industry
+- Real-time job changes, posts, signals
+- Lead lists, alerts, saved searches
+- Inmail credits (separate channel from cold email)
+
+**Hard rules**:
+- **Never bulk scrape**. LinkedIn aggressively bans scrapers. Account ban risk is real and permanent.
+- Use Sales Nav as a research interface — open profiles, read, take notes, capture key data manually.
+- Apollo and other tools claim LinkedIn data via partnerships / public mirroring — verify the source legitimacy before assuming compliance.
+
+**Integration**: no MCP or API access at consumer level. Manual research only.
+
+---
+
+## BuiltWith / Wappalyzer
+
+**Use for**: Tech stack qualification (SaaS branch).
+
+**BuiltWith**:
+- ~50K+ technologies tracked
+- API + bulk lookups (paid)
+- Historical data (when stack changed)
+
+**Wappalyzer**:
+- Free browser extension; paid API
+- Lighter coverage than BuiltWith
+- Faster for one-off lookups
+
+Cross-reference both for high-confidence tech stack signals.
+
+---
+
+## Crunchbase
+
+**Use for**: Funding signals (SaaS branch).
+
+**Strengths**:
+- Free tier shows recent funding events
+- Paid (Pro / Enterprise) unlocks alerts and deep history
+- API access for paid users
+
+**Watch out for**:
+- Coverage is best for VC-backed companies; bootstrapped + small businesses underrepresented
+- Self-reported data — verify funding amounts independently
+
+---
+
+## GitHub (stargazers / forks / watchers)
+
+**Use for**: Developer-intent prospecting. Especially powerful for dev-tool SaaS — stargazers of competitor or category-defining repos are in-market signal.
+
+**Strengths**:
+- Public API, no scraping concerns
+- High signal quality (a starred repo = explicit interest)
+- Forks are an even stronger signal (intent to modify, not just bookmark)
+- Bundled `github-prospects.js` CLI handles pagination + enrichment + CSV output
+- Free with 5,000 req/hr authenticated rate limit
+
+**Watch out for**:
+- Only ~5–20% of users publish email — pair with Apollo/Clay/Hunter for enrichment
+- Very-popular repos (100K+ stars) are mostly noise; smaller targeted repos (5K–25K) give better signal density
+- Most prospects are individuals, not company contacts directly — need to figure out their company from `company` field or LinkedIn
+
+**Integration**: see [github.md](../../../tools/integrations/github.md)
+
+---
+
+## Firecrawl / Browserbase (single-target site research)
+
+**Use for**: Programmatically extracting content from a **prospect's own website** that you already found via discovery on platforms like Google Maps, Yelp, or LinkedIn. Not for scraping those platforms themselves.
+
+### Firecrawl
+
+- **Best for**: "Just give me the page as markdown" — Local SMB website status checks, B2B company about/team page extraction, structured field extraction
+- **Strengths**: Low overhead, returns clean LLM-ready markdown, handles most JS-rendered sites, has an MCP server
+- **API + MCP + SDKs**: Node, Python, Go, Rust
+
+### Browserbase
+
+- **Best for**: When you need real Chromium — JS-heavy pages, cookie consent dialogs, form submission to reach a contact page, session state
+- **Strengths**: Full browser control via Playwright/Puppeteer; Stagehand provides AI-friendly natural-language extraction; session recordings for debugging
+- **API + MCP (Stagehand) + SDKs**: Node, Python
+
+### Critical compliance line
+
+Both tools can technically point at any URL. The hard rule:
+
+- ✓ **OK**: extracting content from a single business's own website (`joescoffeeshop.com`) that you found through manual discovery
+- ✗ **NOT OK**: pointing them at `google.com/maps`, LinkedIn search results, Yelp listings, or any platform whose ToS prohibits bulk extraction
+
+Discovery happens on platforms (manual browser-assisted research). Extraction happens on individual public business sites.
+
+**Integrations**: see [firecrawl.md](../../../tools/integrations/firecrawl.md), [browserbase.md](../../../tools/integrations/browserbase.md)
+
+---
+
+## RB2B / Clearbit Reveal
+
+**Use for**: Identifying anonymous site visitors as warm intent signals.
+
+**Strengths**:
+- Pixel-based visitor → company identification
+- High-intent: they came to your site, they're already in research mode
+- Slack / email alerts on key visits
+
+**Watch out for**:
+- Privacy/GDPR considerations — verify your privacy policy disclosures
+- Person-level identification raises higher concerns than company-level
+
+**Integration**: see [rb2b.md](../../../tools/integrations/rb2b.md)
+
+---
+
+## Free / browser-only fallbacks
+
+When the user has no paid tools, lean on:
+
+- **Google Search** — exact business name + city + role searches
+- **LinkedIn** (manual, no scraping) — company pages, employee lookups
+- **Crunchbase free tier** — funding events
+- **Wappalyzer browser extension** — tech stack at a glance
+- **Hunter.io free tier** — 25 lookups/month
+- **Google Maps** — for Local SMB discovery
+- **Business websites + About pages** — primary source for any claim
+- **News sites + press releases** — trigger event monitoring via Google Alerts
+
+Slower than tooled-up workflows, but produces high-quality smaller lists if the user is willing to do the work.
+
+---
+
+## Sequencing recommendations
+
+A typical full-stack prospecting workflow:
+
+1. **Define ICP** from product-marketing context (no tools needed)
+2. **Initial list** from Apollo or ZoomInfo (firmographic filter)
+3. **Enrich** with Clay (waterfall: tech stack, funding, trigger events)
+4. **Decision-maker mapping** in LinkedIn Sales Nav (manual)
+5. **Email pattern discovery** with Hunter or Apollo's built-in
+6. **Email validation** with Truelist before final list
+7. **Hand off** to cold-email skill for outreach copy
+
+Adapt this sequence based on which tools the user actually has.

--- a/skills/prospecting/references/local-prospecting.md
+++ b/skills/prospecting/references/local-prospecting.md
@@ -1,0 +1,165 @@
+# Local SMB Prospecting Reference
+
+For when the user sells to local small businesses — shops, gyms, restaurants, salons, clinics, professional services, contractors, real estate, fitness studios, dental practices.
+
+Adapted from and generalized beyond the local-client-prospector pattern (browser-assisted discovery + website status classification + proximity scoring).
+
+---
+
+## ICP Signals That Matter (Local SMB branch)
+
+### Operational signals
+
+- **Active business** — Google Business Profile updated, recent reviews, recent hours updates
+- **Recent activity** — open right now, regular hours posted, recent photos uploaded by owner
+- **Customer engagement** — owner responding to reviews, posts on social, active calendar (for service businesses)
+
+### Online presence signals (the core SMB qualification axis)
+
+The reference local-client-prospector skill uses **website status** as the primary qualification — port this directly. Four classifications:
+
+| Status | Definition | Typical outcome |
+|--------|-----------|-----------------|
+| **No site found** | No credible standalone website after cross-checked search | **Hot prospect** for web/marketing service |
+| **Social only** | Facebook, Instagram, WhatsApp, Linktree, booking portal, marketplace page only — no standalone site | **Hot prospect** for web/marketing service |
+| **Weak site** | Standalone site exists but outdated, broken, very thin, non-mobile-friendly, or missing clear contact/conversion flow | **Warm prospect** for refresh / rebuild service |
+| **Has site** | Credible, modern standalone site exists | **Low prospect** unless other signals apply (e.g., poor SEO, weak conversion design) |
+
+### Proximity signals
+
+- **Distance** from the user's location or service area
+- **Density** — clusters of similar businesses in one area = neighborhood targeting opportunity
+- **Travel time** — useful when in-person discovery, install, or service delivery is required
+
+### Decay signals
+
+- Closed permanently (Google Maps banner)
+- Reviews paused or business listing reported as closed
+- Last activity (review, post) >12 months ago
+
+---
+
+## Discovery Sources (Local SMB branch)
+
+### Primary
+
+- **Google Maps** (browser, manual) — search "category near [location]" and walk the visible results. Cross-check details. Don't bulk-extract.
+- **Yelp** — secondary verification; complementary categories
+- **Bing Local / Apple Maps** — different coverage on smaller businesses
+- **Facebook Pages search** — many SMBs are Facebook-only
+
+### Cross-verification
+
+- **Business's own website** (if any)
+- **Industry directories** (e.g., Healthgrades for medical, OpenTable for restaurants, Avvo for legal)
+- **Local Chamber of Commerce listings**
+- **State business registries** for incorporation status
+- **Search results for "[business name] [city]"** to discover non-Maps presence
+
+---
+
+## Browser Research Workflow
+
+1. Open a browser and search Google Maps for the category near `base_location`
+2. Build a candidate list from visible local results, search results, and public directories
+3. For each candidate, inspect public sources to fill required fields
+4. Search the exact business name plus city/town to check whether a standalone website exists
+5. Classify website status per the table above
+6. Mark confidence: High (2+ sources), Medium (1 source + consistent evidence), Low (incomplete/ambiguous)
+
+When the user explicitly asks for subagents AND subagents are available, split candidates into non-overlapping batches and ask each subagent to verify only website/social/contact status. Don't use subagents for the primary search if it slows progress.
+
+### Optional: programmatic verification with Firecrawl or Browserbase
+
+Once you have a candidate's website URL (found via manual Maps/Yelp discovery), you can speed up website-status classification by hitting the URL programmatically:
+
+- **Firecrawl** for simple "is this site live, modern, mobile-friendly, conversion-flow-equipped" reads — returns clean markdown you can inspect
+- **Browserbase** when the candidate site requires JS rendering, has a cookie consent dialog, or you need session state
+
+**Strict line**: use these on the individual business's URL. **Don't** point them at Google Maps, Yelp, or any platform whose ToS prohibits bulk extraction — discovery stays manual.
+
+See [data-sources.md](data-sources.md) for setup details.
+
+---
+
+## Qualification Checklist (Local SMB branch)
+
+- [ ] Business is active (recent reviews or activity in last 6 months)
+- [ ] Category matches user's service offering
+- [ ] Distance / proximity within target radius
+- [ ] Website status classified
+- [ ] Phone or contact channel verified
+- [ ] At least one cross-source confirms business operates at the listed address
+- [ ] Not a duplicate / chain location / out-of-scope category
+- [ ] Not closed permanently
+
+---
+
+## Lead Scoring (Local SMB)
+
+Use this simple rubric (matches local-client-prospector pattern):
+
+| Score | Criteria |
+|-------|----------|
+| **Hot** | No site found OR social-only + phone present + active business + within target radius |
+| **Warm** | Weak site, poor online presentation, or marketplace/booking-page only |
+| **Cold** | Good website already present OR low confidence |
+| **Skip** | Closed, duplicate, outside radius, irrelevant category, or not a business prospect |
+
+---
+
+## Output Columns (Local SMB branch)
+
+Chat table (≤15 rows):
+
+```
+| Score | Business | Category | Area | Distance | Website status | Website/Social | Phone | Why it's a prospect | Confidence |
+```
+
+CSV:
+
+```csv
+score,business,category,area,distance_km,website_status,website_url,social_urls,phone,email,source_urls,why_prospect,confidence,verified_date,notes
+```
+
+Rules:
+- Keep "Why it's a prospect" short and actionable
+- Use `Not found` instead of leaving blank fields
+- Include source links sparingly, not all of them
+- After the table, add **Best first outreach targets** with the top 3 leads and one practical reason each
+- If confidence is low, state exactly what remains uncertain
+
+---
+
+## Top Outreach Targets Selection (Local SMB)
+
+Prioritize for the top 3 hot leads:
+
+1. **No site / social only + phone present** = clearest service opportunity
+2. **High review count** = active, established business with real customers
+3. **Owner-responded reviews** = engaged owner = more likely to evaluate a vendor
+4. **Industry alignment with your service specialty** beats generic category match
+
+Each top target rationale should be one sentence naming the gap and the signal: "No standalone website (cross-checked); 80+ Google reviews with owner replies; 2 km from target area."
+
+---
+
+## Compliance Notes (Local SMB-specific)
+
+The local branch is the most scraping-sensitive of the three motions. Specifically:
+
+- **Google Maps Terms of Service** prohibit bulk extraction. Treat browser visits as research, not as data acquisition.
+- **Don't store full Google Maps Place IDs in your CRM** — the ToS limits storage of Maps data.
+- **Public business contact channels only**: published phone, contact form, info@ email. Don't reach individual employees through their personal channels.
+- **Owner/operator name when published on the business's own site** is OK to use. If you only got it from LinkedIn, mark the source.
+
+---
+
+## Common Mistakes (Local SMB)
+
+1. **Bulk-scraping Google Maps** — fastest way to violate ToS and lose the research channel.
+2. **Treating Google Maps data as truth** — listings go stale. Cross-check hours, status, and reviews.
+3. **Skipping the website status cross-check** — finding "no site" on Maps doesn't mean no site exists; do an exact-name web search before classifying.
+4. **Targeting only the largest businesses** — they're already covered by other providers. The 2–5 employee SMBs are the under-served opportunity.
+5. **Generic outreach to all hot leads** — local SMBs respond better to outreach that names their specific gap ("I noticed your menu isn't visible on mobile") than generic pitches.
+6. **Ignoring chains and franchises** as Skip — sometimes the franchisee is the buyer and they have local marketing authority. Verify before skipping.

--- a/skills/prospecting/references/saas-prospecting.md
+++ b/skills/prospecting/references/saas-prospecting.md
@@ -1,0 +1,123 @@
+# SaaS Prospecting Reference
+
+For when the user sells SaaS or digital services to other SaaS companies / digital businesses.
+
+---
+
+## ICP Signals That Matter (SaaS branch)
+
+Beyond standard firmographics (industry, size, geography), SaaS prospects are qualified by:
+
+### Technographic signals
+
+- **Tech stack** — do they use complementary tools (your integration target) or competing tools (a switch opportunity)?
+- **Recent stack changes** — adding/removing tools signals active vendor evaluation
+- **Custom-built vs off-the-shelf** — DIY tooling often means a buyer who'd benefit from your product
+- **Free/freemium plan signals** — using a free competitor means they may be ready to upgrade
+
+### Growth signals
+
+- **Funding round** — Series A / B / C in last 6 months = budget + new hires + tool needs
+- **Headcount growth** — 10%+ growth in last quarter signals scaling pressure
+- **Hiring signals** — specific role openings (e.g., "Head of RevOps" → ICP for revops tooling)
+- **Product velocity** — frequent shipping, new features, blog posts = healthy growth motion
+- **Open positions for your buyer's role** — if you sell to Marketing Ops and they're hiring one, that's a signal
+
+### Decay signals (downgrade scoring)
+
+- Layoffs in target department
+- Funding round >2 years ago with no follow-up
+- Product hasn't shipped in 6+ months
+- Team page shows founders only (very early — may not have budget)
+
+---
+
+## Discovery Sources (SaaS branch)
+
+Combine 2+ sources for cross-verification.
+
+### Tier 1 — primary discovery
+
+- **Apollo**: firmographic + technographic + contact data. Good for building large initial lists.
+- **Clay**: waterfall enrichment, custom scoring, multi-source merges. Best for high-quality smaller lists.
+- **ZoomInfo**: enterprise-grade firmographic + intent signals. Expensive; mid-market+.
+- **LinkedIn Sales Navigator**: decision-maker mapping. Use manually, never bulk scrape.
+
+### Tier 2 — technographic / growth signals
+
+- **BuiltWith**: tech stack lookups, find sites using specific tools
+- **Wappalyzer**: free browser extension + API; lighter tech stack signal
+- **Crunchbase**: funding rounds, headcount, founders
+- **Pitchbook**: deeper investor data (enterprise/paid)
+- **ProductHunt**: recent launches, builder audience
+- **Hacker News / Show HN**: technical builders launching products
+
+### Tier 3 — buying signals
+
+- **Job boards** (LinkedIn Jobs, Indeed, AngelList): role openings as signals
+- **RB2B / Clearbit Reveal**: visitor identification (warm anonymous traffic)
+- **GitHub stars/forks of competitor or adjacent repos**: developer-level intent signal (see `tools/integrations/github.md` and the `github-prospects.js` CLI). Especially strong for dev-tool SaaS — a developer who starred `vercel/next.js` last week is in-market for adjacent Next.js infrastructure.
+- **Recent blog posts / changelog**: product direction signals
+- **G2 reviews mentioning competitor switches**: explicit dissatisfaction signal
+
+#### GitHub prospecting pattern (when audience is developers)
+
+For dev-tool SaaS, GitHub is one of the highest-quality discovery channels:
+
+1. Identify 3–5 "anchor" repos: your direct competitors, your category leader, complementary tools your buyer uses
+2. Pull stargazers (or forks for stronger intent) via `node tools/clis/github-prospects.js stargazers <owner/repo> --enrich --with-company --format csv`
+3. Filter to users with `company` set — these are the easiest to enrich downstream
+4. Pair with Apollo/Clay/Hunter to lookup email by name + company
+5. Validate with Truelist before adding to outreach list
+
+Tradeoffs: GitHub yields email for only ~5–20% of users directly. The strength is the signal quality — a stargazer of a niche dev tool is genuinely in-market in a way Apollo firmographics alone can't tell you.
+
+---
+
+## Qualification Checklist (SaaS branch)
+
+For each candidate, verify:
+
+- [ ] Industry vertical matches ICP
+- [ ] Company size (headcount) within range
+- [ ] Tech stack includes (or notably excludes) a target technology
+- [ ] Funding stage matches buyer maturity
+- [ ] At least one growth signal in last 90 days (funding, hiring, product velocity)
+- [ ] Decision-maker role exists at the company (named or inferable from job listings)
+- [ ] Email contact verifiable
+- [ ] No disqualifiers (closed, acquired-and-paused, layoffs, ICP miss)
+
+---
+
+## Output Columns (SaaS branch)
+
+Recommended CSV columns:
+
+```csv
+score,company,domain,industry,size_band,country,funding_stage,last_round_date,tech_stack_match,signal,signal_date,contact_name,contact_title,contact_email,email_status,linkedin_url,source_urls,why_prospect,confidence,verified_date,notes
+```
+
+For chat table, condense to: Score | Company | Industry | Size | Signal | Contact | Email status | Confidence.
+
+---
+
+## Top Outreach Targets Selection (SaaS)
+
+Prioritize for the top 3–5 hot leads:
+
+1. **Strongest signal recency** — funding 30 days ago beats funding 9 months ago
+2. **Tech stack match strength** — known integration partner beats inferred fit
+3. **Decision-maker named with verified email** — beats role-pattern-guessed email
+4. **Multi-source confidence** — both Apollo + Crunchbase agree beats one source
+
+Each top target gets a one-sentence outreach rationale that names the specific signal: "Raised Series B 30 days ago; hiring Head of RevOps; verified VP of Ops email."
+
+---
+
+## Common Mistakes (SaaS)
+
+1. **Buying lists from Apollo wholesale** without re-verifying email and re-checking firmographics. Stale data is the norm.
+2. **Treating tech stack data as 100% accurate**. BuiltWith and Wappalyzer miss things; Clay's waterfalls miss things. Cross-check.
+3. **Targeting Series C+ for early-stage SaaS sellers**. The buyer profile is wrong — too many procurement hoops, too much red tape.
+4. **Targeting Series Pre-Seed seed** for products requiring meaningful budget. They have neither budget nor evaluator bandwidth.
+5. **Ignoring intent data when it exists** (ZoomInfo Intent, 6sense, etc.) — pre-warm signals beat cold every time.

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -61,6 +61,10 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | audiencetap | SMS/Email | ✓ | - | - | - | [audiencetap.md](integrations/audiencetap.md) |
 | hunter | Email Outreach | ✓ | - | [✓](clis/hunter.js) | - | [hunter.md](integrations/hunter.md) |
 | snov | Email Outreach | ✓ | - | [✓](clis/snov.js) | - | [snov.md](integrations/snov.md) |
+| truelist | Email Verification | ✓ | ✓ | - | ✓ | [truelist.md](integrations/truelist.md) |
+| github | Developer Intent | ✓ | - | [✓](clis/github-prospects.js) | ✓ | [github.md](integrations/github.md) |
+| firecrawl | Site Scraping | ✓ | ✓ | - | ✓ | [firecrawl.md](integrations/firecrawl.md) |
+| browserbase | Site Scraping | ✓ | ✓ | - | ✓ | [browserbase.md](integrations/browserbase.md) |
 | lemlist | Email Outreach | ✓ | - | [✓](clis/lemlist.js) | - | [lemlist.md](integrations/lemlist.md) |
 | instantly | Email Outreach | ✓ | - | [✓](clis/instantly.js) | - | [instantly.md](integrations/instantly.md) |
 | google-ads | Ads | ✓ | ✓ | [✓](clis/google-ads.js) | ✓ | [google-ads.md](integrations/google-ads.md) |
@@ -310,6 +314,37 @@ Company and person data enrichment for sales and marketing.
 | **clay** | Waterfall enrichment, outbound | 75+ data providers |
 
 **Agent recommendation**: Clearbit for enrichment. Apollo for prospecting and outbound. ZoomInfo for enterprise B2B data with intent signals. Clay for waterfall enrichment across multiple providers.
+
+### Email Verification
+
+Pre-outreach email deliverability validation.
+
+| Tool | Best For | Notes |
+|------|----------|-------|
+| **truelist** | Bulk + single email deliverability validation | Returns `email_state` (ok / email_invalid / risky / unknown / accept_all) + `email_sub_state`. MCP server + 7-language SDKs available. |
+
+**Agent recommendation**: Truelist for any prospect list before outreach — Apollo/ZoomInfo/Hunter data accuracy is typically 60–80%, validation is non-negotiable to keep sender reputation healthy.
+
+### Developer Intent / GitHub
+
+Discovery channel for dev-tool SaaS prospecting via GitHub stargazers, forkers, and watchers.
+
+| Tool | Best For | Notes |
+|------|----------|-------|
+| **github** | Stargazers / forks / watchers of competitor or adjacent repos | Public API; pair with Apollo/Clay/Hunter for email enrichment |
+
+**Agent recommendation**: Use `github-prospects.js` CLI to pull stargazers/forks of 3–5 anchor repos (competitors, category leaders, complementary tools). Filter to users with `company` field set, then enrich missing emails via Apollo or Hunter, then validate via Truelist before outreach.
+
+### Site Scraping (single-target only)
+
+Programmatic page extraction for **individual public business sites** — not for the platforms hosting prospects (Google Maps, LinkedIn, Yelp, Apollo, etc.).
+
+| Tool | Best For | Notes |
+|------|----------|-------|
+| **firecrawl** | Page → clean markdown / structured extraction | API + MCP; lower overhead for "just give me the content" |
+| **browserbase** | Real Chromium when rendering, interaction, or session state is required | API + MCP (Stagehand); use when Firecrawl can't handle the page |
+
+**Agent recommendation**: Default to Firecrawl for static-ish pages and structured extraction. Use Browserbase when the site requires JS rendering, form interaction, cookie consent, or auth — and when you want session recordings for debugging. **For both: discovery happens on platforms (manual browser); extraction happens on the prospect's own website URL.** Don't point either tool at LinkedIn, Google Maps, Yelp, or similar.
 
 ### Reviews
 

--- a/tools/clis/github-prospects.js
+++ b/tools/clis/github-prospects.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+const TOKEN = process.env.GITHUB_TOKEN
+const BASE_URL = 'https://api.github.com'
+const USER_AGENT = 'marketingskills-prospects-cli'
+
+function parseArgs(args) {
+  const result = { _: [] }
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2)
+      const next = args[i + 1]
+      if (next && !next.startsWith('--')) {
+        result[key] = next
+        i++
+      } else {
+        result[key] = true
+      }
+    } else {
+      result._.push(arg)
+    }
+  }
+  return result
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+async function api(path, opts = {}) {
+  const url = path.startsWith('http') ? path : `${BASE_URL}${path}`
+  const headers = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': USER_AGENT,
+  }
+  if (TOKEN) headers['Authorization'] = `Bearer ${TOKEN}`
+
+  if (args['dry-run']) {
+    return {
+      _dry_run: true,
+      method: 'GET',
+      url,
+      headers: { ...headers, Authorization: TOKEN ? 'Bearer ***' : undefined },
+    }
+  }
+
+  const res = await fetch(url, { headers })
+  const rateLimitRemaining = res.headers.get('x-ratelimit-remaining')
+  const rateLimitReset = res.headers.get('x-ratelimit-reset')
+
+  if (res.status === 401 || res.status === 403) {
+    const body = await res.text()
+    return {
+      error: `HTTP ${res.status}`,
+      hint: TOKEN
+        ? 'Token rejected — check GITHUB_TOKEN scopes (public_repo is enough for public data).'
+        : 'Set GITHUB_TOKEN env var to raise rate limit from 60/hr to 5000/hr.',
+      rate_limit_remaining: rateLimitRemaining,
+      rate_limit_reset_unix: rateLimitReset,
+      body,
+    }
+  }
+
+  if (!res.ok) {
+    const body = await res.text()
+    return { error: `HTTP ${res.status}`, body }
+  }
+
+  const data = await res.json()
+  const linkHeader = res.headers.get('link') || ''
+  const nextMatch = linkHeader.match(/<([^>]+)>;\s*rel="next"/)
+  return {
+    data,
+    next: nextMatch ? nextMatch[1] : null,
+    rate_limit_remaining: rateLimitRemaining,
+  }
+}
+
+async function paginate(path, { limit, perPage = 100 } = {}) {
+  const initial = path.includes('?') ? `${path}&per_page=${perPage}` : `${path}?per_page=${perPage}`
+  const all = []
+  let next = initial
+  let lastRate = null
+  while (next) {
+    const result = await api(next)
+    if (result._dry_run) return result
+    if (result.error) return result
+    lastRate = result.rate_limit_remaining
+    all.push(...result.data)
+    if (limit && all.length >= limit) {
+      return { data: all.slice(0, limit), rate_limit_remaining: lastRate, truncated: true }
+    }
+    next = result.next
+  }
+  return { data: all, rate_limit_remaining: lastRate, truncated: false }
+}
+
+async function getUser(login) {
+  const result = await api(`/users/${encodeURIComponent(login)}`)
+  if (result._dry_run || result.error) return result
+  return result.data
+}
+
+function matchesFilter(user, opts) {
+  if (!user) return false
+  if (opts['with-email'] && !user.email) return false
+  if (opts['with-company'] && !user.company) return false
+  if (opts['with-blog'] && !user.blog) return false
+  if (opts['type'] && user.type !== opts.type) return false
+  return true
+}
+
+async function enrichUsers(users, opts = {}, { concurrency = 5, targetCount } = {}) {
+  const matched = []
+  for (let i = 0; i < users.length; i += concurrency) {
+    const batch = users.slice(i, i + concurrency)
+    const profiles = await Promise.all(batch.map(u => getUser(u.login)))
+    for (const profile of profiles) {
+      if (!profile || profile.error) continue
+      if (matchesFilter(profile, opts)) matched.push(profile)
+    }
+    if (targetCount && matched.length >= targetCount) {
+      return matched.slice(0, targetCount)
+    }
+  }
+  return matched
+}
+
+function toCSV(users) {
+  const cols = ['login', 'name', 'company', 'email', 'blog', 'location', 'bio', 'twitter_username', 'public_repos', 'followers', 'created_at', 'html_url']
+  const escape = (v) => {
+    if (v === null || v === undefined) return ''
+    const s = String(v).replace(/\r?\n/g, ' ')
+    if (s.includes(',') || s.includes('"')) return `"${s.replace(/"/g, '""')}"`
+    return s
+  }
+  const lines = [cols.join(',')]
+  for (const u of users) {
+    lines.push(cols.map(c => escape(u[c])).join(','))
+  }
+  return lines.join('\n')
+}
+
+function parseRepo(input) {
+  if (!input) return null
+  const trimmed = input.replace(/^https?:\/\/github\.com\//, '').replace(/\.git$/, '').replace(/\/$/, '')
+  const parts = trimmed.split('/')
+  if (parts.length < 2) return null
+  return { owner: parts[0], repo: parts[1] }
+}
+
+async function main() {
+  const [command, ...rest] = args._
+
+  let result
+
+  switch (command) {
+    case 'stargazers': {
+      const repo = parseRepo(rest[0])
+      if (!repo) { result = { error: 'Usage: stargazers <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--format csv|json]' }; break }
+      const limit = args.limit ? parseInt(args.limit, 10) : undefined
+      const target = args.target ? parseInt(args.target, 10) : undefined
+      const page = await paginate(`/repos/${repo.owner}/${repo.repo}/stargazers`, { limit })
+      if (page._dry_run || page.error) { result = page; break }
+      let users = page.data
+      if (args.enrich || args['with-email'] || args['with-company'] || args['with-blog'] || args.type) {
+        users = await enrichUsers(users, args, { targetCount: target })
+      }
+      if (args.format === 'csv') {
+        console.log(toCSV(users))
+        return
+      }
+      result = { count: users.length, rate_limit_remaining: page.rate_limit_remaining, truncated: page.truncated, users }
+      break
+    }
+
+    case 'forks': {
+      const repo = parseRepo(rest[0])
+      if (!repo) { result = { error: 'Usage: forks <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--format csv|json]' }; break }
+      const limit = args.limit ? parseInt(args.limit, 10) : undefined
+      const target = args.target ? parseInt(args.target, 10) : undefined
+      const page = await paginate(`/repos/${repo.owner}/${repo.repo}/forks`, { limit })
+      if (page._dry_run || page.error) { result = page; break }
+      const forkOwners = page.data.map(f => f.owner)
+      let users = forkOwners
+      if (args.enrich || args['with-email'] || args['with-company'] || args['with-blog'] || args.type) {
+        users = await enrichUsers(forkOwners, args, { targetCount: target })
+      }
+      if (args.format === 'csv') {
+        console.log(toCSV(users))
+        return
+      }
+      result = { count: users.length, rate_limit_remaining: page.rate_limit_remaining, truncated: page.truncated, users }
+      break
+    }
+
+    case 'watchers': {
+      const repo = parseRepo(rest[0])
+      if (!repo) { result = { error: 'Usage: watchers <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--format csv|json]' }; break }
+      const limit = args.limit ? parseInt(args.limit, 10) : undefined
+      const target = args.target ? parseInt(args.target, 10) : undefined
+      const page = await paginate(`/repos/${repo.owner}/${repo.repo}/subscribers`, { limit })
+      if (page._dry_run || page.error) { result = page; break }
+      let users = page.data
+      if (args.enrich || args['with-email'] || args['with-company'] || args['with-blog'] || args.type) {
+        users = await enrichUsers(users, args, { targetCount: target })
+      }
+      if (args.format === 'csv') {
+        console.log(toCSV(users))
+        return
+      }
+      result = { count: users.length, rate_limit_remaining: page.rate_limit_remaining, truncated: page.truncated, users }
+      break
+    }
+
+    case 'user': {
+      const login = rest[0]
+      if (!login) { result = { error: 'Usage: user <username>' }; break }
+      result = await getUser(login)
+      break
+    }
+
+    case 'rate-limit': {
+      const res = await api('/rate_limit')
+      result = res._dry_run || res.error ? res : res.data
+      break
+    }
+
+    default:
+      result = {
+        error: 'Unknown command',
+        usage: {
+          stargazers: 'stargazers <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--type User|Organization] [--format csv|json]',
+          forks: 'forks <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--type User|Organization] [--format csv|json]',
+          watchers: 'watchers <owner/repo> [--limit N] [--target N] [--enrich] [--with-email] [--with-company] [--with-blog] [--format csv|json]',
+          user: 'user <username>',
+          'rate-limit': 'rate-limit',
+        },
+        notes: [
+          'Set GITHUB_TOKEN env var for 5000 req/hr (vs 60/hr unauthenticated).',
+          'Token needs only public_repo scope for public data; no scope is required to list public stargazers/forks.',
+          '--enrich fetches each users full profile (1 extra request per user). Use with --limit on large repos.',
+          '--with-email / --with-company / --with-blog imply --enrich.',
+          '--target N stops enrichment as soon as N users match the filters (saves API quota on restrictive filters).',
+          '--format csv outputs prospecting-ready CSV; default JSON.',
+          'Pair with Apollo, Clay, Hunter, or Truelist to fill in missing emails.',
+        ],
+      }
+  }
+
+  console.log(JSON.stringify(result, null, 2))
+}
+
+main().catch(err => {
+  console.error(JSON.stringify({ error: err.message }))
+  process.exit(1)
+})

--- a/tools/integrations/browserbase.md
+++ b/tools/integrations/browserbase.md
@@ -1,0 +1,111 @@
+# Browserbase
+
+Headless browser as a service. Spin up real Chromium browsers via API, drive them with Playwright/Puppeteer, get full session recordings. Useful when a target site requires JS rendering, user interaction, or session state that simple HTTP fetches can't handle.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API for session management |
+| MCP | ✓ | Official Browserbase MCP server (Stagehand) |
+| CLI | - | None official |
+| SDK | ✓ | Node, Python; drives Playwright/Puppeteer |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `x-bb-api-key: YOUR_API_KEY`
+- **Get key**: https://www.browserbase.com/settings
+- **Env vars**: `BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`
+- **Base URL**: `https://api.browserbase.com`
+
+## Core Operations
+
+### Create a browser session
+
+```bash
+POST https://api.browserbase.com/v1/sessions
+x-bb-api-key: YOUR_API_KEY
+
+{
+  "projectId": "YOUR_PROJECT_ID"
+}
+```
+
+Returns a session ID and a WebSocket URL (`connectUrl`) you connect to with Playwright or Puppeteer.
+
+### Connect with Playwright (Node)
+
+```js
+import { chromium } from 'playwright-core';
+import { Browserbase } from '@browserbasehq/sdk';
+
+const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
+const session = await bb.sessions.create({ projectId: process.env.BROWSERBASE_PROJECT_ID });
+
+const browser = await chromium.connectOverCDP(session.connectUrl);
+const page = await browser.newPage();
+await page.goto('https://joescoffeeshop.com');
+const html = await page.content();
+const title = await page.title();
+await browser.close();
+```
+
+### List session recordings
+
+```bash
+GET https://api.browserbase.com/v1/sessions/{sessionId}/logs
+```
+
+Useful for debugging when a scrape doesn't return what you expected — session recordings show exactly what the browser saw.
+
+### Stagehand (high-level AI-friendly wrapper)
+
+Browserbase ships [Stagehand](https://github.com/browserbase/stagehand), a Playwright wrapper with `act()`, `extract()`, and `observe()` methods that take natural-language instructions instead of CSS selectors. Stagehand also publishes an MCP server.
+
+```js
+import { Stagehand } from '@browserbasehq/stagehand';
+
+const stagehand = new Stagehand({ env: 'BROWSERBASE' });
+await stagehand.init();
+await stagehand.page.goto('https://joescoffeeshop.com');
+
+const contact = await stagehand.page.extract({
+  instruction: "Extract the business phone number, email, and street address",
+  schema: { phone: 'string', email: 'string', address: 'string' }
+});
+```
+
+## When to Use (over Firecrawl)
+
+- **Site requires user interaction** (cookie consent, age gate, click-through before content loads)
+- **Form submission** to access a quote/contact page
+- **Session state matters** (logged-in tools, multi-step flows)
+- **Complex JS rendering** that even Firecrawl's headless option struggles with
+- **Want full session recordings** for audit/debugging
+- **AI-driven scraping** via Stagehand's natural-language extraction
+
+For simple "scrape a page as markdown," **Firecrawl is lower-overhead**. Use Browserbase when you actually need the browser-as-a-service model.
+
+## When NOT to Use
+
+Same hard rules as Firecrawl. Browserbase gives you a more powerful browser, which means the temptation to bypass anti-scraping defenses is higher. Don't:
+
+- ✗ Bulk-scrape Google Maps / search results, LinkedIn, Yelp, or any platform whose ToS forbids it
+- ✗ Bypass CAPTCHAs, login walls, or bot protections
+- ✗ Auto-fill forms on platforms you don't have an account or legitimate access to
+
+**Use Browserbase for**: individual public business sites the user has a URL for, where rendering or interaction is required.
+
+## Pricing
+
+- Free tier: limited monthly minutes
+- Paid tiers scale by browser minutes + concurrency
+- Confirm at https://www.browserbase.com/pricing
+
+## Relevant Skills
+
+- prospecting (programmatic site visits for prospect enrichment)
+- competitor-profiling (when competitor sites need rendering or interaction)
+- cro (page audits that need real browser state)
+- analytics (testing tracking implementations end-to-end)

--- a/tools/integrations/firecrawl.md
+++ b/tools/integrations/firecrawl.md
@@ -1,0 +1,144 @@
+# Firecrawl
+
+Web scraping API that turns single pages or full sites into clean LLM-ready markdown. Handles JS rendering, anti-bot defenses, and proxy rotation so you can extract structured data from individual public business sites.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API + Python/Node SDKs |
+| MCP | ✓ | Official Firecrawl MCP server |
+| CLI | - | None official |
+| SDK | ✓ | Node, Python, Go, Rust |
+
+## Authentication
+
+- **Type**: API Key
+- **Header**: `Authorization: Bearer fc-YOUR_API_KEY`
+- **Get key**: https://www.firecrawl.dev/app/api-keys
+- **Env var**: `FIRECRAWL_API_KEY`
+- **Base URL**: `https://api.firecrawl.dev`
+
+## Core Operations
+
+### Scrape a single page
+
+```bash
+POST https://api.firecrawl.dev/v1/scrape
+Authorization: Bearer fc-YOUR_API_KEY
+
+{
+  "url": "https://joescoffeeshop.com",
+  "formats": ["markdown", "html"]
+}
+```
+
+Returns the page as clean markdown (LLM-ready, no nav cruft) plus optional raw HTML.
+
+### Map a site (discover all URLs)
+
+```bash
+POST https://api.firecrawl.dev/v1/map
+
+{
+  "url": "https://example.com",
+  "limit": 100
+}
+```
+
+Returns a list of URLs found on the site. Use this to identify key pages (`/pricing`, `/about`, `/contact`, `/team`) before scraping individually.
+
+### Crawl multiple pages
+
+```bash
+POST https://api.firecrawl.dev/v1/crawl
+
+{
+  "url": "https://example.com",
+  "limit": 20,
+  "scrapeOptions": {
+    "formats": ["markdown"]
+  }
+}
+```
+
+Crawls multiple pages from a single site. **Use sparingly** — costs scale with pages. Set `limit` and `includePaths` to target specific URL patterns.
+
+### Extract structured data
+
+```bash
+POST https://api.firecrawl.dev/v1/extract
+
+{
+  "urls": ["https://joescoffeeshop.com"],
+  "schema": {
+    "phone": "string",
+    "address": "string",
+    "hours": "string",
+    "email": "string"
+  }
+}
+```
+
+Returns data matching the schema — useful when you want consistent fields across many sites rather than raw markdown.
+
+### Search the web
+
+```bash
+POST https://api.firecrawl.dev/v1/search
+
+{
+  "query": "\"Joe's Coffee Shop\" Boulder Colorado",
+  "limit": 10
+}
+```
+
+Web search + scrape of top results. Useful for cross-source verification (find a business's official site when you only have a name + location).
+
+## MCP Tools (when used via MCP server)
+
+| Tool | Purpose |
+|------|---------|
+| `firecrawl_scrape` | Single-page extraction |
+| `firecrawl_map` | URL discovery on a site |
+| `firecrawl_crawl` | Multi-page crawl |
+| `firecrawl_extract` | Schema-driven structured data |
+| `firecrawl_search` | Web search + scrape |
+
+## When to Use
+
+- **Local SMB prospecting**: verify a business's website status (live, weak, missing) at the URL level after manual Maps/Yelp discovery
+- **Single-target enrichment**: pull contact info, hours, services from a business's own site
+- **Competitor research**: scrape competitor pricing, features, customer pages (this is the primary use in `competitor-profiling` skill)
+- **Programmatic page extraction**: when you need many sites' homepages or about pages in a consistent format
+- **JS-heavy sites**: when the page won't render with a simple `curl` because content loads after page load
+
+## When NOT to Use
+
+**Critical — do not use Firecrawl to scrape platforms hosting prospects:**
+
+- ✗ **Google Maps / Google search results** — Google ToS prohibits bulk extraction
+- ✗ **LinkedIn** — explicit ToS violation, will get scraper accounts banned and risks legal exposure
+- ✗ **Yelp** — ToS prohibits commercial scraping
+- ✗ **Apollo / ZoomInfo / Clearbit listings** — their ToS prohibits using competing data extracts
+- ✗ **Any platform you don't have a legitimate basis to extract from at scale**
+
+**Use Firecrawl for**: the *business's own website* (which you found via manual discovery on those platforms). That's the line — discovery happens on platforms, extraction happens on individual public business sites.
+
+## Pricing
+
+- Free tier: limited monthly credits
+- Paid tiers scale by request volume + concurrency
+- Confirm at https://www.firecrawl.dev/pricing
+
+## Rate Limits
+
+- Default: tier-dependent (typically 5–20 concurrent requests on paid plans)
+- Per-page cost varies by content type and rendering needs
+
+## Relevant Skills
+
+- prospecting (site enrichment for individual business URLs)
+- competitor-profiling (primary use: full-site competitor analysis)
+- ai-seo (scrape your own content for AI search optimization)
+- content-strategy (scrape industry sites for content gap analysis)

--- a/tools/integrations/github.md
+++ b/tools/integrations/github.md
@@ -1,0 +1,182 @@
+# GitHub
+
+GitHub REST API for prospecting use cases: listing users who star, fork, or watch a repo as a high-quality developer-intent signal.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Public REST API, well-documented |
+| MCP | - | Several community MCP servers exist; not bundled here |
+| CLI | ✓ | [github-prospects.js](../clis/github-prospects.js) — stargazers, forks, watchers, user, rate-limit |
+| SDK | ✓ | Official Octokit (JS, Python, Ruby, .NET, Go) |
+
+## Authentication
+
+- **Type**: Personal Access Token (PAT) or Fine-Grained PAT
+- **Header**: `Authorization: Bearer {token}`
+- **Get token**: https://github.com/settings/tokens
+- **Scopes for prospecting**:
+  - Public data (stargazers, forks, public profiles): **no scope required** with a token, or unauthenticated
+  - Public repo metadata: `public_repo` scope
+- **Env var**: `GITHUB_TOKEN`
+
+### Rate limits
+
+| Auth | Limit | When you hit it |
+|------|-------|-----------------|
+| Unauthenticated | 60 req/hr | Fine for one-off small lookups |
+| Authenticated PAT | 5,000 req/hr | Sufficient for a 10K-star repo pull in one hour |
+| GitHub App | 5,000–15,000 req/hr | For high-volume use |
+
+A 1,000-star repo with full enrichment (1 list call + 1 profile call per user) = ~1,011 requests. Always set a token.
+
+## Common Agent Operations
+
+### List stargazers (users who starred a repo)
+
+```bash
+GET https://api.github.com/repos/{owner}/{repo}/stargazers?per_page=100&page=1
+
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+Authorization: Bearer {token}
+```
+
+Pagination via `Link` header (`rel="next"`, `rel="last"`). Default 30 per page, max 100.
+
+Returns array of user objects with `login`, `id`, `html_url`, `type` (User or Organization). Full profile fields (email, company, blog, bio, location) require a follow-up call per user.
+
+### List forks (gives fork owner profiles)
+
+```bash
+GET https://api.github.com/repos/{owner}/{repo}/forks?per_page=100&page=1
+```
+
+Each fork object includes the `owner` (the user/org that forked). Forks are a stronger signal than stars — they imply intent to modify, not just bookmark.
+
+### List watchers (subscribers)
+
+```bash
+GET https://api.github.com/repos/{owner}/{repo}/subscribers?per_page=100&page=1
+```
+
+GitHub's "watch" → API's "subscribers". Smaller pool than stargazers but signals deeper engagement.
+
+### Get user profile (enrichment)
+
+```bash
+GET https://api.github.com/users/{username}
+```
+
+Returns: `name`, `company`, `blog`, `email` (if public), `bio`, `twitter_username`, `location`, `public_repos`, `followers`, `created_at`, `hireable`.
+
+**Key fields for prospecting**:
+- `email`: only ~5–20% of users publish this. Always nullable.
+- `company`: many users include `@org` syntax — strip the `@` for plain company name.
+- `blog`: often a personal website where contact info is published.
+- `twitter_username` / `bio`: useful for cross-channel research.
+
+### Check rate limit
+
+```bash
+GET https://api.github.com/rate_limit
+```
+
+## Prospecting Workflows
+
+### Workflow 1 — Stargazers of a competitor or adjacent tool
+
+```bash
+# 100 stargazers, enrich each one, only keep those with email or company set
+node tools/clis/github-prospects.js stargazers vercel/next.js \
+  --limit 100 --enrich --format csv > nextjs-stars.csv
+```
+
+Filter the CSV in your spreadsheet by `company` set OR `email` set OR `blog` set. Hand off to Apollo/Clay/Hunter to enrich the rest with email-by-name+company.
+
+### Workflow 2 — Forks of your own repo (warm intent)
+
+People who fork your repo have already shown direct interest. High-conversion outreach prospects.
+
+```bash
+node tools/clis/github-prospects.js forks yourorg/yourrepo \
+  --enrich --with-email --format csv > my-fork-prospects.csv
+```
+
+### Workflow 3 — Watchers of a category-defining repo
+
+Watchers are smaller in number but higher in intent — they're tracking changes, not just bookmarking.
+
+```bash
+node tools/clis/github-prospects.js watchers tldraw/tldraw \
+  --enrich --with-company --format csv > tldraw-watchers.csv
+```
+
+## CLI Reference
+
+```bash
+# Stargazers
+node tools/clis/github-prospects.js stargazers <owner/repo> \
+  [--limit N] [--enrich] [--with-email] [--with-company] \
+  [--with-blog] [--type User|Organization] [--format csv|json]
+
+# Forks
+node tools/clis/github-prospects.js forks <owner/repo> [...same flags]
+
+# Watchers (subscribers in API terms)
+node tools/clis/github-prospects.js watchers <owner/repo> [...same flags]
+
+# Single user lookup
+node tools/clis/github-prospects.js user <username>
+
+# Check rate limit
+node tools/clis/github-prospects.js rate-limit
+```
+
+**Flags**:
+- `--limit N`: cap total results pulled from the list endpoint
+- `--target N`: when filtering with `--with-*`, stop enriching as soon as N users match (saves quota on restrictive filters)
+- `--enrich`: fetch full profile per user (1 extra request each)
+- `--with-email` / `--with-company` / `--with-blog`: filter to users with these fields set (implies `--enrich`)
+- `--type User|Organization`: filter by account type
+- `--format csv`: output prospecting-ready CSV; default is JSON
+- `--dry-run`: preview the request without sending
+
+## When to Use
+
+- **SaaS prospecting** (primary use case): stargazers of a competitor, complement, or category-defining repo as in-market developer signal
+- **Open-source product marketing**: see who's forking or watching your own repo for warm outreach
+- **Developer-tool ICP discovery**: stargazers of `next.js`, `prisma`, `tailwindcss`, etc., signal a Next.js / Prisma / Tailwind developer
+- **Trigger event monitoring**: a recent fork of a competitor's repo often signals dissatisfaction or active evaluation
+
+## When NOT to Use
+
+- **Email is your only signal you need** — GitHub yields email for only ~5–20% of users. Pair with Apollo, Clay, or Hunter for enrichment from name + company.
+- **Hyper-broad lists** — a repo with 100K+ stars is mostly noise. Smaller, more specific repos (5K–25K stars) give higher-signal lists.
+- **You don't have a way to handle high-volume LinkedIn lookup downstream** — most enrichment from GitHub username goes through LinkedIn Sales Nav manually.
+
+## Compliance Notes
+
+- **GitHub data is public** — no ToS issue with reading the API. The ToS prohibits abusive scraping (bypassing rate limits, mass account creation), not legitimate API usage.
+- **Personal emails published on GitHub** — users opt in to publishing their email. Treat as business contact when paired with company/blog signals; respect GDPR/CAN-SPAM for the downstream send.
+- **Source URL lineage** — for every prospect added from GitHub, capture `html_url` (their profile URL) and the source repo. Required for GDPR DSAR defense.
+- **Cool-down between large pulls** — even at 5,000 req/hr, don't burst-fingerprint. Pagination is naturally paced; respect `X-RateLimit-Remaining` headers.
+
+## Pairing with Other Tools
+
+Typical GitHub prospecting pipeline:
+
+1. Pull stargazers/forkers via this CLI
+2. Filter to users with company set (or other signal)
+3. **Enrich missing emails** via Apollo / Clay / Hunter (lookup by name + company domain)
+4. **Validate emails** via Truelist before adding to outreach list
+5. **Hand off** to cold-email skill for outreach
+
+See `skills/prospecting/references/saas-prospecting.md` and `data-sources.md` for the full prospecting framework.
+
+## Relevant Skills
+
+- prospecting (primary use case)
+- cold-email (downstream outreach)
+- competitor-profiling (deeper account-level research on individual stargazers worth pursuing)

--- a/tools/integrations/truelist.md
+++ b/tools/integrations/truelist.md
@@ -1,0 +1,184 @@
+# Truelist
+
+Email verification and deliverability validation. Validates single emails synchronously or bulk lists asynchronously. Returns an `email_state` + `email_sub_state` plus rich metadata (domain, MX record, suggested correction, disposable/role classification).
+
+Spec source: [Truelist-Labs/truelist-openapi](https://github.com/Truelist-Labs/truelist-openapi) (OpenAPI 3.1).
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API, OpenAPI 3.1 spec |
+| MCP | ✓ | Official [truelist-mcp](https://github.com/Truelist-Labs/truelist-mcp) server (Claude, Cursor, VS Code) |
+| CLI | ✓ | Official Go [truelist-cli](https://github.com/Truelist-Labs/truelist-cli) |
+| SDK | ✓ | Official: Node/TypeScript, Python, Ruby, PHP, Go, Java, C#/.NET. Framework integrations: Django, Laravel, Next.js, Rails, React, Svelte, Vue, WordPress |
+
+## Authentication
+
+- **Type**: Bearer token (API key)
+- **Header**: `Authorization: Bearer YOUR_API_KEY`
+- **Get key**: https://truelist.io/settings/api-keys
+- **Base URL**: `https://api.truelist.io`
+
+## Common Agent Operations
+
+### Verify a single email (synchronous)
+
+```bash
+POST https://api.truelist.io/api/v1/verify_inline?email=user@example.com
+Authorization: Bearer YOUR_API_KEY
+```
+
+No request body — the email is a query parameter. Returns a single-element `emails` array with verification fields:
+
+```json
+{
+  "emails": [
+    {
+      "address": "user@example.com",
+      "domain": "example.com",
+      "canonical": "user@example.com",
+      "mx_record": null,
+      "first_name": null,
+      "last_name": null,
+      "email_state": "ok",
+      "email_sub_state": "email_ok",
+      "verified_at": "2026-02-21T10:39:12.570Z",
+      "did_you_mean": null
+    }
+  ]
+}
+```
+
+### Bulk verification (asynchronous)
+
+```bash
+POST https://api.truelist.io/api/v1/verify
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+
+{
+  "emails": [
+    "user1@example.com",
+    "user2@example.com"
+  ]
+}
+```
+
+Processes the list in the background. The response acknowledges submission; results are available via the dashboard, the Truelist UI's CSV download, or via integrations (Mailchimp, Klaviyo, HubSpot, Zapier, Make, n8n, etc.).
+
+For large lists, the dashboard's CSV upload + download flow is typically the lowest-friction path.
+
+### Get account information
+
+```bash
+GET https://api.truelist.io/me
+Authorization: Bearer YOUR_API_KEY
+```
+
+Returns email, name, UUID, time zone, admin role, API keys, and account plan info.
+
+## Response Fields (per email)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | string | The email address validated |
+| `domain` | string | The domain part of the address |
+| `canonical` | string | Canonical form of the address |
+| `mx_record` | string \| null | MX record for the domain |
+| `first_name` | string \| null | First name if detected |
+| `last_name` | string \| null | Last name if detected |
+| `email_state` | enum | Overall validation verdict (see below) |
+| `email_sub_state` | enum | More specific reason (see below) |
+| `verified_at` | datetime (ISO 8601) | When verification ran |
+| `did_you_mean` | string \| null | Suggested correction for typos |
+
+## `email_state` values
+
+| State | Meaning | What to do |
+|-------|---------|-----------|
+| `ok` | The email address is deliverable. | Include in outreach |
+| `email_invalid` | The email address is not deliverable. | Exclude — would bounce |
+| `risky` | May be deliverable but carries risk (role address, disposable, etc.) | Include cautiously, lower priority |
+| `unknown` | Deliverability could not be determined (timeout/connection). | Skip or re-verify with Thorough strategy |
+| `accept_all` | The mail server accepts all addresses (catch-all domain) | Include cautiously — can't confirm specific mailbox |
+
+## `email_sub_state` values
+
+| Sub-state | Meaning |
+|-----------|---------|
+| `email_ok` | Passed all checks |
+| `is_disposable` | Disposable / temporary provider (e.g., 10minutemail) |
+| `is_role` | Role-based address (info@, sales@, admin@) |
+| `unknown_error` | Sub-state could not be determined |
+| `failed_smtp_check` | SMTP check failed |
+
+Pair the two: `email_state: ok` + `email_sub_state: is_role` means "deliverable but a role inbox," whereas `email_state: email_invalid` + `email_sub_state: failed_smtp_check` means "doesn't exist."
+
+## Rate Limits
+
+| Endpoint | Limit |
+|----------|-------|
+| `/api/v1/verify_inline` | 10 requests/second |
+| `/api/v1/verify` | 10 requests/second |
+| `/me` | 10 requests/second |
+
+A 429 is returned on rate-limit exceed. Note: the per-email validation rate is separate and depends on your plan.
+
+## Error Responses
+
+| Code | Meaning |
+|------|---------|
+| 401 | Unauthorized — API key missing, invalid, or expired |
+| 429 | Rate limit exceeded |
+| 500 | Server error |
+
+All error bodies follow `{"error": "<human-readable message>"}`.
+
+## When to Use
+
+- **Before adding contacts to any cold outreach list** — non-negotiable safety step. Apollo/ZoomInfo/Hunter data accuracy is typically 60–80%; Truelist catches the rest.
+- **Real-time form validation** — block disposable / typo'd emails at signup. Use the inline endpoint (or the [form validation widget](https://truelist.io/docs/form-validation-widget)).
+- **Periodic list hygiene** — re-verify your active list quarterly to remove bounces before they hurt sender reputation.
+- **Pre-import validation** on email platform imports (Mailchimp, Klaviyo, HubSpot, etc.) — direct integrations exist for most.
+- **AI agent workflows** via the official MCP server for Claude, Cursor, and VS Code.
+
+## Why This Step is Non-Negotiable
+
+Cold email reputation is built over months and destroyed in days. ISPs (Gmail, Outlook, etc.) track sender reputation through:
+
+- **Bounce rate** — bounces over 2% trigger throttling
+- **Spam complaints** — spam traps in unvalidated lists generate complaints
+- **Engagement** — sending to dead mailboxes hurts engagement metrics
+
+A single unvalidated send to a bought or scraped list can damage a domain's sending reputation for months.
+
+## Workflow Integration
+
+Typical prospecting flow:
+
+1. Build initial prospect list (Apollo, Clay, ZoomInfo, Hunter, GitHub stargazers, etc.)
+2. **For agent-driven workflows**: use the Truelist MCP server to validate inline as the agent builds the list
+3. **For programmatic workflows**: POST emails to `/api/v1/verify` for async bulk OR `/api/v1/verify_inline` for sync single
+4. **For one-offs**: CSV upload via dashboard, download annotated CSV
+5. Filter: keep `email_state: ok`, include `risky`/`accept_all` cautiously with a strategy, exclude `email_invalid`, re-verify `unknown`
+6. Hand cleaned list to outreach platform (Instantly, Lemlist, Outreach, etc.) — see [outreach.md](outreach.md), [instantly.md](instantly.md), [lemlist.md](lemlist.md)
+
+## Native Integrations (no API code required)
+
+For non-developer workflows, Truelist has direct integrations:
+
+- **Email platforms**: Mailchimp, Klaviyo, HubSpot, ActiveCampaign, Brevo, Constant Contact, ConvertKit, Drip
+- **Automation**: Zapier, Make.com, n8n
+- **CRM / sales**: Salesforce, Go High Level, Clay.com
+- **Ecom**: BigCommerce
+- **AI / agents**: MCP server (Claude, Cursor, VS Code)
+
+See https://truelist.io/integrations for the current list.
+
+## Relevant Skills
+
+- prospecting (primary use case — validate before adding to outreach lists)
+- cold-email (downstream outreach against the validated list)
+- emails (transactional senders + subscriber list hygiene)
+- popups (real-time form validation on opt-in capture)


### PR DESCRIPTION
## Release v2.2.0 → main

Minor release — adds a new skill (`prospecting`), patches `ads`, fixes the long-standing `plugin.json` version drift, and rolls in community vendor PRs.

### Highlights

**New skill: `prospecting`** (1.0.0)
Build qualified prospect lists across three motions in one branch-aware skill:
- **SaaS** — tech-stack signals (BuiltWith), funding/hiring (Crunchbase), GitHub stargazers/forks as developer intent
- **B2B** — firmographic + trigger events via Apollo / ZoomInfo / LinkedIn Sales Nav
- **Local SMB** — browser-assisted Google Maps research → website-status classification

Shared 5-phase framework (ICP → discovery → qualify → score → output), compliance-forward (CAN-SPAM, GDPR, CASL, platform ToS), with output formats for chat tables and CSV.

**New CLI: `tools/clis/github-prospects.js`**
Zero-dep Node tool to pull GitHub stargazers, forkers, and watchers as developer-intent signal. Supports pagination, enrichment, filter-based early termination (`--target N`), and CSV output. Pairs with Apollo/Clay/Hunter/Truelist downstream.

**New integration docs**:
- `truelist.md` — email deliverability validation (aligned to the official OpenAPI 3.1 spec from [Truelist-Labs/truelist-openapi](https://github.com/Truelist-Labs/truelist-openapi))
- `github.md` — REST API for stargazers/forks/watchers prospecting
- `firecrawl.md` — single-target page scraping for prospect site enrichment
- `browserbase.md` — real Chromium for JS-heavy pages or interaction
- `sequenzy.md` — lifecycle email + sequences (community PR #312)

**ads** (2.0.0 → 2.0.1) — community PR #318
Added Google RSA Output Spec section enforcing platform limits: exactly 15 headlines × 30 chars, 4 descriptions × 90 chars, ad group structure labels, ≥8 negative keywords, ≥4 sitelinks/callouts, output ordering (negatives before RSAs so they don't get truncated), and a self-check before responding. Includes optional Brazilian medical (CFM) compliance rules when product context indicates that vertical.

**Plugin update path fixed (#323)**
`plugin.json` had been stuck at `1.9.0` across three releases (v2.0, v2.0.1, v2.1.0), silently breaking `claude plugin update`. `sync-skills.js` now auto-syncs `plugin.json` version to `marketplace.json` on every release. Closes #323.

**.gitignore** — community PR #317
Added skill install artifacts (`.agents/`, `.claude/`, `skills-lock.json`).

### Version bumps

- `marketplace.json`: 2.1.0 → 2.2.0
- `plugin.json`: 2.1.0 → 2.2.0 (auto-synced)
- `ads`: 2.0.0 → 2.0.1 (RSA spec patch)
- `prospecting`: new at 1.0.0
- Other 40 skills unchanged

**Total skills: 42**

### How to merge

Use **"Create a merge commit"** (not squash) so v2.2.0 ancestry is preserved on main.

## Test plan

- [x] `./validate-skills.sh` — 42/42 passing
- [x] `sync-skills.js` is a no-op
- [x] `plugin.json` version matches `marketplace.json` (2.2.0)
- [x] No `skills` array regression
- [x] All vendor PR files (sequenzy.md, ads RSA section, gitignore entries) preserved
