### PR TITLE
docs(readme): add AI Marketing Training CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A collection of AI agent skills focused on marketing tasks. Built for technical marketers and founders who want AI coding agents to help with conversion optimization, copywriting, SEO, analytics, and growth engineering. Works with Claude Code, OpenAI Codex, Cursor, Windsurf, and any agent that supports the [Agent Skills spec](https://agentskills.io).
 
-Built by [Corey Haines](https://corey.co?ref=marketingskills). Need hands-on help? Check out [Conversion Factory](https://conversionfactory.co?ref=marketingskills) — Corey's agency for conversion optimization, landing pages, and growth strategy. Want to learn more about marketing? Subscribe to [Swipe Files](https://swipefiles.com?ref=marketingskills). Want an autonomous AI agent that uses these skills to be your CMO? Try [Magister](https://magistermarketing.com?ref=marketingskills).
+Built by [Corey Haines](https://corey.co?ref=marketingskills). Need hands-on help? Check out [Conversion Factory](https://conversionfactory.co?ref=marketingskills) — Corey's agency for conversion optimization, landing pages, and growth strategy. Want to learn more about marketing? Subscribe to [Swipe Files](https://swipefiles.com?ref=marketingskills). Want to get dangerously good at using AI for marketing? Check out [AI Marketing Training](https://conversionfactory.co/offers/ai-marketing-training?ref=marketingskills). Want an autonomous AI agent that uses these skills to be your CMO? Try [Magister](https://magistermarketing.com?ref=marketingskills).
 
 New to the terminal and coding agents? Check out the companion guide [Coding for Marketers](https://codingformarketers.com?ref=marketingskills).
 


### PR DESCRIPTION
## Summary

Adds an AI Marketing Training CTA in the README intro paragraph.

## Placement

Inserted between the Swipe Files newsletter mention and the Magister autonomous-agent mention. Preserves the existing flow:

- **Hands-on help** → Conversion Factory
- **Learn from content** → Swipe Files
- **Learn through training** → AI Marketing Training (new)
- **Hands-off autonomous** → Magister

## Copy

> Want to get dangerously good at using AI for marketing? Check out [AI Marketing Training](https://conversionfactory.co/offers/ai-marketing-training?ref=marketingskills).

Uses the "dangerously good at AI" framing from the recent training-launch tweet. Includes the standard `?ref=marketingskills` tracking param matching the other links.

## Test plan
- [ ] Verify the README renders correctly on GitHub after merge
- [ ] Confirm the link resolves and tracks the ref param

Generated with Claude Code
