### PR TITLE
chore: release v2.5.1 — skill version bumps for v2.5.0 cross-refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -17,14 +17,14 @@ Current versions of all skills. Agents can compare against local versions to che
 | competitors | 2.0.0 | 2026-05-05 |
 | content-strategy | 2.0.0 | 2026-05-05 |
 | copy-editing | 2.0.0 | 2026-05-05 |
-| copywriting | 2.0.0 | 2026-05-05 |
+| copywriting | 2.0.1 | 2026-06-16 |
 | cro | 2.0.0 | 2026-05-05 |
 | customer-research | 2.0.0 | 2026-05-05 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
-| launch | 2.0.0 | 2026-05-05 |
+| launch | 2.0.1 | 2026-06-16 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
@@ -34,14 +34,14 @@ Current versions of all skills. Agents can compare against local versions to che
 | ads | 2.0.1 | 2026-05-26 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
-| pricing | 2.0.0 | 2026-05-05 |
+| pricing | 2.0.1 | 2026-06-16 |
 | product-marketing | 2.0.0 | 2026-05-05 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.0.0 | 2026-05-26 |
 | public-relations | 1.0.0 | 2026-06-10 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
-| sales-enablement | 2.0.0 | 2026-05-05 |
+| sales-enablement | 2.0.1 | 2026-06-16 |
 | schema | 2.0.0 | 2026-05-05 |
 | seo-audit | 2.0.0 | 2026-05-05 |
 | signup | 2.0.0 | 2026-05-05 |
@@ -51,6 +51,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.5.1 (2026-06-16)
+
+- Bumped `copywriting`, `launch`, `pricing`, and `sales-enablement` from 2.0.0 → 2.0.1 to reflect the description changes that shipped in v2.5.0 (cross-references added pointing to the new `offers` skill). The skill bodies are unchanged; only the frontmatter description picked up a new "For ..., see offers" line. Without the version bump, the repo's update check (which compares VERSIONS.md against local skill metadata) would not surface the routing/discovery change to users with installed copies. Caught by codex review.
 
 ### 2.5.0 (2026-06-16)
 

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -2,7 +2,7 @@
 name: copywriting
 description: When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says "write copy for," "improve this copy," "rewrite this page," "marketing copy," "headline help," "CTA copy," "value proposition," "tagline," "subheadline," "hero section copy," "above the fold," "this copy is weak," "make this more compelling," or "help me describe my product." Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see emails. For popup copy, see popups. For editing existing copy, see copy-editing. For the offer underneath the copy (bonuses, guarantees, value framing), see offers.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Copywriting

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -2,7 +2,7 @@
 name: launch
 description: "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas. For the offer being launched (bonuses, guarantees, scarcity, naming), see offers."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Launch Strategy

--- a/skills/pricing/SKILL.md
+++ b/skills/pricing/SKILL.md
@@ -2,7 +2,7 @@
 name: pricing
 description: "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywalls. For offer construction (bonuses, guarantees, value framing, naming) on services/courses/coaching/high-ticket B2B, see offers."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Pricing Strategy

--- a/skills/sales-enablement/SKILL.md
+++ b/skills/sales-enablement/SKILL.md
@@ -2,7 +2,7 @@
 name: sales-enablement
 description: "When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,' 'one-pager,' 'leave-behind,' 'objection handling,' 'deal-specific ROI analysis,' 'demo script,' 'talk track,' 'sales playbook,' 'proposal template,' 'buyer persona card,' 'help my sales team,' 'sales materials,' or 'what should I give my sales reps.' Use this for any document or asset that helps a sales team close deals. For competitor comparison pages and battle cards, see competitors. For marketing website copy, see copywriting. For cold outreach emails, see cold-email. For the offer being sold (bonuses, guarantees, pricing structure), see offers."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Sales Enablement


### PR DESCRIPTION
## Summary

v2.5.1 patch bumping `copywriting`, `launch`, `pricing`, and `sales-enablement` from 2.0.0 → 2.0.1 to surface the cross-reference description changes that shipped in v2.5.0.

Caught by a codex review of v2.5.0:

> These description changes alter skill routing/discovery, but the skill metadata and VERSIONS.md entries for copywriting, launch, pricing, and sales-enablement still say 2.0.0 / 2026-05-05. The repo's update check compares VERSIONS.md against local skill metadata, so users with installed copies will not be notified that these four skills changed.

## Changes

- `copywriting/SKILL.md` metadata `version: 2.0.0 → 2.0.1`
- `launch/SKILL.md` metadata `version: 2.0.0 → 2.0.1`
- `pricing/SKILL.md` metadata `version: 2.0.0 → 2.0.1`
- `sales-enablement/SKILL.md` metadata `version: 2.0.0 → 2.0.1`
- `VERSIONS.md` — four table rows updated to 2.0.1 / 2026-06-16; new `### 2.5.1` release notes section
- `marketplace.json` + `plugin.json` `2.5.0 → 2.5.1`

## Versioning

Patch bumps (not minor) because the change is just adding a cross-reference, not adding new content. Matches the precedent of `ai-seo` 2.0.0 → 2.0.1 for the Google guide alignment, and `social` 2.0.0 → 2.1.0 (minor) for the new listening reference (that one added a substantive file).

## Test plan

- [x] `validate-skills.sh` passes 45/45
- [ ] After merge: `claude plugin update` surfaces v2.5.1
- [ ] After merge: update check correctly identifies the 4 bumped skills as changed

Generated with Claude Code
