### PR TITLE
feat(marketing-plan): add budget, growth, and team frameworks (1.0.0 → 1.1.0)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -27,7 +27,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | launch | 2.0.0 | 2026-05-05 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
-| marketing-plan | 1.0.0 | 2026-05-27 |
+| marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | onboarding | 2.0.0 | 2026-05-05 |
 | ads | 2.0.1 | 2026-05-26 |

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -127,19 +127,48 @@ Standard tiers in `references/funding-stage-unlocks.md`:
 
 Use these as anchors. Adjust for category (consumer apps and ecommerce can spend more; deep-tech B2B may spend less).
 
+## Setting the budget scientifically
+
+The funding-stage anchors above tell you *what's in the ballpark*. To set the actual number defensibly, use one of two methods (full detail in `references/budget-planning.md`):
+
+1. **Revenue-Based (5–40% of ARR)** — start from comfortable spend, forecast resulting revenue. Best when historical CAC data exists.
+2. **Goal-Based** — reverse-engineer the budget from the revenue target. Formula: `[(New ARR / (ARPC × 12)) × CAC] / annual retention rate`. Best for fundraising or when the goal is fixed.
+
+Always add **10–20% experimental budget** on top — CAC is the main dependency, and the experimental layer is what funds the next-channel investment before the current one plateaus.
+
+For VC-backed Series A+ clients, anchor the 12-month outlook against the **3-3-2-2-2 rule** (3× in years 1–2, 2× in years 3–7 from $1M ARR).
+
+## Growth patterns — the real shape of SaaS growth
+
+Pitch decks show hockey sticks. Real growth is a series of S-curves with plateaus between them. Full framework in `references/growth-patterns.md`. Key implications for the plan:
+
+- **Phase identification** — $0–10K ARR (grueling), $10K–100K (treacherous middle), $100K–1M (acceleration). Section 3 names the current phase; Section 10 sequences the next.
+- **Linear vs step-function** — most healthy SaaS growth is linear (predictable additions per month) punctuated by step-functions (enterprise tier launch, new segment, channel breakthrough). The plan should describe both honestly — not promise exponential.
+- **S-curve layering** — Channel × Product × Market. Start the next S-curve while the current one is still growing. Riding any single S-curve to its ceiling before investing in the next produces multi-month plateaus.
+
+## Team and agency model
+
+Strategy lives in-house. Execution can — and often should — be outsourced. Full framework in `references/team-and-agency-model.md`. Three implications for every plan:
+
+1. **First hire is a strategist, not a tactician.** Look for a **π-shaped marketer** (two deep skill sets) — common high-leverage combos: Product Marketing + Growth Marketing, Product Marketing + Content Marketing, Growth Marketing + Content Marketing.
+2. **Title conservatively.** First marketing hire is almost always Manager or Lead, not VP or CMO. Inflated titles paint the org into a corner when you scale.
+3. **Use contractors and small niche agencies for execution.** Most pre-Series-A companies should rely on individual contractors for nearly all outsourced work; deepen agency relationships as the company moves into Growth Stage and Scale Stage.
+
 ## What every plan must customize
 
 A generic plan is a failed plan. Every plan must explicitly customize for:
 
-1. **Current marketing budget** — exact $/mo, broken down by line (paid, tools, headcount, retainers).
-2. **Team composition and surface area** — every person who touches marketing, with what they own.
-3. **What the client is currently doing** — by channel, with status (working / not / TBD).
-4. **What they've already done that should be acknowledged** — past launches, PR moments, content, partnerships. Don't write a plan that ignores work they're proud of.
-5. **Future funding milestones** — when the next round closes, what budget tier that unlocks.
-6. **The 50+ marketing skills mapped to specific moves** — every move in the AARRR sections names the skill that executes it.
-7. **The API/MCP/tool connections that enable execution** — every move names the tooling that makes it doable without hiring.
+1. **Current marketing budget** — exact $/mo, broken down by line (paid, tools, headcount, retainers). Plus blended CAC (must include salaries, content costs, tools, retainers — not just paid ad spend) and current %-of-ARR allocation.
+2. **Unit economics** — ARPC, annual retention rate, LTV. These feed the budget math in Section 8 and Section 10.
+3. **Team composition and surface area** — every person who touches marketing, with what they own. Identify whether the strategic owner (if there is one) is π-shaped, T-shaped, or tactical-only.
+4. **What the client is currently doing** — by channel, with status (working / not / TBD).
+5. **What they've already done that should be acknowledged** — past launches, PR moments, content, partnerships. Don't write a plan that ignores work they're proud of.
+6. **Phase of SaaS growth** — $0–10K ARR / $10K–100K / $100K–1M / $1M+. Each phase has its own binding constraint.
+7. **Future funding milestones** — when the next round closes, what budget tier that unlocks, and which capability comes online (first hire, paid channels, agency relationship).
+8. **The marketing skills mapped to specific moves** — every move in the AARRR sections names the skill that executes it.
+9. **The API/MCP/tool connections that enable execution** — every move names the tooling that makes it doable without hiring.
 
-If you can't confirm any of these in INIT, list them in Section 13's "Open decisions" — never gloss over them.
+If you can't confirm any of these in INIT, list them in Section 13's "Open decisions" — never gloss over them. **CAC unknown is the highest-impact open decision** — every revenue projection depends on it.
 
 ## Common client-type variations
 

--- a/skills/marketing-plan/references/budget-planning.md
+++ b/skills/marketing-plan/references/budget-planning.md
@@ -1,0 +1,168 @@
+# Budget Planning — Scientific Methods for Setting the Marketing Budget
+
+The problem with most SaaS marketing budgets is that they're pulled out of thin air — a number that hopefully doesn't constrain growth too much, but doesn't anchor in customer-acquisition economics either. The result: when someone asks "why this number?" there's no answer.
+
+Two scientific methods solve this. Use one (not both) in Section 8 (Revenue) and Section 10 (12-month outlook) of every plan.
+
+Excerpted and adapted from *Founding Marketing* by Corey Haines.
+
+## Method 1 — Revenue-Based (5–40% of annual revenue)
+
+**Direction:** budget → revenue goal.
+
+You start with what the company can comfortably spend on marketing, then forecast what revenue that spend can plausibly generate.
+
+### The ranges
+
+| Posture | % of ARR | When to use |
+|---|---|---|
+| **Conservative (profit-preserving)** | 5% | Established business focused on profit distribution; bootstrapped; founder-paid customer base |
+| **Standard growth** | 15–25% | Most healthy SaaS in the seed-to-Series-A range |
+| **Aggressive growth (deploying raised capital)** | up to 40% | Recently funded round, mandate to deploy fast, board accepts burn |
+
+For reference: public SaaS companies routinely report sales-and-marketing spend between 20% and 55% of revenue (Zoom historically ran between 20% and 55% across years).
+
+### The math (Conservative example)
+
+Business at $1M ARR, 5% allocation:
+
+- Annual marketing budget: **$50,000**
+- Blended CAC: $100 → can acquire **500 new customers**
+- ARPC: $50/mo → adds **$300K** to ARR
+- Account for 15% annual churn → 85% × $300K = **+$255K net new ARR**
+- End-of-year goal: **$1.255M ARR**
+
+### The math (Aggressive example)
+
+Business at $1M ARR, 40% allocation:
+
+- Annual marketing budget: **$400,000**
+- Blended CAC: $100 → can acquire **4,000 new customers**
+- ARPC: $50/mo → adds **$2.4M** to ARR
+- End-of-year goal: **$3.4M ARR**
+
+### Two keys to making this method work
+
+1. **Know your blended CAC** (see "Calculating CAC" below)
+2. **Match the allocation percentage to your actual ambition.** A founder running 5% allocation while telling the board they expect to triple revenue is showing two incompatible signals.
+
+## Method 2 — Goal-Based (reverse-engineered from the revenue target)
+
+**Direction:** revenue goal → budget.
+
+You start with the revenue goal and work backward through the unit economics to derive the budget required to hit it. Best for:
+
+- Companies just starting up (no historical CAC baseline yet, working from first principles)
+- Companies anticipating outside capital (need to defend the ask)
+- Companies using revenue-based financing (Pipe, Capchase, Founderpath)
+
+### The formula
+
+```
+Marketing budget = [(New ARR / (ARPC × 12)) × CAC] / annual retention rate
+```
+
+### Worked example: $1M ARR → $2M ARR
+
+Step 1 — How much new ARR per customer?
+ARPC × 12 = $50 × 12 = **$600 ARR per new customer**
+
+Step 2 — How many new customers do we need?
+$1,000,000 / $600 = **1,667 new customers**
+
+Step 3 — What's the raw acquisition cost?
+1,667 × $100 CAC = **$166,700**
+
+Step 4 — Account for churn (15% annual = 85% retention)
+$166,700 / 0.85 = **$196,118** (round to **$200K**)
+
+When someone asks how you got to the budget, walk them through the four steps. It's defensible.
+
+### Why this formula and not something simpler
+
+The four steps each correspond to a real economic reality:
+- Step 1 converts MRR-language into the ARR-language a board talks in
+- Step 2 names the customer count, which is what the funnel actually has to deliver
+- Step 3 anchors the budget in the cost of acquisition
+- Step 4 acknowledges that churned customers don't count toward net new ARR, so the budget needs to cover the gap
+
+### Required buffer
+
+**Always add 10–20% as "experimental budget"** on top of the formula output. CAC is the main dependency; if CAC comes in 50% higher than estimated, the cascading effect is missing the revenue goal. It is much cheaper to overestimate CAC than to underestimate it.
+
+The experimental budget also funds the experiments that find your next channel before your current one plateaus (see `growth-patterns.md` — channel S-curves).
+
+## The VC growth path (3-3-2-2-2 rule)
+
+Once a company has crossed $1M ARR and taken a Series A, the implicit benchmark VCs expect is:
+
+| Year | ARR multiple | Cumulative ARR (from $1M start) |
+|---|---|---|
+| Year 0 | — | $1M |
+| Year +1 | 3× | $3M |
+| Year +2 | 3× | $9M |
+| Year +3 | 2× | $18M |
+| Year +4 | 2× | $36M |
+| Year +5 | 2× | $72M |
+| Year +6 | 2× | $144M |
+| Year +7 | 2× | $288M |
+
+That's the 3-3-2-2-2 rule. Useful when:
+
+- The plan needs to map 12-month and 36-month milestones to VC expectations
+- The founder is mid-raise and the board needs to see a plausible path to the next round
+- Section 10 (12-month outlook) needs anchoring against an industry benchmark, not just internal ambition
+
+Most companies miss it. That's fine. Knowing the benchmark gives the team a defensible reason to either match it or explicitly choose not to.
+
+## Calculating CAC (blended, not paid-only)
+
+If there's no historical CAC, use a baseline: **one year of revenue from the smallest paid plan.** Deploy the budget, capture actual CAC data, replace the baseline with the measured number for the next planning cycle.
+
+For an established CAC calculation, **CAC must be blended.** Include:
+
+- Marketing salaries (full loaded cost, not just base)
+- Advertising spend
+- Marketing tech stack costs
+- Content production costs (writers, designers, video editors)
+- Agency / contractor retainers
+- SDR / BDR salaries if doing outbound
+- Tools (CRM, marketing automation, analytics)
+
+Then divide by the number of new customers acquired in the period. That blended number is the one to use in either budgeting method.
+
+The mistake to avoid: calculating CAC from paid ad spend alone. A company that "doesn't run ads" still has a CAC — it's just hidden in the content team, the founder's time, the SEO contractor, the conference booth.
+
+## The reality check on forecasting
+
+This whole framework derives a budget and a revenue goal — not a 12-month month-by-month forecast accurate to the dollar.
+
+**Unless the company is publicly traded, all forecasts are educated guesses.** No startup under $100M ARR reliably hits forecasts to the month. The honest framing for the plan:
+
+- The annual goal is a defensible direction-of-travel
+- The budget is the resource commitment that makes the goal plausible
+- The 90-day roadmap (Section 9) is what's actionable now
+- Month-to-month variance is expected; quarterly review is when the plan adjusts
+
+What's actionable: how to deploy the budget, what concrete moves to execute, what to adjust when real data comes in.
+
+What's not actionable: trying to forecast traffic, pipeline, retention curves, conversion rates, and channel mix all down to the decimal point and expecting that forecast to hold. Founders who over-engineer the forecast tend to spend the plan period explaining variance instead of executing.
+
+**Rule for the plan:** the budget number is honest. The annual goal is honest. The month-by-month projection is illustrative.
+
+## How this flows into the plan
+
+| Section | What to include |
+|---|---|
+| **3 (Current state)** | Current monthly marketing spend broken down by line (paid, tools, content, headcount, retainers). Compute current %-of-ARR allocation. |
+| **8 (Revenue)** | The unit-economics table (CAC, ARPC, churn) that feeds whichever budget method you're using. |
+| **10 (12-month outlook)** | Apply Method 1 or Method 2 to derive the 12-month budget and the resulting revenue goal. Anchor against the 3-3-2-2-2 rule if Series A+ and VC-backed. |
+| **11 (Ops stack)** | Show the budget allocation across the AARRR stages — what % to Acquisition, Activation, etc. The ops-stack mapping informs which line items grow when the next funding tier unlocks. |
+| **13 (Open decisions)** | If CAC is unknown or contested, flag it as the highest-impact open decision — every other number depends on it. |
+
+## When to choose which method
+
+- **Method 1 (Revenue-Based)** when the company has historical CAC data, a profit/burn posture, and the question is "given our posture, what's a plausible goal."
+- **Method 2 (Goal-Based)** when the company has a specific goal (board mandate, VC milestone, fundraise target) and the question is "what budget do we need to hit it."
+
+For most plans in the seed-to-Series-A range, Method 2 is more useful — it forces the conversation about whether the goal is funded.

--- a/skills/marketing-plan/references/funding-stage-unlocks.md
+++ b/skills/marketing-plan/references/funding-stage-unlocks.md
@@ -4,6 +4,11 @@ Every marketing plan must include explicit "what changes when funding closes / w
 
 This doc defines the standard tiers. Use them as anchors, adjust for client category and unit economics.
 
+**Related docs:**
+- `budget-planning.md` — two scientific methods for setting the actual budget number (Revenue-Based 5–40%, or Goal-Based reverse-engineered from the revenue target), CAC calculation, experimental buffer
+- `growth-patterns.md` — the real shape of SaaS growth by phase ($0–10K / $10K–100K / $100K–1M+), linear vs step-function, S-curve layering
+- `team-and-agency-model.md` — what each tier means for team composition, the first marketing hire, and the in-house vs outsource ratio
+
 ## Why funding stage matters in a marketing plan
 
 Most marketing plans are written as if budget is unconstrained. That's a failure mode for early-stage clients — it produces aspirational lists rather than executable roadmaps.

--- a/skills/marketing-plan/references/growth-patterns.md
+++ b/skills/marketing-plan/references/growth-patterns.md
@@ -1,0 +1,148 @@
+# Growth Patterns — The Real Shape of SaaS Growth
+
+The 12-month outlook in every plan (Section 10) describes a trajectory. This doc names the shape of that trajectory honestly — what real SaaS growth looks like, when to expect plateaus, and how to plan for the next leg of growth before the current one stalls.
+
+Excerpted and adapted from *Founding Marketing* by Corey Haines.
+
+## The long, slow SaaS ramp of death
+
+Pitch decks show hockey sticks. Real growth shows a series of S-curves — each representing a distinct phase followed by a plateau that tests resolve and creativity.
+
+### Phase 1 — $0 → $10K ARR (the grueling phase)
+
+The hardest milestone. Every customer is a hard-won victory. Typical time: **6–12 months.** Most companies pivot the product multiple times during this phase.
+
+What it requires:
+- Runway long enough to keep experimenting until something clicks
+- A financial cushion or additional income sources (often the difference between success and shutdown)
+- Tolerance for ambiguity — the product positioning, the pricing, and the channel can all still be wrong at this stage
+
+### Phase 2 — $10K → $100K ARR (the treacherous middle)
+
+The middle ground that kills most promising startups. The average company reaches ~$40K ARR in year one. The danger: enough revenue to prove the concept, not enough to support a team.
+
+The threshold to watch for: **$8–10K MRR.** That's when founders can typically go full-time on the business without other income sources. Until then, careful cash management or side income carries the company through.
+
+Companies that flame out in Phase 2 usually run out of runway just as things start working.
+
+### Phase 3 — $100K → $1M ARR (the acceleration phase)
+
+Where things get interesting. Typical time: nearly 2 years total to reach $1M. But there's an acceleration pattern: **once across $100K, companies often double from $100K → $200K in one-third the time it took to reach the first $100K.**
+
+Why: critical mass kicks in. Word-of-mouth starts working. Early customers become your best salespeople. The product has proven itself, and growth becomes more about execution than experimentation.
+
+This is the phase where the marketing plan's 90-day roadmap (Section 9) starts compounding instead of just covering ground.
+
+## Two real growth patterns (and the exponential myth)
+
+The myth: successful SaaS companies grow exponentially, doubling revenue month over month like clockwork.
+
+The reality: two distinct patterns, often combining at scale to *look* exponential when zoomed out.
+
+### Pattern 1 — Linear growth
+
+Build a predictable revenue machine. Find a channel that works (content, partnerships, paid, outbound) and steadily scale it. Some companies reliably add **$10K MRR per month** through a well-oiled marketing engine.
+
+Less sexy than exponential. Far more sustainable. Crucially, **plannable**: when you know what you can count on adding each month, hiring decisions, product roadmap, and expansion planning all become tractable.
+
+### Pattern 2 — Step-function growth
+
+Periods of plateau followed by sudden jumps. Jumps aren't random — they're triggered by specific events:
+- Breaking into a new market segment (e.g., enterprise after starting SMB)
+- Launching a major product expansion (new feature line, new tier)
+- Cracking a new marketing channel that compounds
+
+Example: one founder saw revenue triple in two months after launching enterprise features — following six months of flat growth.
+
+Key insight for the plan: **each step requires deliberate action and investment.** Steps don't happen by waiting. While standing on the current step, you have to be actively building the next one.
+
+### How they combine
+
+Zoom out far enough and a series of linear phases + step functions can look exponential. That's where the myth comes from. Understanding it's actually a series of plannable shapes changes how you build the plan:
+
+- Don't chase the myth of doubling every month
+- Build sustainable linear systems (Sections 4–8 AARRR moves)
+- Plan deliberate step functions (Section 10 12-month milestones)
+
+## Layering growth curves — Channel × Product × Market
+
+The secret to sustained growth isn't one perfect channel. It's orchestrating multiple S-curves that work together. Three S-curves to track:
+
+### Channel S-curves
+
+Every marketing channel has its own lifecycle:
+- **SEO** — 6–12 months to mature; once it does, steady leads for years. Marathon runner.
+- **Paid ads** — quick wins; diminishing returns as you scale.
+- **Content marketing** — slow to start, compounds beautifully over time.
+- **Partnerships / co-marketing** — episodic; high yield when the right partner aligns.
+- **Outbound** — predictable when calibrated; CAC-heavy and plateaus at team capacity.
+- **PR** — spike-driven; sustains awareness rather than direct conversion.
+
+**The rule:** start the next channel before the current one plateaus. Riding one channel to its ceiling before investing in the next produces a multi-month growth plateau that takes more effort to break out of than it would have taken to start the next channel earlier.
+
+In the plan: Section 4 (Acquisition) names current channels, planned channels, and skipped channels. The 12-month roadmap (Section 10) sequences when the next channel investment begins.
+
+### Product S-curves
+
+Your core product naturally hits a growth ceiling as you saturate the initial market. Pushing harder on the same features doesn't break through. What does:
+
+- Adding features that target new use cases
+- Extending the product line to serve adjacent needs
+- Expanding into new market segments (e.g., team collaboration added to a single-user tool — opens a new market)
+
+In the plan: Sections 5 (Activation) and 8 (Revenue) name where the product needs to grow to unlock the next growth tier.
+
+### Market S-curves
+
+Every market segment has its own growth ceiling. Time the expansion into the next segment while the current segment is still showing strong growth. Common patterns:
+
+- SMB → mid-market → enterprise
+- Single vertical → adjacent verticals
+- Domestic → international
+
+Waiting until a segment is saturated makes the transition harder.
+
+In the plan: Section 2 (Strategic frame) names current segment + future segments. Section 10 (12-month outlook) sequences when expansion moves begin.
+
+### The orchestration
+
+The real magic: while SEO is maturing, you're using paid for quick wins. As those channels mature, you're developing product features that unlock enterprise. Meanwhile, the groundwork for international expansion is being laid for when domestic saturates.
+
+This is the operational thesis behind the AARRR mapping (Sections 4–8) and the 12-month outlook (Section 10): each section is a curve, and the plan sequences them so the next curve is ramping while the current one is still growing.
+
+## The 3-3-2-2-2 VC growth path
+
+For companies that have crossed $1M ARR and raised institutional capital, the VC benchmark is:
+
+| Year | Multiple | Cumulative ARR (from $1M) |
+|---|---|---|
+| Year 0 | — | $1M |
+| Year +1 | 3× | $3M |
+| Year +2 | 3× | $9M |
+| Year +3 | 2× | $18M |
+| Year +4 | 2× | $36M |
+| Year +5 | 2× | $72M |
+| Year +6 | 2× | $144M |
+| Year +7 | 2× | $288M |
+
+Most companies don't hit this. Useful regardless — anchoring the 12-month outlook against this benchmark forces the plan to either (a) match it and show how, or (b) explicitly defend choosing a slower trajectory.
+
+For non-VC-backed (bootstrapped, founder-funded, profit-focused) companies, this curve doesn't apply. Use linear or step-function targeting instead.
+
+## How this informs the plan
+
+| Section | What to include |
+|---|---|
+| **3 (Current state)** | Where the company is on each S-curve (channel maturity, product maturity, market saturation). Name the current phase ($0–10K / $10K–100K / $100K–1M / $1M+). |
+| **4 (Acquisition)** | Current channels + their position on the S-curve (early / mature / plateauing). Next channel investment with rationale. |
+| **5–8 (AARRR)** | Each section names the binding constraint at the current phase. For Phase 2 companies, Activation is usually the leverage point. For Phase 3, Retention + Referral compound the existing growth. |
+| **9 (90-day roadmap)** | Linear-pattern moves dominate (predictable additions). Step-function setups (the build-up to a launch, an enterprise tier, a new market segment) live here. |
+| **10 (12-month outlook)** | Sequence channel S-curves, product S-curves, market S-curves. If VC-backed Series A+, anchor against 3-3-2-2-2. If not, name the linear or step-function targets. |
+| **13 (Measurement)** | The north-star metric reflects the current phase (Phase 1 is usually pure new-signup; Phase 3 is usually expansion ARR or NRR). |
+
+## Operational guidance for the planner
+
+- **Don't promise exponential.** If the plan implies doubling every month, the founder will use it against you in 90 days. Linear + step-function is honest.
+- **Name the binding constraint.** Phase 1 binding constraint is finding any channel that works. Phase 2 is funding the team. Phase 3 is breaking the ceiling on whichever channel got you here.
+- **Plateaus aren't failures.** They're the moment between two S-curves. The plan should anticipate them and stage the next move.
+- **Don't conflate "growth" with "growth rate."** A company adding $20K MRR each month for 24 months has built a remarkable machine. The fact that the *percentage* growth rate declines as the base grows is arithmetic, not failure.

--- a/skills/marketing-plan/references/measurement-framework.md
+++ b/skills/marketing-plan/references/measurement-framework.md
@@ -2,6 +2,10 @@
 
 Every plan needs a measurement section that tells the team how to know if the plan is working. This doc is the source for Section 13's measurement subsection.
 
+**Related docs:**
+- `growth-patterns.md` — the 3-3-2-2-2 VC growth path (3× in years 1–2, 2× in years 3–7 from $1M ARR) and which phase of SaaS growth the company is in ($0–10K / $10K–100K / $100K–1M+)
+- `budget-planning.md` — CAC calculation (blended, not paid-only) and the forecasting reality check (forecasts under $100M ARR are educated guesses, not precise predictions)
+
 ## The north-star principle
 
 A north star is one metric that captures the business-model thesis at the highest level. It should:
@@ -134,6 +138,28 @@ For each quarter in Section 10, the plan must include 3–5 specific KPI targets
 **Q4 (compound quarter):**
 - Mostly *compound* metrics — is the flywheel turning? "50%+ of new subs from non-paid channels." "Ambassador-driven 15–25% of new subs."
 - Some *narrative* metrics — does the Series A story write itself? "Blended LTV/CAC > 3."
+
+## Anchoring against the VC growth path
+
+For VC-backed clients past $1M ARR, anchor 12-month and multi-year targets against the **3-3-2-2-2 rule** (3× in years 1 and 2, then 2× in years 3 through 7). Hitting it is rare; most companies don't. Anchoring against it forces the plan to either match it and show how, or explicitly defend choosing a slower trajectory. Full table and context in `growth-patterns.md`.
+
+For non-VC-backed companies (bootstrapped, founder-funded, profit-focused), the 3-3-2-2-2 doesn't apply. Use linear-pattern targets ("$X MRR added per month") or step-function targets ("$Y revenue jump after the enterprise tier launches") instead.
+
+## Forecasting reality check
+
+A plan derives a budget and an annual goal. It does not produce a 12-month month-by-month forecast that's reliably accurate to the dollar.
+
+**Unless the company is publicly traded, all forecasts are educated guesses.** No startup under $100M ARR consistently hits month-by-month forecasts. Quarterly review is when the plan adjusts — not when variance is treated as failure.
+
+What the plan commits to honestly:
+- The annual goal is a defensible direction-of-travel
+- The budget is the resource commitment that makes the goal plausible
+- The 90-day roadmap (Section 9) is what's actionable now
+- Month-to-month projection is illustrative, not promised
+
+Founders who over-engineer the forecast end up explaining variance every month instead of executing. The plan should resist this — name the annual target, the quarterly KPIs, and the kill criteria. Don't promise the month.
+
+Full context in `budget-planning.md`.
 
 ## Kill criteria
 

--- a/skills/marketing-plan/references/methodology.md
+++ b/skills/marketing-plan/references/methodology.md
@@ -137,11 +137,14 @@ For every gap in the materials, ask the user. The minimum intake covers ten topi
 - Advisors who touch marketing?
 - Agencies / contractors / fractionals?
 - Where are the obvious gaps?
+- For the team's current marketing owner (if there is one): is the shape π-shaped (two deep skill sets), T-shaped (one deep, broad), or tactical-only? See `team-and-agency-model.md` for the framework that informs Section 11 RACI and the first-hire recommendation in Section 9.
 
 #### Intake 6 — Budget
 - Current monthly marketing spend, broken down: paid acquisition, tools, retainers, headcount?
 - Budget tier this maps to (see `funding-stage-unlocks.md`)?
 - What budget unlocks when the next round closes?
+- Blended CAC if known (including salaries, content costs, tools, retainers — not just paid ad spend). If unknown, flag as the top Section 13 open decision — every revenue projection depends on it.
+- ARPC, annual retention rate (or churn rate), so the budget math in `budget-planning.md` can be applied to Section 8 (Revenue) and Section 10 (12-month outlook).
 
 #### Intake 7 — Channels currently active
 - Acquisition: organic SEO, paid search, paid social, content, social, partnerships, events, PR, ambassadors, etc. — for each, status (live / paused / never tried)

--- a/skills/marketing-plan/references/plan-template.md
+++ b/skills/marketing-plan/references/plan-template.md
@@ -82,15 +82,20 @@ Table of every person with marketing surface area:
 | Person | Role | Marketing surface area |
 |---|---|---|
 
-Be honest about gaps. If there's no dedicated marketing hire yet, name when one becomes necessary and what role.
+Be honest about gaps. If there's no dedicated marketing hire yet, name when one becomes necessary and what role (see `references/team-and-agency-model.md` — first hire should be π-shaped strategist titled Manager or Lead, not VP/CMO).
 
 ### Marketing budget (current)
 - Paid acquisition: $X/mo
 - Tooling stack: list with estimated cost
 - Retainers / fCMO: list
 - Headcount: list
+- Blended CAC: $X (must include salaries, content costs, tools, retainers — not just paid spend; see `references/budget-planning.md` for the calculation)
+- Current spend as % of ARR: X% (compare against 5–40% range)
 
 State the funding-stage tier this maps to (see `references/funding-stage-unlocks.md`). Implication: what 90-day plan must produce *without* lever pulls that require future budget.
+
+### Phase of SaaS growth
+Name the current phase: $0–10K ARR / $10K–100K / $100K–1M / $1M–$10M / $10M+. Each phase has its own binding constraint and dominant growth pattern (see `references/growth-patterns.md`). Section 10 sequences the move into the next phase.
 
 ### What's already done (acknowledge, then build on)
 Table:
@@ -246,6 +251,19 @@ Quarter-by-quarter outcome state (Q1 / Q2 / Q3 / Q4).
 - B2B case studies + sales material
 - Long-term value pools (data licensing, enterprise expansion) — flagged not executed in 12-month plan
 
+### Unit economics
+Required table:
+
+| Metric | Value | Note |
+|---|---|---|
+| ARPC (avg monthly revenue per customer) | $X | Pulled from Stripe / billing |
+| Blended CAC | $X | Includes all marketing costs, not just paid |
+| Annual retention rate | X% | 1 − annual churn |
+| LTV (rough) | $X | ARPC × 12 / annual churn |
+| LTV / CAC | X | Health benchmark: > 3 |
+
+These feed the budget math in Section 10. If any of these are unknown, flag in Section 13 as top open decision.
+
 ### Skills + tools
 `pricing`, `paywalls`, `sales-enablement`, `revops`, `ab-testing`, etc.
 
@@ -278,13 +296,21 @@ Second-order moves. Layered tactics. 90-day review prep.
 
 ## Section 10 — 12-month outlook
 
-**Purpose:** Quarterly milestones with explicit funding-stage capability unlocks named.
+**Purpose:** Quarterly milestones with explicit funding-stage capability unlocks named, anchored against a defensible growth pattern.
 
-**Length:** Four sub-sections, one per quarter. ~250–400 words each.
+**Length:** Four sub-sections, one per quarter. ~250–400 words each. Plus a short framing paragraph at the top naming the budget method and growth pattern.
 
-**Structure (per quarter):**
+### Framing (top of Section 10)
 
-### Q{N} — Months {X}–{Y}
+State explicitly:
+- **Budget method used.** Method 1 (Revenue-Based 5–40% of ARR) or Method 2 (Goal-Based formula). See `references/budget-planning.md`. Show the math.
+- **Annual budget total** + the experimental buffer (+10–20%).
+- **Resulting end-of-year ARR goal.** Honest forecast, not a guarantee — see the forecasting reality check in `references/measurement-framework.md`.
+- **Growth pattern expected.** Linear (predictable $X MRR added per month), step-function (plateau between deliberate jumps), or layered S-curves. For VC-backed Series A+, anchor against 3-3-2-2-2 and show whether the plan matches it or explicitly chooses a different trajectory. See `references/growth-patterns.md`.
+
+### Structure (per quarter)
+
+#### Q{N} — Months {X}–{Y}
 
 **Funding state:** {tier} per `funding-stage-unlocks.md`
 
@@ -294,6 +320,8 @@ Second-order moves. Layered tactics. 90-day review prep.
 - Bulleted outcome list (5–8 items)
 
 **KPI targets:** 3–5 specific numerical targets.
+
+**Channel/Product/Market S-curve position:** Which curves are growing, which are plateauing, which is the next one being staged for this quarter (see `growth-patterns.md` — layering principle).
 
 ---
 
@@ -334,6 +362,20 @@ Pick one operational moment that proves the stack works (e.g., "Customer.io MCP 
 | (current) | (list) | (list) | (list) |
 | (next round) | (delta) | (delta) | (delta) |
 | ... | ... | ... | ... |
+
+### Team and agency model (RACI)
+
+Apply the principle from `references/team-and-agency-model.md`: strategy in-house, execution often outsourced.
+
+| Function | Owned by (internal strategic role) | Executed by (IC / contractor / agency) |
+|---|---|---|
+| Growth marketing (demand engine) | | |
+| Product marketing (story engine) | | |
+| Content marketing (trust engine) | | |
+
+If the team is missing a strategic owner for one of these functions, the first 90-day move (Section 9) should be the hire — Manager or Lead title, π-shaped if possible, not VP/CMO.
+
+If execution capacity is the gap, name the contractor or small niche agency in the right cell rather than the team's existing IC.
 
 Pull from `references/funding-stage-unlocks.md`.
 

--- a/skills/marketing-plan/references/team-and-agency-model.md
+++ b/skills/marketing-plan/references/team-and-agency-model.md
@@ -1,0 +1,278 @@
+# Team and Agency Model — Hire for Strategy, Outsource Execution
+
+The marketing operations stack (Section 11 of every plan) describes *what* gets done. This doc describes *who does it* — the operating principle, the org shape, the first hire, the agency model, and how it evolves as the company scales.
+
+Excerpted and adapted from *Founding Marketing* by Corey Haines.
+
+## The principle
+
+**Strategy lives in-house. Execution can — and often should — be outsourced.**
+
+Two failure modes are common when founders ignore this:
+
+1. **Hire junior tactician first.** Founder hits a milestone, raises a round, hires a junior to "do marketing" (run ads, write blogs, post on social). Six months later: scattered tactics, no coherent strategy, disappointing results.
+2. **Hire expensive agency for strategy.** Burns cash while the internal team struggles to execute on recommendations they don't fully understand. Strategic insight gathers dust; tactical needs go unmet.
+
+The traditional advice — "hire full-time for competitive advantages, only use agencies for commoditized work" — made sense when marketing moved slowly and talent stayed for decades. That world is gone. Full-time hires take months to ramp and years to develop deep expertise. The best agencies and contractors deliver results immediately, with cross-industry pattern recognition you couldn't build in-house affordably.
+
+## What stays in-house
+
+The strategic heart of the marketing operation. Specifically:
+
+- **Strategic direction and vision** — the "why" behind every move
+- **Customer and market understanding** — only comes from daily immersion in the business
+- **Positioning and deep market knowledge** — represents the company's unique place in the market
+- **Core product and service delivery** — the heart of the value proposition
+- **Long-term institutional knowledge** — the compound interest of experience
+
+These are not delegatable. An external partner can sharpen the articulation, but the underlying conviction must come from the team.
+
+## What's safe to outsource
+
+External expertise shines in specific contexts:
+
+- **Best-in-class implementation of specialized skills** (paid media operators, technical SEO, video production, designers)
+- **Burst capacity** — launch sprints, campaign cycles, one-off content production
+- **Well-defined strategies** — when the scope, deliverables, and success metrics are clear
+- **Fresh eyes on old problems** — external perspective when the team is too close to see clearly
+
+The trick is *defining* what's being outsourced. Vague briefs ("help us with marketing") produce vague results. Specific briefs ("ship 20 RSAs across 4 ad groups by month-end with the CTR benchmarks in the brief") produce shippable work.
+
+## The three core functions
+
+Every marketing engine has three primary functions. Whether you have a team of 1 or 50, the functions exist — even if one person owns several.
+
+### Growth Marketing — the demand engine
+
+- Optimizes campaigns
+- Manages the funnel
+- Operates distribution channels
+- Runs the marketing tech stack
+- Data-driven; constantly testing and measuring
+
+Drives quantitative outcomes: leads, signups, paid traffic, conversion rate, CAC.
+
+### Product Marketing — the story engine
+
+- Transforms product benefits into compelling messages
+- Powers product launches
+- Equips the sales team
+- Owns pricing and packaging communication
+- Bridges what's built and why people should care
+
+Drives positioning quality, message-market fit, launch impact, sales enablement.
+
+### Content Marketing — the trust engine
+
+- Maintains the brand voice
+- Manages the editorial calendar
+- Produces content that reaches and teaches the audience
+- Proves impact through customer stories
+- Shapes industry conversations through thought leadership
+- Supports sales with closing content
+
+Drives organic traffic, brand affinity, thought leadership, trust signals.
+
+These three functions are interconnected. Growth without story is performance with no positioning. Story without distribution is a great pitch nobody hears. Trust without demand capture is brand affinity that doesn't compound into revenue.
+
+## The first marketing hire
+
+The most consequential decision in building the marketing engine isn't about channels or technology — it's who leads.
+
+**The first marketing hire should be a strategist, not a tactician.** Counterintuitive when there's a mountain of tactical work to ship. Essential for sustainable growth.
+
+### Look for π-shaped, not T-shaped
+
+The standard advice is to hire a **T-shaped marketer**: broad knowledge across many areas, deep in one. That's fine for a tactical IC role.
+
+For the first strategic hire, look for **π-shaped**: two deep skill sets, plus broad surface-level competency across the rest. The two depths create unique leverage through their combination.
+
+#### High-leverage combinations
+
+**Product Marketing + Growth Marketing**
+- Owns positioning *and* drives distribution
+- Crafts the message *and* gets it to market
+- No gap between planning and doing
+- Best for technical products or complex sales
+
+**Product Marketing + Content Marketing**
+- Translates product into compelling stories
+- Owns voice and positioning together
+- Creates content that compounds
+- Best for thought-leadership or education-driven markets
+
+**Growth Marketing + Content Marketing**
+- Builds the demand engine and the content that fuels it
+- Closes the loop between SEO/social distribution and conversion
+- Best for content-led growth motions
+
+The wrong shape for a first hire: deep paid media specialist alone, deep SEO specialist alone, deep designer alone. These are tactical depths; they need a strategic owner above them.
+
+### Title and progression — don't inflate
+
+A common mistake: making the first marketing hire a "CMO" or "VP." Creates problems when you actually need to scale the org, because there's no headroom above them.
+
+The right progression:
+
+| Title | Scope |
+|---|---|
+| **Manager** | Individual contributor, co-manages freelancers |
+| **Lead** | Senior IC, manages freelancers/agencies |
+| **Director / Head** | Manages ICs and vendors |
+| **VP** | Manages Directors |
+| **Chief (CMO)** | Manages VPs |
+
+The first hire is almost always **Marketing Manager** or **Marketing Lead**. They should be able to:
+
+- Define positioning — not just describe what you do, but why it matters
+- Identify best channels — from data, not intuition
+- Create the messaging framework — consistency across touchpoints
+- Build the marketing engine — systems that scale beyond any individual
+- Manage external resources — get the most from agencies and contractors
+
+Both strategic *and* hands-on. Comfortable setting direction and rolling up sleeves. Most importantly: a **builder** — creates processes, frameworks, and systems that scale beyond their individual capacity.
+
+## The marketing engine — three components
+
+Think of the marketing organization as an engine. Each part has a specific role; the magic is in how they work together.
+
+### The Fuel — Strategy
+
+What powers everything else. Without good fuel, even the best engine sputters.
+
+- Product marketing creates positioning (foundation of all communication)
+- Content marketing develops stories (features → benefits that resonate)
+- Brand marketing establishes identity (memorable and meaningful)
+
+Quality of the fuel determines efficiency. Poor positioning, weak stories, inconsistent branding waste energy regardless of execution.
+
+### The Engine — Execution
+
+Where strategy turns into action.
+
+- Growth marketing drives distribution (right message to the right people)
+- Demand gen creates opportunities (attention → interest)
+- Operations maintains systems (everything running smoothly)
+
+Needs to be well-maintained and properly tuned. Right processes, tools, people in place to execute consistently.
+
+### The Dashboard — Analytics
+
+How you know if you're heading in the right direction.
+
+- Metrics track performance (measuring what matters)
+- Attribution shows what works (cause and effect)
+- Data informs decisions (evidence over opinion)
+
+Without good instrumentation, flying blind. Need both leading and lagging indicators.
+
+## Working with agencies — selection framework
+
+Not all agencies are created equal. Ranked from most appropriate for early-stage to least:
+
+### Individual contractors
+- **Most flexible** — adapt quickly to changing requirements
+- **Direct relationship** — no account-management layer
+- **Often most cost-effective** — pay for pure expertise
+- **Best for** specific skills (paid media op, technical SEO, video editor, designer)
+
+For most pre-Series-A companies, this is the right answer for nearly all outsourced work.
+
+### Small niche agencies
+- **Specialized expertise** — deep knowledge in specific areas
+- **Personal attention** — often working directly with senior team
+- **Often founder-led** — experienced practitioners calling the shots
+- **Clear focus** — they know what they're good at
+- **Best for** specialized needs with some complexity (full SEO program, lifecycle email program, brand identity work)
+
+### Small generalist agencies
+- **Broader capabilities** — handle multiple needs
+- **More resources** — team approach to problems
+- **Multiple skill sets** — cross-functional
+- **Usually more expensive** — paying for convenience
+- **Best for** companies needing broader support and willing to pay for the simplicity of fewer relationships
+
+### Large agencies (not recommended for most startups)
+- Long contracts, high minimums, junior account teams, slow turnaround
+- Useful only when the brand spend is large enough to command senior attention
+
+## Setting agencies up for success
+
+The difference between a successful and failed agency relationship usually comes down to structure and management.
+
+### Before starting
+
+- **Define clear objectives** — what specific outcomes are we seeking?
+- **Set realistic timelines** — when do we need to see results?
+- **Establish communication channels** — how do we stay aligned?
+- **Agree on metrics** — what defines success?
+- **Document processes** — how do we work together?
+
+### During engagement
+
+- **Regular check-ins** — weekly tactical, monthly strategic
+- **Clear feedback loops** — both ways, positive and constructive
+- **Data sharing** — give them what they need to succeed
+- **Performance reviews** — measure against agreed metrics
+- **Strategy alignment** — ensure they're moving with the business
+
+### Red flags
+
+- **Scope creep beyond core expertise** — trying to do too much
+- **High team turnover** — losing institutional knowledge
+- **Missed deadlines** — failing to deliver as promised
+- **Poor communication** — lack of proactive updates
+- **Unclear reporting** — can't demonstrate value
+
+The best agency relationships feel like partnership: they understand the business, care about success, bring expertise you couldn't build in-house affordably. Takes work on both sides — clear expectations, open communication, mutual respect.
+
+## Scaling the model by stage
+
+The right ratio of internal to external resources isn't static. It evolves with stage, needs, and market conditions.
+
+### Early stage (pre-product-market-fit)
+
+**Mode:** discovery and iteration
+
+- **Internal:** 1–2 strategic hires leading the charge (often the founder + one π-shaped marketer)
+- **External:** specialized contractors for execution (no long-term commitment)
+- **Agency relationships:** project-based, testing approaches before bigger investments
+- **North star:** solid foundation while keeping fixed costs low
+
+### Growth stage (post-PMF, scaling what works)
+
+**Mode:** optimization
+
+- **Internal:** small but mighty core strategic team that owns marketing direction
+- **External:** balanced mix of contractors and agencies, each chosen for specific expertise
+- **Agency relationships:** deeper, longer-term — partners who grow with you
+- **North star:** double down on channels and approaches that have proven successful
+
+### Scale stage (multi-channel, multi-segment)
+
+**Mode:** coordination
+
+- **Internal:** larger strategic team focused on coordination and oversight (not execution)
+- **External:** specialized agencies, each bringing deep expertise in specific areas of the mix
+- **Trusted contractor network:** flexibility for variable workloads and special projects
+- **North star:** finding efficiencies, improving processes, maximizing return
+
+The metaphor: a symphony orchestra. The internal team conducts. External partners play their instruments with expertise.
+
+## How this informs the plan
+
+| Section | What to include |
+|---|---|
+| **3 (Current state)** | Team composition — every person who touches marketing, what they own. Identify where the team is π-shaped vs. T-shaped vs. tactical-only. Flag gaps. |
+| **9 (90-day roadmap)** | If the team is missing the strategic owner, the first move is the first marketing hire (Lead or Manager). If the team has strategy but no execution capacity, the first move is the first contractor or specialized agency. |
+| **10 (12-month outlook)** | Map team evolution against funding-stage capability unlocks (see `funding-stage-unlocks.md`). When does the second hire come in? When does an agency relationship deepen? |
+| **11 (Marketing operations stack)** | RACI is more honest with this model: "owned by" = internal strategic role; "executed by" = internal IC, contractor, or agency. The plan should make it explicit who does what. |
+| **13 (Open decisions)** | If "first marketing hire" is open, name it as a top-three decision. If "in-house vs agency" for a specific function is open, frame the tradeoff using this doc's heuristics. |
+
+## Operational guardrails
+
+- **Don't title-inflate the first hire.** It paints the org into a corner.
+- **Don't outsource positioning.** Even the best agency can articulate it back to you, but only if the conviction came from the team.
+- **Don't full-time hire for a six-month sprint.** Use a contractor. The hidden cost of full-time is the months of ramp + the awkwardness of letting them go if the work doesn't compound.
+- **Don't agency-hire to delay a strategy conversation.** Agencies execute; they don't replace strategic owners. If the internal team can't tell the agency what to do, the agency can't help.
+- **Don't measure team size as a success metric.** Measure output, not headcount. A 4-person team with the right π-shaped leader and great external partners out-performs a 15-person team without strategic clarity.


### PR DESCRIPTION
## Summary

Adds three substantive new reference frameworks to the `marketing-plan` skill, drawn from *Founding Marketing* by Corey Haines. Bumps the skill from 1.0.0 → 1.1.0.

The three new docs cover the three areas the v1.0 plan structure pointed at but didn't fully equip the planner with: **how to set the budget defensibly, what real SaaS growth shapes look like, and who should be on the team vs. outsourced**.

## What's in it

### `references/budget-planning.md` (168 lines)
- **Method 1 — Revenue-Based** (5–40% of ARR): conservative (5%), standard (15–25%), aggressive (up to 40%). Worked examples at $1M ARR.
- **Method 2 — Goal-Based**: formula `[(New ARR / (ARPC × 12)) × CAC] / annual retention rate`, walked step-by-step at the $1M → $2M ARR example.
- **CAC must be blended** — must include salaries, content costs, tools, retainers; not just paid ad spend.
- **+10–20% experimental buffer** rule.
- **3-3-2-2-2 VC growth path** (3× in years 1–2, 2× in years 3–7 from $1M ARR).
- **Forecasting reality check** — no startup under $100M ARR reliably hits monthly forecasts. Annual goal + budget commit honestly; month-by-month projection is illustrative.

### `references/growth-patterns.md` (148 lines)
- **The long, slow SaaS ramp** — $0–10K (grueling), $10K–100K (treacherous middle, $8–10K MRR is the full-time threshold), $100K–1M (acceleration: from $100K → $200K in 1/3 the time it took to reach the first $100K).
- **Linear vs step-function growth** — both are real; the exponential growth myth isn't. They combine to *look* exponential when zoomed out.
- **Channel × Product × Market S-curves** — start the next curve before the current plateaus. SEO is the marathon runner (6–12 months to mature). Paid hits diminishing returns. Content compounds.
- **3-3-2-2-2 anchor** for VC-backed Series A+ companies.

### `references/team-and-agency-model.md` (278 lines)
- **The principle**: strategy lives in-house, execution can — and often should — be outsourced.
- **The two failure modes**: hiring a junior tactician first / hiring an expensive agency for strategy.
- **Three core functions**: Growth (demand engine), Product (story engine), Content (trust engine).
- **π-shaped marketer** (not T-shaped) — two deep skill sets. High-leverage combos: PM+Growth, PM+Content, Growth+Content.
- **Title progression**: Manager → Lead → Director → VP → Chief. Don't inflate first hire.
- **Agency selection**: individual contractors → small niche → small generalist → large (last resort).
- **Three-stage scaling model**: Early (1–2 strategic hires, contractors for execution) → Growth (small core team + deeper agency relationships) → Scale (larger strategic team coordinating specialized partners).

## Enhanced existing files (wiring the new frameworks in)

- **`SKILL.md`** (244 → 270 lines, still well under 500): new sections "Setting the budget scientifically," "Growth patterns — the real shape of SaaS growth," "Team and agency model." Expanded "What every plan must customize" from 7 items to 9 (added unit economics + phase of growth). Description unchanged.
- **`references/funding-stage-unlocks.md`**: Related-docs pointer block linking to the three new frameworks.
- **`references/measurement-framework.md`**: Related-docs pointer block. New "Anchoring against the VC growth path" section. New "Forecasting reality check" section.
- **`references/methodology.md`**: Intake 5 (Team) now probes π-shaped vs T-shaped vs tactical-only. Intake 6 (Budget) now probes blended CAC, ARPC, retention rate.
- **`references/plan-template.md`**: Section 3 adds Phase of SaaS Growth. Section 8 adds required Unit Economics table. Section 10 adds budget-method framing block + per-quarter S-curve position field. Section 11 adds RACI table mapping the three core functions to internal-owner and external-executor.

## VERSIONS bump

`marketing-plan: 1.0.0 → 1.1.0` (last updated 2026-05-29). Marketplace version stays at 2.3.0 — release decision is separate.

## Test plan

- [x] `./validate-skills.sh` — 43/43 passing
- [x] SKILL.md still under 500 lines (270)
- [x] SKILL.md description still under 1024 chars (949)
- [x] No `audit-marketing`, `cf-skills`, `conversionfactory` references in any of the new files
- [x] No Claude-Code-only `` !`command` `` syntax
- [x] All three new docs cross-reference each other and the existing reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
