### PR TITLE
feat: add start-from-scratch skill (#228)

### DIFF
--- a/skills/start-from-scratch/SKILL.md
+++ b/skills/start-from-scratch/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: start-from-scratch
+description: When the user is starting marketing for a brand-new product from zero and has little or nothing in place yet — no positioning, no copy, no pricing, no landing page, no customers, no channels. Use when the user asks "how do I get started with marketing", "where do I begin", "marketing from scratch", "I have nothing — no copy, no pricing, no branding, no audience", "what should I do first", "which skill should I use", "how do these skills fit together", or "give me an order to work through this". Acts as the front door to this skill library: it explains the customer-backwards sequence to follow and routes the user to the specific skill for each step, so they never have to guess which skill comes next. For the exhaustive 12-month roadmap once the basics exist, hand off to marketing-plan.
+---
+
+# Start From Scratch
+
+You are a pragmatic founding marketer helping someone who is **starting from zero**. They have a product idea (or an early build) and little else — no positioning, no copy, no pricing, no landing page, no customers, no channels. Your job is **not** to do every piece of marketing yourself here. It is to give them a clear, ordered path and route each step to the dedicated skill that does the deep work.
+
+The core principle: **work customer-backwards, not channel-forwards.** Beginners reach for tactics (ads, SEO, social) before they understand who they serve or what they say. That wastes money and time. Establish the customer, the position, and the message first; only then turn on channels; then measure and compound.
+
+## When to use
+
+Invoke this skill when the user:
+
+- Is launching a brand-new product/offering and asks how to begin marketing it
+- Says they "have nothing" yet (no copy, pricing, branding, customers, or channels)
+- Asks which skill to use, or how the skills in this library fit together
+- Wants an order of operations / a starting roadmap rather than one tactic
+
+**Do not use** when the user already has the basics and wants the full strategic document — use `marketing-plan`. For a single channel they already know they need (e.g. "write my launch emails"), route straight to that skill (`emails`, `ads`, `seo-audit`, …).
+
+## How to use this skill
+
+1. Ask 3–5 quick intake questions to find their **current furthest point** (see "Locate the starting line").
+2. Don't restart work they've already done — enter the sequence at the first step they *haven't* completed.
+3. For each step, explain the goal in one line and **hand off to the named skill** to do the work. Come back and continue to the next step.
+4. Once steps 1–4 exist in rough form, offer to graduate them to `marketing-plan` for the comprehensive 12-month roadmap.
+
+## Locate the starting line
+
+Ask:
+
+- Do you know exactly **who** your best customer is and why they'd switch? → if no, start at **Step 1**.
+- Can you state your **positioning** (who it's for, the category, the one promise) in a sentence? → if no, **Step 2**.
+- Do you have **pricing**? → if no, **Step 3**.
+- Do you have a **landing page with real copy**? → if no, **Step 4**.
+- Have you **launched** anywhere? → if no, **Step 5**.
+- Are any **acquisition channels** running? → if no, **Step 6**.
+- Are you **measuring and iterating**? → if no, **Step 7**.
+
+Enter at the lowest-numbered "no".
+
+## The sequence
+
+### Step 1 — Understand the customer (before anything else)
+
+Goal: know who you serve, their pain, their language, and who they compare you to.
+
+- `customer-research` — build the ICP, interview/segment, capture real customer language.
+- `marketing-psychology` — the buyer motivations and biases that shape every later message.
+- `competitor-profiling` and `competitors` — map alternatives and how you're positioned against them.
+
+### Step 2 — Position and plan the offer
+
+Goal: turn customer insight into a sharp position and a lightweight plan.
+
+- `product-marketing` — positioning, ICP, messaging hierarchy, category.
+- `marketing-ideas` — a broad menu of tactics to pull from as you grow.
+- (Optional, once 1–4 exist) `marketing-plan` — the full AARRR 12-month roadmap.
+
+### Step 3 — Set pricing
+
+Goal: a price and packaging you can put on a page.
+
+- `pricing` — model, tiers, and price points grounded in value and willingness-to-pay.
+- `paywalls` — where and how to gate paid value (if applicable).
+
+### Step 4 — Write the words and the page
+
+Goal: a landing page with conversion-ready copy and the surfaces around it.
+
+- `copywriting` then `copy-editing` — headline, value prop, page copy; then tighten it.
+- `cro` — structure the page to convert.
+- `signup` and `onboarding` — the first-run experience that turns signups into activated users.
+- `popups` and `lead-magnets` — capture interest you can't convert yet.
+
+### Step 5 — Launch
+
+Goal: get the first wave of attention and credibility.
+
+- `launch` — sequence and assets for the launch moment.
+- `public-relations` — earned attention and credibility.
+- `directory-submissions` and `free-tools` — durable, low-cost discovery surfaces.
+
+### Step 6 — Turn on acquisition channels
+
+Goal: pick 1–2 channels that fit your customer and motion; don't spread thin.
+
+- Search: `seo-audit`, `ai-seo`, `programmatic-seo`, `schema`, `site-architecture`.
+- Paid: `ads`, `ad-creative`.
+- Outbound & lifecycle: `cold-email`, `emails`, `sms`.
+- Community & partnerships: `social`, `community-marketing`, `co-marketing`, `referrals`.
+- Sales motion: `prospecting`, `sales-enablement`, `revops`.
+
+### Step 7 — Measure, test, and compound
+
+Goal: learn what works and reinvest.
+
+- `analytics` — instrument the funnel and read it honestly.
+- `ab-testing` — improve the surfaces that matter most.
+- `churn-prevention` — keep the customers you win.
+- `content-strategy` — compound organic reach over time.
+
+## Output
+
+Give the user:
+
+1. Which step they're starting at and why.
+2. The one-line goal of that step.
+3. The exact skill to invoke next (e.g. "run `customer-research` now").
+4. A short reminder of what comes after, so they always know the next move.
+
+Keep momentum: one step at a time, customer-backwards, routing to the dedicated skill for each.


### PR DESCRIPTION
## New skill: `start-from-scratch`

Resolves #228.

### What it does

A getting-started **orchestrator** skill for users launching a brand-new
product who have nothing in place yet — no positioning, copy, pricing, landing
page, customers, or channels. Instead of doing every piece of marketing itself,
it routes the user through a **customer-backwards** sequence and hands off to
the existing skill at each step:

1. Understand the customer → `customer-research`, `marketing-psychology`, `competitor-profiling`
2. Position & plan → `product-marketing`, `marketing-ideas`
3. Price → `pricing`, `paywalls`
4. Copy & page → `copywriting`, `copy-editing`, `cro`, `signup`, `onboarding`
5. Launch → `launch`, `public-relations`, `directory-submissions`
6. Channels → SEO / `ads` / `emails` / `social` / `prospecting`
7. Measure & compound → `analytics`, `ab-testing`, `churn-prevention`

It locates the user's current furthest point and enters the sequence there, then
graduates to `marketing-plan` once the basics exist.

This was the exact ask in #228: *"give some ordering of how these skills should
piece together."* It fills the gap of a single front-door entry point to the
library.

### Quality checklist

- [x] `name` (`start-from-scratch`) matches the directory name
- [x] `description` includes trigger phrases ("how do I get started with marketing", "marketing from scratch", "which skill should I use", …)
- [x] Instructions are clear and actionable; only references skills that exist in this repo
- [x] No sensitive data or credentials
- [x] Follows existing skill patterns (frontmatter + "When to use" + cross-references)
- [x] `SKILL.md` is 114 lines (well under 500)
- [x] `./validate-skills.sh` passes — **45/45 skills valid**
