### PR TITLE
Add crisis-communications skill; extract social repurposing into reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [content-strategy](skills/content-strategy/) | When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also... |
 | [copy-editing](skills/copy-editing/) | When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the... |
 | [copywriting](skills/copywriting/) | When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages,... |
+| [crisis-communications](skills/crisis-communications/) | When the user wants help responding to a PR crisis, data breach, security incident, product outage, executive controversy,... |
 | [cro](skills/cro/) | When the user wants to optimize, improve, or increase conversions on any marketing page or form — including homepage,... |
 | [customer-research](skills/customer-research/) | When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer... |
 | [directory-submissions](skills/directory-submissions/) | When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for... |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,6 +18,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | content-strategy | 2.0.0 | 2026-05-05 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
+| crisis-communications | 1.0.0 | 2026-06-23 |
 | cro | 2.0.0 | 2026-05-05 |
 | customer-research | 2.0.0 | 2026-05-05 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
@@ -38,7 +39,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | product-marketing | 2.0.0 | 2026-05-05 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.0.0 | 2026-05-26 |
-| public-relations | 1.0.0 | 2026-06-10 |
+| public-relations | 1.0.1 | 2026-06-23 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |
@@ -47,10 +48,15 @@ Current versions of all skills. Agents can compare against local versions to che
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
-| social | 2.1.0 | 2026-06-10 |
+| social | 2.2.0 | 2026-06-23 |
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### Unreleased
+
+- Added `crisis-communications` skill for reactive, time-sensitive incident response — data breaches, product outages, executive controversy, viral customer-harm stories, billing errors, and leaked layoffs. Distinct from `public-relations` (proactive/earned media on your own timeline) — this skill is reactive and time-compressed, where the story is already running. Covers a severity-triage table (Tier 1-4), a first-60-minutes checklist, channel sequencing (notify affected parties before going public), a common-crisis-types table with playbook notes, an explicit "what not to do" list (non-apologies, going dark, deleting criticism, public speculation), and post-crisis retro/trust-rebuild guidance. Includes `references/statement-templates.md` with adaptable templates for a holding statement, full incident statement, data breach notification, outage statement, customer-harm apology, billing-error statement, and public postmortem. Cross-referenced from `public-relations` (1.0.0 → 1.0.1, description-only change). Total skills: 46.
+- **social** (2.1.0 → 2.2.0): extracted the inline "Content Repurposing System" section into `references/repurposing.md` to match the pattern used by `platforms.md`, `platform-limits.md`, `post-templates.md`, and `short-form-video.md`. The reference keeps all existing tables (Blog Post → Social, Podcast/Video → Social atom types, Webinar → Social, Newsletter → Social) and the 6-step workflow, and adds three new sections: a repurposing tools table (transcript, clip extraction, captioning, graphics, scheduling), a "repurposing math" table giving a realistic atom-count and derivative-post-count per pillar format (so a thin pillar piece doesn't get force-extracted into more posts than its content supports), and a before/after example showing the same content atom reframed for Twitter/X vs. LinkedIn. `SKILL.md`'s Content Repurposing System section is now a short summary that links to the reference, consistent with how other reference-backed sections are presented.
 
 ### 2.5.1 (2026-06-16)
 

--- a/skills/crisis-communications/SKILL.md
+++ b/skills/crisis-communications/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: crisis-communications
+description: "When the user wants help responding to a PR crisis, data breach, security incident, product outage, executive controversy, social media backlash, or other reputation-damaging event. Also use when the user mentions 'crisis communications,' 'crisis comms,' 'damage control,' 'we need a statement,' 'apology statement,' 'data breach notification,' 'outage postmortem,' 'reputation management,' 'PR crisis,' 'this is blowing up on Twitter/X,' 'going viral for the wrong reasons,' 'how do we respond to this backlash,' 'customers are angry,' 'security incident disclosure,' or 'do we need to make a statement.' Use this for reactive, time-sensitive incident response — not routine earned media (see public-relations) and not customer-support replies to individual tickets (see customer support workflows)."
+metadata:
+  version: 1.0.0
+---
+
+# Crisis Communications
+
+You are a crisis communications advisor. Your goal is to help the user respond to a reputation-damaging event quickly, honestly, and in a way that minimizes long-term trust damage — without making the situation worse through silence, over-promising, or a statement that reads as legally hedged non-apology.
+
+This is a different mode from routine PR. `public-relations` is about earning coverage on your terms and your timeline. Crisis communications is reactive, time-compressed, and the story is already running with or without you.
+
+## Before Starting
+
+Get the facts straight before drafting anything. Ask (or infer from what the user has shared):
+
+1. **What actually happened** — not the rumor, the confirmed fact. If it's still unconfirmed, say so explicitly in any statement.
+2. **Who is affected** — customers, employees, the public, a specific demographic, regulators
+3. **What's the exposure** — is this contained, still unfolding, or could it get worse (more data exposed, more victims, ongoing outage)?
+4. **What's already public** — is this breaking on social media, covered by press, only known internally?
+5. **What can legal/security/eng confirm right now** vs. what's still being investigated
+
+**Never draft a statement that asserts something not yet confirmed.** A statement that has to be walked back 24 hours later does more damage than a slower, accurate one.
+
+---
+
+## Core Philosophy
+
+- **Speed matters, but accuracy matters more.** Silence in the first hours reads as either incompetence or concealment. A wrong statement reads as dishonesty — and dishonesty compounds.
+- **One source of truth.** Designate a single spokesperson or statement owner. Mixed messages from different employees/channels is its own crisis.
+- **Acknowledge before you explain.** Open with what happened and who it affects — not with context, mitigating factors, or "first, some background." Readers scan for "are we affected and what do we do," and bury that and you lose them.
+- **A real apology has no "but."** "We're sorry this happened, but our systems generally..." is not an apology — it's a defense with an apology-shaped opener. Say sorry, say what you're doing, stop.
+- **Don't go dark after the first statement.** A crisis is a sequence of updates, not one press release. Commit to a cadence (e.g., "we'll update again by 6pm ET") and keep it, even if the update is "still investigating, no new information yet."
+- **Don't litigate in public.** If there's legal exposure, the public statement and the legal posture are usually two different documents — write them separately, and never let liability-minimization language leak into the human-facing one.
+
+---
+
+## Crisis Severity Triage
+
+Not every incident needs a CEO statement. Calibrate response to actual severity.
+
+| Tier | Examples | Typical Response |
+|------|----------|-------------------|
+| **1 — Contained** | Single feature bug, isolated complaint thread, minor copy mistake | Support/community team replies directly; no public statement needed |
+| **2 — Visible** | Service degradation, a viral complaint gaining traction, a misleading marketing claim called out | Public acknowledgment via status page/social, owned by support or marketing lead |
+| **3 — Significant** | Full outage, billing error affecting many customers, a widely-shared customer harm story | Formal statement, exec-reviewed, posted to status page + email + social; spokesperson designated |
+| **4 — Severe** | Data breach, security incident, executive misconduct, safety issue, regulatory inquiry | Legal-reviewed formal statement, CEO/exec-level spokesperson, regulatory notification timelines may apply, dedicated incident page |
+
+When unsure which tier, triage up — under-responding to a Tier 3 reads worse than over-responding to a Tier 2.
+
+---
+
+## The First 60 Minutes
+
+1. **Confirm the facts** with whoever has direct knowledge (eng, security, legal, support lead) — not secondhand summaries.
+2. **Designate the spokesperson** and the single channel of record (status page, pinned post, or both).
+3. **Draft a holding statement** — acknowledges the issue is known and being worked on, with zero unconfirmed claims. This buys time without going dark.
+4. **Notify internally before going public** — employees should not learn about a public crisis from Twitter/X. A short internal note ("here's what's happening, here's what to say if asked, here's who to route press/customer questions to") prevents conflicting public statements from staff.
+5. **Set the next update time** and say so publicly ("we'll share more by [time]").
+
+**For a ready-to-adapt holding statement template, full statement structure, and templates for specific incident types** — see [references/statement-templates.md](references/statement-templates.md)
+
+---
+
+## Channel Sequencing
+
+Order matters. Getting this backwards (e.g., posting publicly before notifying directly-affected customers) creates a second, avoidable crisis.
+
+1. **Directly affected parties first** — individual email/in-app notification to customers actually impacted, especially for data breaches or billing errors. They should not find out from a public post.
+2. **Status page / incident page** — the canonical, linkable source of truth that you control and can update.
+3. **Owned social channels** — short post linking to the full statement, not the full statement itself (character limits force omissions that read as evasive).
+4. **Press / media** — if reporters are already asking, respond directly rather than waiting for your own announcement to go out — but never let press get the news before affected customers.
+5. **Internal all-hands or Slack note** — should happen in parallel with step 1, not after.
+
+---
+
+## Common Crisis Types & Playbook Notes
+
+| Type | Key first move | Watch for |
+|------|----------------|-----------|
+| **Data breach / security incident** | Confirm scope with security team before any public claim about what was/wasn't exposed. Check breach-notification laws for your jurisdictions (often 72-hour windows). | Don't say "no sensitive data was affected" unless security has actually confirmed it — this is the single most common statement that gets walked back. |
+| **Product outage** | Status page update within minutes, even if just "investigating." | Avoid committing to an ETA you can't keep — "investigating, next update by [time]" is safer than a guessed resolution time. |
+| **Executive misconduct / controversy** | Legal and board involvement before any public statement. This is the one category where speed is secondary to getting it right. | Avoid a statement that reads as protecting the executive over the affected parties. |
+| **Customer harm story going viral** | Reach out to the affected customer directly and privately first — a public reply before private outreach reads as PR management, not care. | Don't argue the facts in public reply threads; resolve privately, then (if appropriate) post a brief public update. |
+| **Billing / pricing error** | Confirm scope (how many customers, how much money) before announcing a fix. | Proactively refund/credit before being asked — reactive refunds after public pressure read as conceding under fire, not as doing the right thing. |
+| **Layoffs leak before official announcement** | Move the internal announcement up — employees should hear it from the company before social media. | A leaked layoff story without an official statement reads as the company losing control of its own narrative. |
+| **Misleading marketing claim called out** | Acknowledge the specific claim, correct it, and explain the fix (not just "we'll look into it"). | Don't get defensive about intent — the audience cares about the correction, not whether you meant to mislead. |
+
+---
+
+## What Not to Do
+
+- **Don't go silent.** Even "we don't have new information yet, next update at [time]" is better than nothing.
+- **Don't delete the criticism.** Deleting comments/threads (rather than responding) almost always gets screenshotted and becomes a second story about the cover-up attempt.
+- **Don't issue a non-apology.** "We're sorry if anyone was offended/affected" shifts the burden onto the reader's reaction instead of owning the action.
+- **Don't speculate publicly.** "We believe this may have also affected..." invites a correction cycle. State only what's confirmed; note explicitly what's still under investigation.
+- **Don't let legal language overwrite the human statement.** Liability-conscious phrasing ("the Company denies any wrongdoing") in a customer-facing apology reads as insincere. Keep the legal posture and the human statement in separate documents if they're in tension.
+- **Don't bury the lede.** Don't open with three paragraphs of context before saying what happened and who's affected.
+
+---
+
+## After the Crisis: Retro & Trust Rebuild
+
+1. **Public postmortem** (for Tier 3-4 incidents) — what happened, root cause, what's changing so it doesn't recur. Specificity builds more trust than a vague "we take this seriously."
+2. **Internal retro** — separate from the public postmortem; covers what should change in the response process itself, not just the technical root cause.
+3. **Follow-through tracking** — if the statement promised a fix, a credit, or a policy change, track it to completion and consider a follow-up post confirming it shipped. A promise made during a crisis and never followed up on becomes its own future crisis.
+4. **Monitor sentiment for 1-2 weeks** post-resolution — crises often have a second wave when a follow-up detail surfaces.
+
+## Task-Specific Questions
+
+- What tier is this, and does the response match the tier (not over- or under-responding)?
+- Who are the directly affected parties, and have they been notified before any public statement?
+- What's confirmed vs. still under investigation — and does the draft statement only claim the confirmed part?
+- Is there a single spokesperson and a single channel of record?
+- What's the next update commitment, and who owns keeping it?
+
+## Related Skills
+
+- For earned media, journalist pitching, and proactive press coverage (not crisis-driven), see `public-relations`.
+- For individual customer support replies and ticket-level tone, use your support/customer-service workflow — this skill is for incidents affecting multiple customers or public reputation, not one-off support tickets.
+- For product launches and announcements (the planned, non-crisis version of a big public moment), see `launch`.

--- a/skills/crisis-communications/references/statement-templates.md
+++ b/skills/crisis-communications/references/statement-templates.md
@@ -1,0 +1,145 @@
+# Crisis Statement Templates
+
+Ready-to-adapt structures for the most common crisis communication moments. Every template needs real specifics filled in — none of these should ship with placeholder brackets still in them.
+
+## Contents
+- Holding Statement (buy time without overcommitting)
+- Full Incident Statement (general structure)
+- Data Breach / Security Incident Notification
+- Product Outage Statement
+- Customer Harm / Apology Statement
+- Billing or Pricing Error Statement
+- Public Postmortem (post-resolution)
+
+## Holding Statement
+
+Use within the first 30-60 minutes, before all facts are confirmed. Buys time without making claims you can't back up yet.
+
+```
+We're aware of [specific issue — outage / reports of X / the incident described in Y].
+
+We're actively investigating and will share a full update by [specific time].
+
+[If applicable: In the meantime, here's what we recommend — e.g., status page link, workaround.]
+```
+
+Do not speculate on cause, scope, or who's affected in a holding statement — that's what the full statement is for, once confirmed.
+
+## Full Incident Statement (General Structure)
+
+```
+[1. What happened — one or two sentences, plain language, no jargon]
+
+[2. Who is affected — be specific: "customers on the X plan," "users who signed up before [date]," "all users in [region]"]
+
+[3. What we know is confirmed, and what is still being investigated]
+
+[4. What we're doing about it right now]
+
+[5. What affected parties should do, if anything]
+
+[6. When we'll share the next update]
+
+[7. A direct contact or channel for questions]
+```
+
+## Data Breach / Security Incident Notification
+
+```
+Subject: Important security update regarding your [Company] account
+
+We're writing to let you know about a security incident that [affected/may have affected] your account.
+
+What happened: [Plain-language description — how it was discovered, when, by whom (internal team / external researcher / reported by a customer)]
+
+What information was involved: [Be exact. If still confirming scope, say: "We have confirmed [X] was affected. We are still investigating whether [Y] was also affected and will update you by [time/date] either way."]
+
+What we've done: [Immediate containment steps — e.g., "We've patched the vulnerability, rotated affected credentials, and engaged a third-party security firm to audit the fix."]
+
+What you should do: [Specific actions — reset password, enable 2FA, monitor statements, etc. Don't just say "be vigilant" — give concrete steps.]
+
+What we're doing going forward: [Process/system change that prevents recurrence]
+
+We take full responsibility for this and are sorry for the disruption and concern this has caused. If you have questions, reach us directly at [contact] — we will respond within [timeframe].
+```
+
+**Note:** Check breach-notification laws in every relevant jurisdiction before sending — many (e.g., GDPR, US state laws) have mandatory disclosure windows (commonly 72 hours) and required content elements. This template is a communications starting point, not a substitute for legal review.
+
+## Product Outage Statement
+
+**Initial (status page or pinned post):**
+```
+We're currently experiencing [specific symptom — e.g., "elevated error rates on [feature]" or "a full service outage"] affecting [scope — all users / users in region X / users on plan Y].
+
+We're investigating and will post an update by [time].
+```
+
+**Resolution:**
+```
+This incident is resolved as of [time]. 
+
+Root cause: [Plain-language summary — save the full technical postmortem for a separate doc if needed]
+
+Duration: [start] to [end], affecting [scope]
+
+What's changing: [Specific prevention step]
+
+We're sorry for the disruption. [If applicable: credits/compensation details and how they'll be applied automatically — don't make affected customers request it.]
+```
+
+## Customer Harm / Apology Statement
+
+For a specific customer's negative experience that's gone public (viral complaint, news story).
+
+```
+We saw [customer]'s experience with [specific situation], and we're sorry. [State plainly what went wrong — no hedging, no "if" language.]
+
+[What you're doing to make it right for this specific customer — be concrete]
+
+[What you're changing so this doesn't happen to others — be concrete, not "we're reviewing our processes"]
+
+We've reached out to [customer] directly and will keep working with them until this is resolved.
+```
+
+**Sequence matters:** reach out to the customer privately before posting anything public. A public apology that the customer hasn't seen yet, or that contradicts what you told them privately, makes things worse.
+
+## Billing or Pricing Error Statement
+
+```
+We identified an error that [specific issue — e.g., "overcharged customers on the annual plan between [dates]"], affecting [number/percentage] of customers.
+
+We've already [issued refunds / applied credits / fixed the billing logic] — you don't need to do anything; [refunds/credits] will appear by [date]. If you don't see it by then, contact us at [channel].
+
+This happened because [brief, honest root cause — e.g., "a bug in our billing migration"]. We've fixed it and added [specific safeguard] to catch this before it reaches customers in the future.
+
+We're sorry for the inconvenience and appreciate your patience.
+```
+
+Lead with the fix already being underway/done, not with a request for affected customers to come forward — proactive correction reads far better than reactive correction under pressure.
+
+## Public Postmortem (Post-Resolution)
+
+For Tier 3-4 incidents, published once the immediate crisis is resolved and root cause is confirmed.
+
+```
+# [Incident name] — Postmortem
+
+**Summary:** [2-3 sentences: what happened, impact, duration]
+
+**Timeline:**
+- [Time] — [Event, e.g., "issue introduced," "first reports received," "internal escalation," "fix deployed," "fully resolved"]
+
+**Root cause:** [Specific technical or process cause — avoid vague language like "a configuration issue"]
+
+**Impact:** [Who/what was affected, scope, duration]
+
+**What we're changing:**
+1. [Specific, verifiable change — e.g., "added automated rollback on deploy failures"]
+2. [Specific, verifiable change]
+
+**What we got right:** [Optional but builds credibility — e.g., fast detection, clear internal communication]
+
+**What we'd do differently:** [Honest reflection on response gaps, not just the technical cause]
+```
+
+Specificity is what makes a postmortem rebuild trust rather than read as PR theater — vague commitments ("we'll do better") are forgettable; specific, checkable commitments are not.

--- a/skills/public-relations/SKILL.md
+++ b/skills/public-relations/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: public-relations
-description: "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get featured,' 'media list,' 'media kit,' 'press kit,' 'newsjacking,' 'news hijack,' 'HARO,' 'Qwoted,' 'Featured,' 'Help A Reporter,' 'reporter request,' 'tech press,' 'TechCrunch,' 'earned media,' 'thought leadership placement,' 'op-ed,' 'guest article,' 'press contacts,' or 'how do I get press.' Use this for earned media work — finding journalists, pitching stories, newsjacking, and responding to press requests. For startup/SaaS/AI directory submissions, see directory-submissions. For product launches, see launch. For social-media engagement, see social. For cold-email outreach to prospects, see cold-email."
+description: "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get featured,' 'media list,' 'media kit,' 'press kit,' 'newsjacking,' 'news hijack,' 'HARO,' 'Qwoted,' 'Featured,' 'Help A Reporter,' 'reporter request,' 'tech press,' 'TechCrunch,' 'earned media,' 'thought leadership placement,' 'op-ed,' 'guest article,' 'press contacts,' or 'how do I get press.' Use this for earned media work — finding journalists, pitching stories, newsjacking, and responding to press requests. For startup/SaaS/AI directory submissions, see directory-submissions. For product launches, see launch. For social-media engagement, see social. For cold-email outreach to prospects, see cold-email. For reactive crisis response — data breaches, outages, executive controversy, viral backlash — see crisis-communications."
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Public Relations & Earned Media

--- a/skills/social/SKILL.md
+++ b/skills/social/SKILL.md
@@ -2,7 +2,7 @@
 name: social
 description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms, or wants to do social listening and engagement triage. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' 'create a reel,' 'social listening,' 'brand mentions,' 'competitor monitoring,' 'top posts to comment on,' or 'find people asking for.' Use this for social media content creation, repurposing, scheduling, short-form video scripting, and social listening. For broader content strategy, see content-strategy. For paid ads, see ad-creative. For earned media, see public-relations."
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Social Content
@@ -109,73 +109,11 @@ The first line determines whether anyone reads the rest.
 
 ## Content Repurposing System
 
-Turn one piece of content into many. The best social content isn't created from scratch — it's extracted from longer-form pillar content and adapted to each platform.
+Turn one piece of content into many. The best social content isn't created from scratch — it's extracted from longer-form pillar content (blog, podcast, webinar, newsletter) and adapted to each platform's format and audience.
 
-### Blog Post → Social Content
+Quick version: extract 5-10 self-contained "content atoms" (quotes, stories, tips, data) from the pillar piece, adapt each to the target platform's format and tone, write standalone captions that don't assume the reader saw the original, and spread the derivative posts across the week instead of dumping them all at once.
 
-| Platform | Format |
-|----------|--------|
-| LinkedIn | Key insight + link in comments |
-| LinkedIn | Carousel of main points |
-| Twitter/X | Thread of key takeaways |
-| Instagram | Carousel with visuals |
-| Instagram | Reel summarizing the post |
-
-### Podcast / Video → Social Content
-
-Extract "content atoms" — self-contained moments from any long-form content that work on their own:
-
-| Atom Type | What to Look For | Best Platform |
-|-----------|-----------------|---------------|
-| Quotable moment | A bold claim, hot take, or memorable line (15-60 sec) | Twitter/X, LinkedIn, TikTok |
-| Story arc | A complete mini-story with setup, conflict, resolution (60-90 sec) | Instagram Reels, TikTok, YouTube Shorts |
-| Tactical tip | A specific how-to or framework explained clearly (30-60 sec) | LinkedIn, YouTube Shorts |
-| Controversial take | A contrarian opinion that sparks debate | Twitter/X, LinkedIn |
-| Data/stat callout | A surprising number or research finding | LinkedIn carousel, Twitter/X |
-| Behind-the-scenes | Authentic, unpolished moments | Instagram Stories, TikTok |
-
-**Podcast repurposing workflow:**
-1. **Get transcript** — use Whisper, Descript, or your podcast host's transcription
-2. **Mark timestamps** — flag the 5-10 best moments while listening or scanning transcript
-3. **Extract clips** — pull video/audio clips for each moment (Descript, Opus Clip, or manual)
-4. **Write standalone captions** — each clip needs context; don't assume the viewer heard the rest
-5. **Add subtitles** — most social video is watched without sound
-6. **Schedule across 1-2 weeks** — spread a single episode across multiple posts
-
-**Per episode, aim for:**
-- 3-5 short video clips or audiograms (15-60 sec) for Reels/TikTok/Shorts
-- 1-2 LinkedIn text posts from key insights
-- 1 Twitter/X thread of takeaways
-- 1 carousel summarizing the main framework or list
-- 1 newsletter section or blog post from the best segment
-
-### Webinar / Live Event → Social Content
-
-| Extract | Format |
-|---------|--------|
-| Key slides with commentary | LinkedIn carousel |
-| Q&A highlights | Twitter/X thread |
-| Speaker quotes | Quote graphics for Instagram/LinkedIn |
-| Audience reactions/poll results | Engagement posts |
-| Full recording → short clips | Reels, TikTok, Shorts |
-
-### Newsletter → Social Content
-
-| Extract | Format |
-|---------|--------|
-| Main insight | LinkedIn post |
-| Curated links with commentary | Twitter/X thread |
-| Data or stat | Quote graphic |
-| Hot take or opinion | Twitter/X post, LinkedIn |
-
-### Repurposing Workflow
-
-1. **Create pillar content** (blog, video, podcast, webinar, newsletter)
-2. **Extract content atoms** (5-10 per piece — quotes, stories, tips, data)
-3. **Adapt to each platform** (format, length, and tone)
-4. **Write standalone captions** (each post must work without context)
-5. **Schedule across the week** (spread distribution, don't dump all at once)
-6. **Update and reshare** (evergreen content can repeat every 3-6 months)
+**For platform-by-platform repurposing tables, the podcast extraction workflow, repurposing tools, and a before/after example**: See [references/repurposing.md](references/repurposing.md)
 
 ---
 

--- a/skills/social/references/repurposing.md
+++ b/skills/social/references/repurposing.md
@@ -1,0 +1,136 @@
+# Content Repurposing System
+
+Turn one piece of pillar content into many platform-native posts. The best social content isn't created from scratch — it's extracted from longer-form content and adapted to each platform's format and audience expectations.
+
+## Contents
+- Blog Post → Social Content
+- Podcast / Video → Social Content (content atoms, podcast repurposing workflow)
+- Webinar / Live Event → Social Content
+- Newsletter → Social Content
+- General Repurposing Workflow
+- Repurposing Tools by Format
+- Repurposing Math (how many posts per pillar piece)
+- Before/After Example
+
+## Blog Post → Social Content
+
+| Platform | Format |
+|----------|--------|
+| LinkedIn | Key insight + link in comments |
+| LinkedIn | Carousel of main points |
+| Twitter/X | Thread of key takeaways |
+| Instagram | Carousel with visuals |
+| Instagram | Reel summarizing the post |
+
+**Process:**
+1. Re-read the post and underline every standalone claim, stat, or framework — these are your atoms.
+2. Pick the single strongest atom as the hook for a thread or carousel slide 1.
+3. Sequence the remaining atoms in the order that builds the strongest argument, not the order they appeared in the post.
+4. Write a closing line that links back to the full post (in a reply/comment, not the main post — most platforms suppress reach on posts with outbound links).
+
+## Podcast / Video → Social Content
+
+Extract "content atoms" — self-contained moments from any long-form content that work on their own without the surrounding context:
+
+| Atom Type | What to Look For | Best Platform |
+|-----------|-----------------|---------------|
+| Quotable moment | A bold claim, hot take, or memorable line (15-60 sec) | Twitter/X, LinkedIn, TikTok |
+| Story arc | A complete mini-story with setup, conflict, resolution (60-90 sec) | Instagram Reels, TikTok, YouTube Shorts |
+| Tactical tip | A specific how-to or framework explained clearly (30-60 sec) | LinkedIn, YouTube Shorts |
+| Controversial take | A contrarian opinion that sparks debate | Twitter/X, LinkedIn |
+| Data/stat callout | A surprising number or research finding | LinkedIn carousel, Twitter/X |
+| Behind-the-scenes | Authentic, unpolished moments | Instagram Stories, TikTok |
+
+**Podcast repurposing workflow:**
+1. **Get transcript** — use Whisper, Descript, or your podcast host's transcription
+2. **Mark timestamps** — flag the 5-10 best moments while listening or scanning transcript
+3. **Extract clips** — pull video/audio clips for each moment (Descript, Opus Clip, or manual)
+4. **Write standalone captions** — each clip needs context; don't assume the viewer heard the rest
+5. **Add subtitles** — most social video is watched without sound
+6. **Schedule across 1-2 weeks** — spread a single episode across multiple posts
+
+**Per episode, aim for:**
+- 3-5 short video clips or audiograms (15-60 sec) for Reels/TikTok/Shorts
+- 1-2 LinkedIn text posts from key insights
+- 1 Twitter/X thread of takeaways
+- 1 carousel summarizing the main framework or list
+- 1 newsletter section or blog post from the best segment
+
+## Webinar / Live Event → Social Content
+
+| Extract | Format |
+|---------|--------|
+| Key slides with commentary | LinkedIn carousel |
+| Q&A highlights | Twitter/X thread |
+| Speaker quotes | Quote graphics for Instagram/LinkedIn |
+| Audience reactions/poll results | Engagement posts |
+| Full recording → short clips | Reels, TikTok, Shorts |
+
+## Newsletter → Social Content
+
+| Extract | Format |
+|---------|--------|
+| Main insight | LinkedIn post |
+| Curated links with commentary | Twitter/X thread |
+| Data or stat | Quote graphic |
+| Hot take or opinion | Twitter/X post, LinkedIn |
+
+## General Repurposing Workflow
+
+1. **Create pillar content** (blog, video, podcast, webinar, newsletter)
+2. **Extract content atoms** (5-10 per piece — quotes, stories, tips, data)
+3. **Adapt to each platform** (format, length, and tone — never copy-paste the same text across platforms)
+4. **Write standalone captions** (each post must work without context from the original piece)
+5. **Schedule across the week** (spread distribution, don't dump all derivative posts on the same day)
+6. **Update and reshare** (evergreen content can repeat every 3-6 months with a fresh hook)
+
+## Repurposing Tools by Format
+
+| Need | Tools |
+|------|-------|
+| Transcript generation | Whisper (free, self-hosted), Descript, Otter.ai |
+| Video clip extraction | Opus Clip, Descript, Riverside, manual editing |
+| Auto-captioning | CapCut, Descript, Submagic |
+| Quote/stat graphics | Canva, Figma |
+| Carousel design | Canva, Figma, Tweethunter (for Twitter) |
+| Scheduling across platforms | Buffer, Hypefury, Typefully, native schedulers |
+
+## Repurposing Math
+
+A useful sanity check when planning a content calendar: one well-chosen pillar piece should yield roughly **8-12 derivative posts** without feeling stretched thin.
+
+| Pillar piece | Typical atom count | Realistic derivative output |
+|---|---|---|
+| 1,500-word blog post | 4-6 atoms | 1 thread, 1-2 carousels, 2-3 single posts |
+| 30-45 min podcast episode | 8-12 atoms | 3-5 video clips, 1-2 LinkedIn posts, 1 thread, 1 carousel |
+| Webinar (45-60 min) | 6-10 atoms | 1-2 carousels, 1 thread, 2-3 quote graphics, 2-4 clips |
+| Newsletter issue | 2-4 atoms | 1-2 single posts, 1 thread or quote graphic |
+
+If a pillar piece can't realistically produce at least 3-4 atoms, it's likely too thin to be pillar content — repurpose it as a single post instead of forcing a full extraction pass.
+
+## Before/After Example
+
+**Pillar atom (from a blog post on pricing):**
+> "We raised prices 20% and churn didn't move. The customers who left over a 20% increase were already unprofitable to serve — we just didn't know it until the price test forced the question."
+
+**Twitter/X thread opener (atom as hook):**
+```
+We raised prices 20%.
+
+Churn didn't move.
+
+Here's what that taught us about which customers were actually profitable: 🧵
+```
+
+**LinkedIn post (atom as proof point in a broader argument):**
+```
+Most founders are scared to raise prices because they assume churn = lost revenue.
+
+We tested a 20% increase last quarter.
+
+Churn stayed flat. The customers who left were the ones costing us the most to support.
+
+Price increases don't just capture more revenue — they're a free customer profitability audit.
+```
+
+Same atom, two platforms, two different framings — neither is a copy-paste of the other.


### PR DESCRIPTION
## Summary
- Adds a new `crisis-communications` skill (v1.0.0) for reactive, time-sensitive incident response — data breaches, outages, executive controversy, viral backlash, billing errors, leaked layoffs. This is distinct from `public-relations`, which is scoped to proactive/earned media on your own timeline. Includes a severity-triage table (Tier 1-4), a first-60-minutes checklist, channel sequencing, a common-crisis-types playbook table, an explicit "what not to do" list, and post-crisis retro guidance, plus `references/statement-templates.md` with 7 adaptable statement templates (holding statement, full incident statement, data breach notification, outage statement, customer-harm apology, billing-error statement, public postmortem).
- Cross-referenced from `public-relations`'s description (1.0.0 → 1.0.1, description-only bump per existing repo convention for routing/discovery changes).
- Extracts `social`'s inline "Content Repurposing System" section into `references/repurposing.md`, matching the extract-to-references pattern already used by the skill's other major sections (platforms, platform-limits, post-templates, short-form-video). Expands it with a repurposing-tools table, a repurposing-math table (realistic atom count and derivative-post count per pillar format), and a before/after example. `social` bumped 2.1.0 → 2.2.0.
- Updates `VERSIONS.md` and `README.md`'s skill table accordingly. Total skills: 46.

## Test plan
- [ ] Verify `crisis-communications` frontmatter: `name` matches directory, description includes trigger phrases, under 500 lines (122 lines)
- [ ] Verify `social/SKILL.md` still reads coherently with the trimmed section (349 lines)
- [ ] Spot-check `references/statement-templates.md` and `references/repurposing.md` render correctly
- [ ] Confirm `VERSIONS.md` total skill count (46) matches actual `skills/` directory count