### PR TITLE
fix(marketing-plan): strip internal-skill refs + add evals + reverse cross-refs

### DIFF
--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -269,3 +269,4 @@ Don't ask all five at once — lead with #1 and #2, then follow up as needed.
 | Writing cold email using research on pain/trigger | `cold-email` |
 | Translating customer research into an ICP for outbound | `prospecting` |
 | Planning content based on discovered topics | `content-strategy` |
+| Rolling research into a comprehensive marketing plan | `marketing-plan` |

--- a/skills/marketing-ideas/SKILL.md
+++ b/skills/marketing-ideas/SKILL.md
@@ -160,6 +160,7 @@ When recommending ideas, provide for each:
 
 ## Related Skills
 
+- **marketing-plan**: When the user wants a comprehensive plan instead of standalone ideas. Section 12 of the plan cross-references all 139 ideas here against AARRR stages and client-specific status.
 - **programmatic-seo**: For scaling SEO content (#4)
 - **competitors**: For comparison pages (#11)
 - **emails**: For email marketing tactics

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: marketing-plan
-description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and the 17-section audit-marketing rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For scoring current state, see audit-marketing. For positioning before planning, see positioning. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
+description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and an embedded 17-section current-state audit rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For positioning and ICP context before planning, see product-marketing. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
 ---
 
 # Marketing Plan
 
-You are an expert marketing strategist operating at fCMO (fractional CMO) level. Your job is to produce a comprehensive, executable 12-month marketing plan for a specific client or company, structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to their actual budget, team, stage, and capabilities, and cross-referenced with the full marketing-ideas library and audit-marketing rubric.
+You are an expert marketing strategist operating at fCMO (fractional CMO) level. Your job is to produce a comprehensive, executable 12-month marketing plan for a specific client or company, structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to their actual budget, team, stage, and capabilities, and cross-referenced with the full marketing-ideas library and the embedded 17-section current-state audit rubric.
 
 The deliverable is a single Notion-paste-ready markdown document — the kind of strategy artifact a fractional CMO would present to founders. It must be specific to the client (not generic), exhaustive (covers every tactical surface area, not just what's prescribed), and operationally honest (reflects what their team can actually execute with their current stack and headcount).
 
@@ -17,7 +17,7 @@ Invoke this skill when:
 - A founder needs a 12-month marketing roadmap they can share with their team or investors
 - A team wants to consolidate scattered marketing work (SEO research, brand voice docs, audit findings, onboarding analyses) into a single coherent plan
 - The user explicitly asks for a "marketing plan," "growth plan," "GTM plan," "fCMO plan," "AARRR plan," or "90-day + 12-month marketing roadmap"
-- A previous `/audit-marketing` run produced findings that need to be sequenced into an action plan
+- An existing scored audit (from any prior current-state assessment) needs to be sequenced into an action plan
 
 **Do not use** when the user wants a tactical execution document for a single channel (use the channel-specific skill instead — `emails`, `ads`, `seo-audit`, `onboarding`, etc.), or when the user just wants marketing ideas without commitment to a plan (use `marketing-ideas`).
 
@@ -42,7 +42,7 @@ The full workflow lives in `references/methodology.md`. Quick summary:
 
 Read all available materials about the client. Pull data from any wired tools (Ahrefs, GA4 MCP, Stripe MCP, etc.). Conduct structured intake covering: client overview, ICP, current funnel state, funding state, team composition, marketing budget, channels currently active, what's already been done, what's in-flight, what's stuck, tooling stack. Save to `research.md`.
 
-If no `/audit-marketing` has been run on this client and useful, offer to run it before continuing.
+Use the embedded 17-section current-state rubric (`references/current-state-rubric.md`) as your scoring lens for Section 3 — score each section 0–5 against available materials.
 
 ### Phase 2 — REVIEW (walk through each of 13 sections interactively)
 
@@ -66,7 +66,7 @@ Full template lives in `references/plan-template.md`. The structure:
 
 1. **Executive summary** — 3 big bets, 90-day priorities, 12-month outcome. Written so it can be lifted into an investor or board update.
 2. **Strategic frame** — Category claim, ICP distilled, business-model logic, brand voice non-negotiables.
-3. **Current state** — Team, budget, what's done, what's in-flight, what's stuck. Scored against the 17-section `audit-marketing` rubric.
+3. **Current state** — Team, budget, what's done, what's in-flight, what's stuck. Scored against the embedded 17-section current-state rubric (`references/current-state-rubric.md`).
 4. **Acquisition** — How strangers become aware. Channels current + planned + skipped, 90-day and 12-month moves, skills + tools.
 5. **Activation** — How a new user has an experience that converts. Onboarding, first session, App Store / signup, paywall, lifecycle setup.
 6. **Retention** — How a converted user stays and deepens. Lifecycle flows, churn prevention, win-back, support-as-marketing.
@@ -94,19 +94,17 @@ Brand and content are **cross-cutting**, not their own AARRR stage — they serv
 
 ## The current-state rubric
 
-The plan's "Current State" section scores the client against the 17-section `audit-marketing` rubric. Full mapping in `references/current-state-rubric.md`.
+The plan's "Current State" section scores the client against the embedded 17-section rubric. Full rubric in `references/current-state-rubric.md` — it's the source of truth, not a derivative of any external skill.
 
-If the user has already run `/audit-marketing` on this client, ingest the scored output directly. If not, offer to run it before drafting Section 3, OR use the rubric as a lens against existing materials (faster, less rigorous — useful when client provides rich context but a formal audit hasn't happened).
+If the user already has a separately scored audit, ingest those scores directly into Section 3. Otherwise, score from available materials using the rubric as your lens — mark "scored from materials" in the section header so the team can push back where they have better data.
 
 ## Cross-references — skills this plan integrates with
 
-Some referenced skills live in this `marketingskills` repo; others live in adjacent Claude Code marketplaces (notably `cf-skills` for `audit-marketing` and `positioning`). The plan still works without external skills — it falls back to using the embedded rubric as a lens (see `references/current-state-rubric.md`).
+1. **`marketing-ideas`** — 139 proven marketing tactics. Section 12 of the plan cross-references every one to AARRR + client status. Detail in `references/idea-cross-reference.md`.
+2. **`product-marketing`** — Sets up the foundational `.agents/product-marketing.md` context file (positioning, ICP, voice). Read this first; Section 2 (Strategic frame) builds on it.
+3. **AARRR-stage-specific skills** — `onboarding`, `signup`, `emails`, `referrals`, `pricing`, etc. The "Marketing operations stack" (Section 11) maps these to AARRR stages.
 
-1. **`marketing-ideas`** *(this repo)* — 139 proven marketing tactics. Section 12 of the plan cross-references every one to AARRR + client status. Detail in `references/idea-cross-reference.md`.
-2. **`audit-marketing`** *(external — `cf-skills` repo)* — 17-section scored rubric. Section 3 uses this as the scoring lens; falls back to lens-only mode if the skill isn't installed.
-3. **AARRR-stage-specific skills** *(mostly this repo)* — `onboarding`, `signup`, `emails`, `referrals`, `pricing`, etc. The "Marketing operations stack" (Section 11) maps these to AARRR stages.
-
-The plan is **opinionated about which skills serve which stages.** Full mapping in `references/ops-stack-mapping.md` (which also lists optional external skills and substitutions).
+The plan is **opinionated about which skills serve which stages.** Full mapping in `references/ops-stack-mapping.md`.
 
 ## The marketing operations stack
 
@@ -204,10 +202,9 @@ The full schema for `progress.md` and the resumption decision tree live in `refe
 
 ## Related skills
 
-- **`audit-marketing`** — Run before planning to score current state across 17 sections. Output feeds Section 3 of the plan.
-- **`positioning`** — Run if positioning is unclear before planning. Output feeds Section 2.
+- **`product-marketing`** — Run first. Captures positioning, ICP, voice in `.agents/product-marketing.md` so every section of the plan references the same foundation.
 - **`marketing-ideas`** — Source of the 139 tactics in Section 12.
-- **`product-marketing`** — Sets up the client context file used at intake.
+- **`customer-research`** — Deepens the ICP and voice-of-customer inputs that feed Section 2 (Strategic frame).
 - **`onboarding`** — Deep work on Section 5 (Activation).
 - **`emails`** — Deep work on Section 6 (Retention) + onboarding emails in Section 5.
 - **`referrals`** — Deep work on Section 7 (Referral).

--- a/skills/marketing-plan/evals/evals.json
+++ b/skills/marketing-plan/evals/evals.json
@@ -1,0 +1,96 @@
+{
+  "skill_name": "marketing-plan",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I'm starting a fractional CMO engagement with a Series A B2B SaaS doing $2M ARR, 12-person team with 1 marketer, $20K/month marketing budget. They want a marketing plan we can share with the team and the board. Build it.",
+      "expected_output": "Should check for product-marketing.md first. Should ask for client name or use a slug. Should walk through three-phase workflow (INIT → REVIEW → FINALIZE), starting with intake covering funding state, team, budget, channels, what's done, in-flight, tooling stack. Should produce a 13-section AARRR-structured plan: executive summary, strategic frame, current state (scored against the embedded 17-section rubric), Acquisition, Activation, Retention, Referral, Revenue, 90-day roadmap with owner-assigned moves, 12-month outlook with funding-stage capability unlocks, marketing operations stack mapping skills + MCPs to AARRR stages, tactical idea bank cross-referencing all 139 marketing-ideas to AARRR + client-specific status, measurement framework with north-star + leading indicators + RACI + open decisions. Should be ~8–12K words, Notion-paste-ready. Should be specific to the client (their budget, team, channels), not generic.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Asks for client name or uses a slug",
+        "Walks through INIT phase with structured intake",
+        "Produces 13-section plan structured by AARRR",
+        "Section 3 scores against the embedded 17-section rubric",
+        "Section 9 (90-day roadmap) has owner-assigned moves, not just actions",
+        "Section 10 names funding-stage capability unlocks explicitly",
+        "Section 11 maps marketing skills + MCPs to each AARRR stage",
+        "Section 12 cross-references all 139 marketing-ideas with client-specific status",
+        "Output is Notion-paste-ready markdown",
+        "Plan is specific to the client (their budget, team, current channels), not generic"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "We're pre-seed bootstrapped, $0 paid marketing budget, 4-person team building a D2C consumer app. Founder wants a 90-day plan + 12-month roadmap they can show investors during the upcoming raise. The product is in beta.",
+      "expected_output": "Should recognize Tier 1 funding profile (pre-seed) and skip paid acquisition recommendations until budget unlocks. Should lean Acquisition heavy on organic + lifecycle + ambassador moves. Should explicitly map what unlocks when seed closes (paid test budget $5–15K/mo, first marketing hire, etc.). Should respect that the product is in beta and account for activation/throttling gates. Should include the AARRR diagnostic — likely binding constraint at this stage is Activation (onboarding) and Referral. Plan must be investor-friendly: exec summary can be lifted into an update.",
+      "assertions": [
+        "Recognizes pre-seed tier and uses Tier 1 budget profile",
+        "Skips paid acquisition recommendations until budget unlocks",
+        "Leans Acquisition on organic + lifecycle + ambassador",
+        "Names what unlocks when seed closes",
+        "Accounts for product being in beta",
+        "Identifies binding-constraint AARRR stage (likely Activation or Referral)",
+        "Executive summary can be lifted into an investor update",
+        "Plan is operationally honest — doesn't pretend paid budget exists"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "we have an audit already done — can you take that and turn it into a real plan",
+      "expected_output": "Should ask for the audit output (file path or paste). Should recognize that current-state scoring already exists and ingest it directly into Section 3 — don't re-score. Should note scoring date in case material has shifted since. Should proceed with full 13-section plan generation using audit findings to inform 90-day roadmap and AARRR sections (gaps from audit become moves in the plan).",
+      "assertions": [
+        "Asks for the audit output",
+        "Ingests prior audit scoring directly into Section 3",
+        "Does not re-score what's already been scored",
+        "Notes the scoring date and flags any shifted material",
+        "Uses audit gaps to inform 90-day roadmap and AARRR section moves",
+        "Still produces a full 13-section plan, not just Section 3"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "/marketing-plan acme-saas — pick up where we left off",
+      "expected_output": "Should read ~/marketing-plans/acme-saas/progress.md to determine state machine phase. Should resume from the next unfinished section in REVIEW phase, or transition to FINALIZE if all sections approved. Should NOT silently restart from scratch. If progress.md is missing or shows 'finalized', should ask: revise as v{N+1}, start fresh, or re-open a section.",
+      "assertions": [
+        "Reads ~/marketing-plans/acme-saas/progress.md",
+        "Resumes from next unfinished section based on state machine",
+        "Does not silently restart from scratch",
+        "Handles finalized state by asking user how to proceed (revise / fresh / re-open)",
+        "Saves each newly confirmed section to the progress file"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "I need a plan for a hybrid hardware+software wellness company. They sell a physical product and a subscription app. Series A, $100K/month marketing budget, 8-person team including a marketing lead.",
+      "expected_output": "Should recognize hybrid hardware+software archetype and consult references/client-types.md for archetype-specific emphases. Acquisition leans PR + retail + Amazon + Shopify SEO + paid. Activation = unboxing + setup + first session + paywall. Retention = lifecycle + community. Referral = gifting + reviews. Revenue = blended LTV (hardware + subscription + accessories). Should recognize Series A tier and recommend appropriate paid spend. Should include cross-cutting brand + customer-research moves. Idea bank should skip ideas that conflict with premium positioning or hardware constraints.",
+      "assertions": [
+        "Recognizes hybrid hardware+software archetype",
+        "Acquisition leans on PR, retail, Amazon, Shopify SEO, paid",
+        "Activation covers unboxing, setup, first session, paywall",
+        "Retention covers lifecycle, community",
+        "Referral covers gifting, reviews",
+        "Revenue covers blended LTV with hardware + subscription + accessories",
+        "Recognizes Series A tier in budget recommendations",
+        "Idea bank skips ideas that conflict with brand fit, with explicit rationale"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Just give me a quick marketing plan. Don't make it long.",
+      "expected_output": "Should resist defaulting to a short plan. Should explain that a marketing-plan is the comprehensive fCMO-deliverable artifact (~10K words) and that for a single-channel quick plan, the channel-specific skill is the right tool (emails, ads, seo-audit, etc.). Should offer alternatives: (a) full marketing-plan as designed, or (b) point to a specific skill for the user's actual need. Should NOT silently produce a stripped-down 3K-word plan that misses the ops stack or the idea bank.",
+      "assertions": [
+        "Resists short-plan request and explains why",
+        "Names marketing-plan as the comprehensive fCMO artifact",
+        "Recommends channel-specific skills for single-channel quick plans",
+        "Offers alternatives clearly",
+        "Does not silently produce a stripped-down plan"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/marketing-plan/references/client-types.md
+++ b/skills/marketing-plan/references/client-types.md
@@ -294,7 +294,7 @@ The 13-section plan structure stays consistent across client types. What changes
 
 ### Skills emphasis
 - Light traditional marketing
-- Heavy `positioning`, `sales-enablement`, `pricing`
+- Heavy `product-marketing`, `sales-enablement`, `pricing`
 - `cold-email` to specific researchers / practitioners
 - PR + investor marketing
 

--- a/skills/marketing-plan/references/current-state-rubric.md
+++ b/skills/marketing-plan/references/current-state-rubric.md
@@ -1,15 +1,14 @@
 # Current State Rubric — 17-Section Scoring Lens
 
-The `audit-marketing` skill (in the `cf-skills` repo, `conversionfactory/cf-skills`) scores a company against 17 sections. This rubric is the scoring lens for Section 3 of every marketing plan — whether or not a formal audit has been run.
+This 17-section rubric is the source of truth for Section 3 ("Current State") of every marketing plan. Score each section 0–5 from available materials, then write a 2–4 sentence "shape interpretation" that names where strengths and gaps cluster.
 
-## The two paths
+## How to score
 
-**Path A — Formal audit run.** If `/audit-marketing {client-domain}` has been run, paste the scored output directly. Each of the 17 sections has a score (0–5) and findings. Section 3 of the plan uses this verbatim, with one addition: an interpretive "shape" paragraph after the table.
+**From rich materials.** When the team has shared decks, prior content audits, a brand voice doc, kickoff transcript, app store and analytics snapshots — score each section from those artifacts. Mark "scored from materials" in the section heading so the team can push back where they have better data.
 
-**Path B — Lens used, not formal audit.** If no audit has been run (common when fCMO has rich context from kickoff but a formal audit hasn't happened), use the rubric as a *lens* — score each of the 17 sections from available materials, mark "lens used, not formal audit" in the heading. Less rigorous but faster.
+**From a separately scored audit.** If the team has already run a scored current-state assessment (in any format), ingest those scores directly. Don't redo the work — note the date the rubric was scored and flag any sections where material has shifted since.
 
-When to choose Path A: client engagement is starting from scratch, materials are sparse, founder wants a scored deliverable.
-When to choose Path B: rich materials exist, fCMO already has 30+ pages of context, time is short.
+Either way, the output is the same: a 17-row scored table, a total out of 85, and a shape paragraph.
 
 ## The 17 sections (scored 0–5 each)
 
@@ -249,8 +248,8 @@ Some sections are easier to score from outside than others. Subjectivity tier:
 
 For subjective sections, write the rationale into the "Note" column so the team can push back if they disagree.
 
-## When the audit-marketing skill version is run
+## When a prior scored audit exists
 
-If the user runs `/audit-marketing {client-domain}` before or during the plan, use that output verbatim — don't redo the scoring. The Plan skill respects audit-marketing's outputs as the ground truth.
+If the team already has scored output from any current-state assessment, ingest those scores directly — don't redo the work. Treat that prior scoring as the ground truth for sections it covers.
 
-If the audit was run weeks ago and material has changed since (new shipped flows, new content live, etc.), note "rubric scored on YYYY-MM-DD; material has shifted since" and update any specific scores you have evidence for.
+If the prior scoring was done weeks ago and material has shifted since (new shipped flows, new content live, repositioning, etc.), note "scored on YYYY-MM-DD; material has shifted since" and update any specific scores you have current evidence for.

--- a/skills/marketing-plan/references/example-quietude.md
+++ b/skills/marketing-plan/references/example-quietude.md
@@ -170,9 +170,9 @@ This is what we're starting from — team, budget, what's already in motion, wha
 | 29% monthly App Store churn vs. 38% 12-month retention claim | Metric definition mismatch confusing the team | Reconcile with Devon + Customer.io data |
 | Mira post-session reflection scope unknown | Blocks Variant B and Variant C onboarding tests | Resolve with Devon |
 
-### Audit rubric snapshot (17-section, lens from `audit-marketing`)
+### Audit rubric snapshot (17-section)
 
-Scored 0–5. This isn't a full audit — it's what we'd score Quietude today using the rubric as a current-state lens. The full audit can be run via `/audit-marketing quietude.app` if Alex wants a formal artifact.
+Scored 0–5 from materials, using the embedded rubric in `references/current-state-rubric.md`. Marked "scored from materials" rather than "formal audit" — Alex can push back on any score where they have better data.
 
 | # | Section | Score | Note |
 |---|---|---|---|
@@ -250,7 +250,7 @@ Held until seed funding lands. Initial test budget: $5–10K/mo split across App
 
 ### Skills + tools
 
-- **Skills:** `seo-audit`, `ai-seo`, `programmatic-seo`, `schema`, `content-strategy`, `competitors`, `launch`, `ads`, `ad-creative`, `social`, `typefully`, `analytics`, `audit-marketing`, `copywriting`, `marketing-website-design`, `free-tools`
+- **Skills:** `seo-audit`, `ai-seo`, `programmatic-seo`, `schema`, `content-strategy`, `competitors`, `launch`, `ads`, `ad-creative`, `social`, `typefully`, `analytics`, `copywriting`, `marketing-website-design`, `free-tools`
 - **MCPs / APIs:** Ahrefs API, DataForSEO API, Typefully MCP (LinkedIn scheduling), GA4 MCP (when wired), GitHub MCP (`quietude-promo` repo work), Notion (knowledge directory), Stripe MCP (LTV / paid-CAC math), `agent-browser` (LinkedIn drafting + testing), `defuddle` (research)
 
 ---
@@ -627,12 +627,12 @@ The fCMO's job is to:
 
 | Stage | Primary skills | Supporting skills |
 |---|---|---|
-| **Acquisition** | `seo-audit`, `ai-seo`, `programmatic-seo`, `schema`, `content-strategy`, `competitors`, `ads`, `ad-creative`, `social`, `typefully`, `audit-marketing` | `launch`, `free-tools`, `analytics`, `cold-email`, `copywriting`, `marketing-website-design` |
+| **Acquisition** | `seo-audit`, `ai-seo`, `programmatic-seo`, `schema`, `content-strategy`, `competitors`, `ads`, `ad-creative`, `social`, `typefully` | `launch`, `free-tools`, `analytics`, `cold-email`, `copywriting`, `marketing-website-design` |
 | **Activation** | `onboarding`, `signup`, `paywalls`, `cro`, `copywriting`, `copy-editing`, `copycraft` | `marketing-website-design`, `ab-testing`, `marketing-psychology`, `cro`, `popups` |
 | **Retention** | `emails`, `churn-prevention` | `copywriting`, `copy-editing`, `ab-testing`, `paywalls` |
 | **Referral** | `referrals`, `social` | `copywriting`, `marketing-website-design`, `emails` |
 | **Revenue** | `pricing`, `paywalls`, `sales-enablement`, `revops` | `ab-testing`, `copywriting` |
-| **Cross-cutting** (brand, intelligence) | `positioning`, `brand-voice`, `customer-research`, `marketing-psychology`, `audit`, `audit-marketing` | `brand-strategy`, `brand-guidelines`, `brand-style-guide`, `branding`, `marketing-ideas`, `diagram-maker`, `product-marketing` |
+| **Cross-cutting** (brand, intelligence) | `product-marketing`, `customer-research`, `marketing-psychology` | `marketing-ideas`, `diagram-maker` |
 
 ### MCPs / APIs mapped to stages
 

--- a/skills/marketing-plan/references/methodology.md
+++ b/skills/marketing-plan/references/methodology.md
@@ -236,8 +236,8 @@ Compile everything into `research.md` with this structure:
 - Investor pressure points
 - Constraints
 
-## Audit-marketing scores
-[If run, paste section scores. If not run, mark "lens used, not formal audit."]
+## Current-state rubric scores
+[17 section scores using `references/current-state-rubric.md`. If a prior scored audit exists, paste those scores. Otherwise mark "scored from materials."]
 
 ## Materials read
 [List of files in materials/ + when read]

--- a/skills/marketing-plan/references/methodology.md
+++ b/skills/marketing-plan/references/methodology.md
@@ -78,7 +78,7 @@ If `materials/` has files, read all of them. Common drops:
 - Customer research / ICP doc
 - App Store metrics / analytics snapshot
 - Lifecycle email inventory
-- Prior audit output (`audit_final_output.md` from `/audit-marketing`)
+- Prior audit output (any scored current-state assessment the team has run)
 - SEO research (`seo/plan.md`, `seo/keyword-shortlist.md`)
 - Kickoff call transcript
 - Founder Slack / async notes
@@ -172,14 +172,14 @@ What past work should this plan acknowledge?
 - What investors / board are asking about most
 - Any constraints not visible elsewhere (legal, partnership-related, brand-related)
 
-### Step 1.5 — Optionally run audit-marketing
+### Step 1.5 — Score current state against the rubric
 
-If no audit has been run on this client AND the user wants a formal scored current-state, offer:
-> *"Want me to run `/audit-marketing {client-domain}` before we draft the plan? It produces a 17-section scored audit that becomes the foundation of Section 3 (Current State). Takes ~30–60 min of walking through sections together."*
+Use the 17-section rubric in `references/current-state-rubric.md` as your scoring lens. Two modes:
 
-If user agrees, run that skill. Resume here when done.
+- **From rich materials.** When the team has shared decks, prior content audits, an existing brand voice doc, recent positioning work, or a kickoff call transcript — score from those. Mark "scored from materials" in the section heading.
+- **From a separately scored audit.** If the team already has a scored current-state assessment (in any format), ingest those numbers directly. Don't redo the work.
 
-If user declines (common when fCMO already has rich context), use the rubric as a current-state *lens* against existing materials — faster, less rigorous, captured in `references/current-state-rubric.md`.
+Either way, the output is the scored 17-row table that becomes Section 3 of the plan, followed by a 2–4 sentence "shape interpretation" calling out where strengths and gaps cluster.
 
 ### Step 1.6 — Write research.md
 
@@ -272,7 +272,7 @@ For each section, use the template at `references/plan-template.md` to draft. Th
 
 **Section 1 (Executive summary)** is synthesized from Sections 2–13 after they're all approved. Draft it last; present it first in the output document.
 
-**Section 3 (Current state)** is where audit-marketing output gets integrated. If a formal audit was run, paste the scored rubric. If not, use the rubric as a lens (see `references/current-state-rubric.md`).
+**Section 3 (Current state)** uses the embedded 17-section rubric in `references/current-state-rubric.md`. If a prior scored audit exists, paste those scores in. If not, score from available materials.
 
 **Sections 4–8 (AARRR)** each follow the same internal structure: current state, the plan (numbered moves), 90-day moves, 12-month outlook, skills + tools. Don't skip the skills + tools sub-section — it's what makes the plan operationally honest.
 

--- a/skills/marketing-plan/references/ops-stack-mapping.md
+++ b/skills/marketing-plan/references/ops-stack-mapping.md
@@ -2,7 +2,7 @@
 
 This doc maps every marketing-skill and every relevant MCP/API integration to the AARRR stage(s) it primarily serves. It's the source for Section 11 of every plan.
 
-> **Note on scope.** Skills below are drawn from the broader Claude Code marketplace ecosystem — not all live in this `marketingskills` repo. Skills shown without a `:` prefix (e.g., `seo-audit`) are in this repo. Skills referenced from adjacent marketplaces (e.g., `cf-skills:audit-marketing`, `vercel:agent-browser`, `compound-engineering:diagram-maker`, `marketing-skills:typefully`) are optional — substitute equivalents if not installed. When a plan references a skill that isn't available, fall back to the underlying tactic and call it out in Section 13's open decisions.
+> **Note on scope.** Skills below live in this `marketingskills` repo. A few references point to optional tools from adjacent Claude Code marketplaces (e.g., `vercel:agent-browser`, `compound-engineering:diagram-maker`) — substitute equivalents if not installed. When a plan references a skill or tool that isn't available, fall back to the underlying tactic and call it out in Section 13's open decisions.
 
 ## The thesis
 
@@ -32,7 +32,6 @@ The plan's Section 11 makes this thesis explicit by:
 | `typefully` | Schedule/post tweets, threads, LinkedIn content | Cadence operations for founder-led channels |
 | `cold-email` | Write B2B cold outreach + sequences | Outbound for B2B SaaS / hybrid businesses |
 | `analytics` | Set up tracking, GA4, conversion events | Funnel instrumentation |
-| `audit-marketing` | Run the 17-section product marketing audit | Comprehensive scoring of current state |
 | `free-tools` | Plan engineering-as-marketing free tools | Build tools that generate links + leads |
 | `marketing-website-design` | Design marketing sites with intention | Pillar/landing page design |
 | `launch` | Plan and execute launches (Product Hunt, GA, feature launches) | GTM moments — strategy + tactical execution |
@@ -87,23 +86,10 @@ The plan's Section 11 makes this thesis explicit by:
 
 | Skill | What it does | Primary use |
 |---|---|---|
-| `positioning` | Define market positioning | Section 2 of plan (Strategic frame) |
+| `product-marketing` | Set up the `.agents/product-marketing.md` context file (positioning, ICP, voice) | Foundational — run first; every section of the plan references this |
 | `customer-research` | Conduct customer interviews + surveys | Section 2 + Section 3 (Current state) |
-| `brand-voice` | Apply / enforce brand voice | Every section that involves copy |
-| `brand-strategy` | Brand strategy workshop (stage-3 from CF process) | Foundational brand work |
-| `brand-guidelines` | Apply brand guidelines (e.g., Anthropic's) | Cross-functional brand artifact creation |
-| `brand-style-guide` | Build a brand style guide doc (stage-7) | Handoff to designers |
-| `branding` | Implement a defined brand in code | Building brand-aligned UI |
-| `product-marketing` | Set up the `.agents/product-marketing.md` context file | Persistent client context for future skill runs |
 | `marketing-psychology` | Apply behavioral science | Cross-cuts copy, CRO, paywalls |
 | `marketing-ideas` | The 139-idea library | Section 12 of plan (Idea bank) |
-| `diagram-maker` | Create visual diagrams | Flows, architecture, RACI charts |
-
-### CF process / workflow skills (less directly used)
-
-These exist for full client engagements (Conversion Factory process). The plan skill doesn't usually invoke them directly, but they show up in RACI when a client is doing a full revamp.
-
-`client-intake` (stage-0), `sitemap-workshop` (stage-4), `creative-direction` (stage-5), `logo-design` (stage-6), `wireframes` (stage-9), `website-build-native` / `-webflow` / `-framer` (stage-10), `client-handoff` (stage-11), `growth-engine` (stage-13)
 
 ## MCPs and APIs mapped to AARRR
 

--- a/skills/marketing-plan/references/plan-template.md
+++ b/skills/marketing-plan/references/plan-template.md
@@ -117,9 +117,9 @@ Table:
 Stuck things are the most leverage-positive places to focus the first weeks of the 90-day plan.
 
 ### Audit rubric snapshot
-17-section scored snapshot using the `audit-marketing` rubric as a lens. See `references/current-state-rubric.md` for the full rubric.
+17-section scored snapshot using the embedded current-state rubric. See `references/current-state-rubric.md` for the full rubric and scoring guides.
 
-If a formal `/audit-marketing` was run, paste the scored output. If not, note "lens used, not formal audit."
+If a prior scored audit exists, paste those scores in. Otherwise score from available materials and note "scored from materials" under the heading.
 
 | # | Section | Score | Note |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

Three pre-release fixes for the `marketing-plan` skill before v2.3.0 ships to main:

1. **Strip references to internal-only skills.** The skill was authored where `audit-marketing` and `positioning` (in the private `cf-skills` repo) were available. Public users would see 27 references to a skill they cannot install + an explicit private-repo path. Rewritten to depend only on skills that live in this public repo (`product-marketing` replaces `positioning`; the embedded 17-section rubric in `current-state-rubric.md` replaces `audit-marketing`).

2. **Add `evals/evals.json`** — marketing-plan was the only skill in the repo without one (42/43 had them). Added 6 representative evals.

3. **Reverse cross-references** from `marketing-ideas` and `customer-research` to `marketing-plan` so users browsing the foundational skills discover the comprehensive-plan deliverable.

## Commits

- `fb2fff9` — strip audit-marketing + positioning refs across 7 files
- `b02566d` — add evals.json (6 evals)
- `1300f2a` — reverse cross-references in marketing-ideas + customer-research

## What changed structurally

- **`SKILL.md` frontmatter description** rewritten — drops "see audit-marketing" / "see positioning"; substitutes `product-marketing` as the foundational skill. Description now 949 chars.
- **`SKILL.md` "Cross-references" and "Related skills" sections** reorganized to only name skills that exist in this repo
- **`methodology.md` Step 1.5** rewritten — instead of "offer to run `/audit-marketing`," now describes scoring from materials or ingesting a separately scored audit (in any format)
- **`current-state-rubric.md`** intro rewritten — the rubric is the source of truth for Section 3, not a derivative. Removed cf-skills repo path. Removed "Path A vs Path B" framing.
- **`plan-template.md`, `ops-stack-mapping.md`, `client-types.md`, `example-quietude.md`** — `audit-marketing` and `positioning` removed from skill lists
- **`evals/evals.json`** added with 6 evals covering standard engagement, pre-seed budget tier, prior-audit ingestion, resumable workflow, hardware+software archetype, and quick-plan pushback

## Why this matters

The release-readiness review for the dev→main PR flagged this as a release blocker. The skill should not point external users at skills they can't install. The rubric content was already fully embedded in `current-state-rubric.md`, so external users have everything they need to execute Section 3 of the plan.

## Test plan

- [x] `./validate-skills.sh` — 43/43 passing after changes
- [x] `grep -rn "audit-marketing\|cf-skills\|conversionfactory" skills/marketing-plan/` returns zero matches
- [x] `grep -rn "\`positioning\`" skills/marketing-plan/` returns zero matches (only lowercase concept mentions remain, which are normal marketing vocabulary)
- [x] SKILL.md description still under 1024 chars (949)
- [x] All 43 skills now have `evals/evals.json`
- [x] No Claude-Code-only `` !`command` `` syntax anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
