### PR TITLE
chore: release v2.4.0

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -33,6 +33,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | ads | 2.0.1 | 2026-05-26 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
+| pr | 1.0.0 | 2026-06-10 |
 | pricing | 2.0.0 | 2026-05-05 |
 | product-marketing | 2.0.0 | 2026-05-05 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
@@ -45,10 +46,16 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
-| social | 2.0.0 | 2026-05-05 |
+| social | 2.1.0 | 2026-06-10 |
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.4.0 (2026-06-10)
+
+- Added `pr` skill for public relations / earned media work — pitching journalists, newsjacking trending stories, responding to press requests (HARO/Connectively, Qwoted, Featured, Help A B2B Writer), and building the owned-media foundation (press page + media kit). Four PR modes (reactive / proactive / inbound / owned), explicit when-to-skip framing, and a banned-vocabulary list. References include: `newsjacking.md` (detect → score → angle → pitch loop with newsworthiness scoring rubric, 7 angle templates, Google News / HN / Reddit curl recipes, failure modes); `journalist-pitching.md` (media list construction, journalist fit scoring, 6 pitch templates by angle — data story / exclusive launch / op-ed / customer story / trend connector / newsjack response — subject-line craft, embargo etiquette, follow-up cadence); `press-platforms.md` (daily triage workflow, response template, ROI reality check); `media-outlets.md` (tiered list of tech press, SaaS, AI, devtools, business outlets, newsletters, podcasts, vertical press, regional press — explicitly scoped to journalist-driven outlets, with startup directories deferred to `directory-submissions`). Scope is enforced via cross-references: the `pr` skill handles earned media; `directory-submissions` handles Product Hunt / BetaList / SaaS directories; `launch` handles the broader launch moment.
+- **social** (2.0.0 → 2.1.0): added `references/listening.md` for engagement triage — a daily loop for surfacing the top posts to comment on rather than scrolling feeds. Includes a 5-dimension scoring rubric (ICP fit, intent signal, reach potential, comment opportunity, recency), comment quality tiers, curl-based recipes for Reddit / HN Algolia / Bluesky (no auth required), and a browser-driven workflow for LinkedIn and X via `dev-browser` with persistent session. Added `references/listening-sources-template.md` — a copyable starter for `.agents/listening-sources.md` covering brand/category context, ICP definition, target accounts per platform, intent keywords, subreddits, saved-search URLs, and a do-not-engage list. SKILL.md Engagement Strategy section now links to the listening reference.
+- Total skills: 44.
 
 ### 2.3.0 (2026-05-27)
 


### PR DESCRIPTION
## Summary

Release v2.4.0. Adds the new `pr` skill and bumps `social` for the listening reference.

- New skill: **`pr`** (1.0.0) — public relations / earned media. Newsjacking, journalist pitching, press platforms, media outlets. PR #355.
- Updated skill: **`social`** (2.0.0 → 2.1.0) — listening reference + sources template for daily engagement triage. PR #347.

Total skills: 43 → 44.

## VERSIONS.md changes

- Added `pr | 1.0.0 | 2026-06-10` row to the skill table
- Bumped `social` row to `2.1.0 | 2026-06-10`
- Added `### 2.4.0 (2026-06-10)` section to "Recent Changes" with full descriptions of both additions

## Test plan

- [ ] Verify `VERSIONS.md` table renders correctly on GitHub
- [ ] Verify version comparison still works for agents fetching VERSIONS.md raw
- [ ] Confirm the `pr` skill triggers on PR-related phrases without conflicting with "pull request" usage
- [ ] Confirm `social` listening workflow triggers via engagement-related phrasing

Generated with Claude Code
