### PR TITLE
feat(ai-seo): add Open Knowledge Format (OKF) coverage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ Current versions of all skills. Agents can compare against local versions to che
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
 | ad-creative | 2.0.0 | 2026-05-05 |
-| ai-seo | 2.0.1 | 2026-05-18 |
+| ai-seo | 2.1.0 | 2026-06-15 |
 | analytics | 2.0.0 | 2026-05-05 |
 | aso | 2.0.0 | 2026-05-05 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
@@ -50,6 +50,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.4.2 (2026-06-15)
+
+- **ai-seo** (2.0.1 → 2.1.0): added coverage of Google's Open Knowledge Format (OKF), a v0.1 markdown spec for agent-readable site bundles introduced on the Google Cloud blog on 2026-06-12 and shipped inside Knowledge Catalog. New `references/okf.md` reference covers what OKF is (directory of cross-linked markdown files with YAML frontmatter — `type` required, plus `title`/`description`/`resource`/`tags`/`timestamp` recommended), honest framing (Google built it for data-team catalog metadata; site-readable repurposing popularized by Suganthan Mohanadasan is a clever secondary use), what it does for AI search today (nothing immediate; protocol-layer registration like early schema.org adoption), where OKF fits in the agent-readable stack alongside `sitemap.xml` / `robots.txt` / `llms.txt` / `/pricing.md` / schema, three ways to ship a bundle (Suganthan's free web generator, his pending WordPress plugin, or by hand), hosting guidance (`yoursite.com/okf/index.md` plus an `llms.txt` line pointing to it), when to skip (closed platforms like Wix/Squarespace, very small sites, sites without other machine-readable files), and what to watch (v1.0 spec, AI engine adoption signals). `SKILL.md` adds a brief OKF subsection under "Machine-Readable Files for AI Agents" pointing to the reference. Frontmatter description extended with new triggers: `llms.txt`, `OKF`, `Open Knowledge Format`, `knowledge bundle`, `agent-readable site`. `references/platform-ranking-factors.md` Google AI Overviews section gets an OKF callout framing it as a "register early" protocol bet rather than a confirmed ranking signal.
 
 ### 2.4.1 (2026-06-10)
 

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ai-seo
-description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
+description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' 'optimize for Claude/Gemini,' 'llms.txt,' 'OKF,' 'Open Knowledge Format,' 'knowledge bundle,' or 'agent-readable site.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
 metadata:
-  version: 2.0.1
+  version: 2.1.0
 ---
 
 # AI SEO
@@ -312,6 +312,10 @@ Add these machine-readable files to your site root:
 **`/llms.txt`** — Context file for AI systems (see [llmstxt.org](https://llmstxt.org))
 
 If you don't have one yet, add an `llms.txt` that gives AI systems a quick overview of what your product does, who it's for, and links to key pages (including your pricing).
+
+**`/okf/` — Open Knowledge Format bundle (Google-backed, v0.1)**
+
+Google [introduced OKF](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) in June 2026 — a markdown spec for representing site content as a directory of cross-linked files with YAML frontmatter, agent-readable without scraping. Built primarily for data-team catalog metadata; the site-readable-by-agents repurposing was popularized by Suganthan Mohanadasan. No confirmed AI-search ranking signal today — treat it as protocol-layer registration like early schema.org. **For the full breakdown, implementation paths (free generator, WordPress plugin, by-hand), hosting guidance, and when to skip, see [references/okf.md](references/okf.md).**
 
 ### Schema Markup for AI
 

--- a/skills/ai-seo/references/okf.md
+++ b/skills/ai-seo/references/okf.md
@@ -1,0 +1,104 @@
+# Open Knowledge Format (OKF)
+
+Google's v0.1 markdown spec for representing site content as an agent-readable bundle. Introduced on the [Google Cloud blog](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) on 2026-06-12 and shipped inside Knowledge Catalog.
+
+## What it is
+
+OKF is a directory of cross-linked markdown files. Each file has:
+
+- A YAML frontmatter block (`type` required; `title`, `description`, `resource`, `tags`, `timestamp` recommended)
+- A standard markdown body
+- Standard markdown links to other files in the bundle (which the spec treats as concept relationships)
+
+An optional `index.md` lists the files for progressive disclosure. The bundle can be distributed as a git repo (recommended), a tarball/zip, or a subdirectory of a larger repo.
+
+The [full spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/HEAD/okf/SPEC.md) fits on one page. The repo lives under `GoogleCloudPlatform` (the "not an official Google product" disclaimer is Google's standard open-source boilerplate, not a denial — it appears on most of Google's open-source repos including their main AI samples repo).
+
+### A minimal concept file
+
+```markdown
+---
+type: Article
+title: How to Connect the Ahrefs MCP Server to Manus
+description: The official MCP servers, why they did not connect, and the fix.
+resource: https://yoursite.com/blog/ahrefs-mcp-manus/
+tags: [mcp, ahrefs]
+---
+
+# How to Connect the Ahrefs MCP Server to Manus
+
+The body of the post, as clean markdown.
+```
+
+Add an `index.md` that lists all files so an agent can see the bundle's shape before opening each file, and that is the entire format.
+
+## Honest framing
+
+**Google built OKF for data teams sharing catalog metadata** — BigQuery tables, API endpoints, metrics, playbooks. Most of the spec's examples are data-team artifacts, not blog posts. Google's blog post framing: "improve data sharing" and "standardized documentation" for collaboration across teams.
+
+Pointing OKF at a marketing site is a **clever repurposing** popularized by [Suganthan Mohanadasan](https://suganthan.com/blog/open-knowledge-format/). It's a legitimate use case for the format but not Google's primary one. Frame it accurately when explaining it to founders or marketing teams.
+
+## What it does for AI search today
+
+Nothing immediate. Nothing crawls the web for OKF bundles yet — the spec is weeks old, no AI engine has announced integration, and Knowledge Catalog ingests bundles only for paying enterprise customers' data teams.
+
+Treat OKF as **protocol-layer registration** — the same shape of bet as early `schema.org` adoption was a decade ago. Schema took the better part of ten years to pay off; people who shipped it early are still glad they did.
+
+A secondary benefit that pays off today regardless: **generating the bundle is itself an internal-linking audit**. Suganthan's tool draws every page as a node and every internal link as an edge, so islands and orphans become obvious at a glance.
+
+## Where OKF fits in the agent-readable stack
+
+| Layer | Purpose |
+|---|---|
+| `sitemap.xml` | Tells a crawler which URLs exist |
+| `robots.txt` (with AI bot rules) | Permits or blocks AI crawlers |
+| `llms.txt` | Points an agent at the handful of pages you most want read |
+| `/pricing.md` | Structured pricing for agent-buyer comparisons |
+| **`/okf/` bundle** | Hands over the content itself as cross-linked concepts |
+| Schema markup | Per-page structured data (Article, FAQPage, Product, etc.) |
+
+These stack rather than compete. `llms.txt` is a signpost, OKF is the library.
+
+## How to ship one
+
+Three options, ordered by how much effort they take:
+
+### 1. Suganthan's free web tool (recommended for most sites)
+
+[suganthan.com/okf-generator](https://suganthan.com/okf-generator/) — paste a URL or sitemap, crawls up to 100 pages, returns a downloadable bundle. Also draws the resulting page graph so you can spot disconnected pages before publishing.
+
+### 2. WordPress plugin (pending wp.org approval)
+
+Suganthan's plugin (free, GPL, awaiting wp.org approval at time of writing) installs in a minute, serves the bundle at `/okf/`, and rebuilds on every publish or edit so it stays in sync. Direct download link is in [his blog post](https://suganthan.com/blog/open-knowledge-format/). Requires WordPress 6.0+ and PHP 7.4+. Read-only — never edits posts or settings.
+
+### 3. By hand
+
+Only practical for a handful of pages. Each post becomes a markdown file with frontmatter that you cross-link manually. Miserable for a whole site.
+
+## Hosting & discovery
+
+Serve the bundle at `yoursite.com/okf/`, starting with `yoursite.com/okf/index.md`:
+
+- **Static hosts / Cloudflare**: drag and drop
+- **WordPress**: Suganthan's plugin handles the serving
+- **Static sites with custom paths**: upload the directory to `/okf/`
+- **Closed platforms (Wix, Squarespace, most page-builders)**: you usually can't serve files at custom paths — skip OKF entirely
+
+After it's serving, add a line to `llms.txt` pointing to the bundle so agents that read `llms.txt` (today) can discover the bundle (later).
+
+## When to skip
+
+- Site is <10 pages — overhead exceeds payoff
+- Site is on a closed platform that won't allow custom paths
+- You're not maintaining `llms.txt`, schema markup, or other machine-readable files (OKF compounds with those; alone it does nothing)
+- You can't budget the 30 minutes a quarter to refresh the bundle as content changes
+
+## What to watch
+
+OKF is v0.1, weeks old. Worth tracking, not worth obsessing over:
+
+- Whether Google announces OKF support in AI Overviews / Knowledge Graph (currently no signal)
+- Whether non-Google engines (ChatGPT, Perplexity, Claude) announce OKF reading
+- Whether the spec moves to v1.0 (breaking changes are possible at <1.0)
+- Whether Knowledge Catalog adds public ingestion endpoints
+- Adoption signals — search GitHub for `okf/index.md` to see who's shipping bundles

--- a/skills/ai-seo/references/platform-ranking-factors.md
+++ b/skills/ai-seo/references/platform-ranking-factors.md
@@ -34,6 +34,8 @@ Google AI Overviews pull from Google's own index and lean heavily on E-E-A-T sig
 - Get into Google's Knowledge Graph where possible (an accurate Wikipedia entry helps)
 - Target "how to" and "what is" query patterns — these trigger AI Overviews most often
 
+**Watch for OKF.** In June 2026 Google introduced the [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) — a markdown spec for agent-readable site bundles. There is no confirmed signal that AI Overviews factor it in today, but the spec is published, the GitHub repo lives under `GoogleCloudPlatform`, and it ships inside Knowledge Catalog. For protocol-layer "register early" plays, it has the same shape as early schema.org adoption did a decade ago. See **Machine-Readable Files for AI Agents** in the main `SKILL.md` for how to generate and serve a bundle.
+
 ---
 
 ## ChatGPT


### PR DESCRIPTION
## Summary

Adds coverage of Google's Open Knowledge Format (OKF) to the `ai-seo` skill. Shipped as a release of the skill (2.0.1 → 2.1.0) and a patch on the repo (2.4.1 → 2.4.2 — no new skill, content addition only).

OKF is a v0.1 markdown spec Google [introduced](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) on 2026-06-12, shipping inside Knowledge Catalog. Suganthan Mohanadasan's [post](https://suganthan.com/blog/open-knowledge-format/) surfaced it for SEO/AI-search audiences.

## Changes

- **`skills/ai-seo/references/okf.md`** — new 104-line reference covering what OKF is, where it fits in the agent-readable stack (sitemap → robots → llms.txt → /pricing.md → /okf/ → schema), three ways to ship a bundle (Suganthan's free generator, his pending WordPress plugin, by hand), hosting guidance, when to skip, and what to watch
- **`skills/ai-seo/SKILL.md`** — brief OKF subsection under "Machine-Readable Files for AI Agents" pointing to the reference. Frontmatter description extended with five new triggers: `llms.txt`, `OKF`, `Open Knowledge Format`, `knowledge bundle`, `agent-readable site`. Description still under 1024 (~750 chars). Skill bumped 2.0.1 → 2.1.0.
- **`skills/ai-seo/references/platform-ranking-factors.md`** — brief OKF callout added to the Google AI Overviews section, framing it as a "register early" protocol bet rather than a confirmed ranking signal
- **`VERSIONS.md`** — `ai-seo` row updated to 2.1.0 / 2026-06-15. New `### 2.4.2 (2026-06-15)` release notes section.
- **`.claude-plugin/marketplace.json`** + **`.claude-plugin/plugin.json`** — version 2.4.1 → 2.4.2

## Honest framing

Carried consistently through both `SKILL.md` and `references/okf.md`:

- Google built OKF for **data-team catalog metadata sharing** (BigQuery tables, API endpoints, metrics, playbooks)
- The **site-readable-by-agents repurposing** popularized by Suganthan is a clever secondary use, not Google's framing
- **No confirmed AI-search ranking signal today** — nothing crawls the web for OKF bundles yet
- Treat OKF adoption as **protocol-layer registration** — same shape of bet as early schema.org a decade ago
- Generating a bundle is a **free internal-linking audit** even if no agent ever reads it
- **Skip if** on a closed platform that won't allow `/okf/` paths, or if you're not maintaining other machine-readable files

## Verification

All four primary sources verified before drafting:
- Google Cloud blog post live, `datePublished: 2026-06-12`, title "How the Open Knowledge Format can improve data sharing"
- OKF v0.1 spec at `GoogleCloudPlatform/knowledge-catalog/okf/SPEC.md` retrieved in full (15KB single-page spec)
- Knowledge Catalog product page live at `cloud.google.com/products/knowledge-catalog`
- Suganthan's free OKF generator at `suganthan.com/okf-generator/` confirmed in his blog post
- WordPress plugin awaiting wp.org approval at time of writing (consistent with Suganthan's own note)

## Test plan

- [x] `validate-skills.sh` passes 44/44 skills
- [x] `ai-seo/SKILL.md` is 489 lines (under 500 soft cap after moving detail into reference)
- [x] Frontmatter description is ~750 chars (under 1024)
- [ ] After merge: verify trigger phrases like "set up OKF for my site" route to ai-seo
- [ ] After merge: confirm `claude plugin update` surfaces v2.4.2

Generated with Claude Code
