### PR TITLE
docs: improve skill quality checklist in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,8 +78,10 @@ skills/your-skill-name/
 
 ## Skill Quality Checklist
 
-- [ ] `name` matches directory name
-- [ ] `description` clearly explains when to use the skill
+- [ ] `name` matches directory name exactly
+- [ ] `name` follows naming rules (lowercase, hyphens only, no consecutive `--`)
+- [ ] `description` is 1-1024 chars and includes trigger phrases
+- [ ] `SKILL.md` is under 500 lines (move details to `references/`)
 - [ ] Instructions are clear and actionable
 - [ ] No sensitive data or credentials
 - [ ] Follows existing skill patterns in the repo


### PR DESCRIPTION
## Summary

- Added explicit naming rule: lowercase, hyphens only, no consecutive `--`
- Added description length constraint (1-1024 chars with trigger phrases)
- Added 500-line limit for `SKILL.md` (consistent with `CLAUDE.md`)

The checklist was missing a few validation rules that are already documented in `CLAUDE.md`. This aligns both files so contributors have the full picture in one place.