### PR TITLE
ads: reconcile Audience Targeting Overview with creative-as-targeting shift

### DIFF
--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -108,21 +108,48 @@ LI_LeadGen_CMOs-SaaS_Whitepaper_Mar24
 
 ---
 
-## Audience Targeting Overview
+## Audience Understanding & Targeting
 
-### Platform Strengths
+Knowing your audience deeply is still the highest-leverage work in paid ads — demographics, job titles, pain points, fears, hopes, the exact language they use, who they follow, what they've tried, why they failed, what they buy. **Gather every identifier you can.**
 
-| Platform | Key Targeting | Best Signals |
-|----------|---------------|--------------|
-| Google | Keywords, search intent | What they're searching |
-| Meta | Interests, behaviors, lookalikes | Engagement patterns |
-| LinkedIn | Job titles, companies, industries | Professional identity |
+What's changed in 2026 is **where you apply that knowledge.** As ad-platform algorithms have gotten dramatically better at finding the right person, jamming all your audience identifiers into the platform's *targeting filters* underperforms feeding those same identifiers into the *creative* (headlines, copy, visuals, hooks, examples).
 
-### Key Concepts
+The discipline now: **audience knowledge → creative first, targeting filters second.** How much that ratio tips toward "creative" varies meaningfully by platform.
 
-- **Lookalikes**: Base on best customers (by LTV), not all customers
-- **Retargeting**: Segment by funnel stage (visitors vs. cart abandoners)
-- **Exclusions**: Exclude existing customers and recent converters — showing ads to people who already bought wastes spend
+### Platform-by-platform: where to apply audience knowledge
+
+| Platform | Audience knowledge → creative | Audience knowledge → targeting filters | Notes |
+|----------|------------------------------|-------------------------------------|-------|
+| **Meta** (post-Andromeda) | **80%+** | 20% | Algorithm rewards broad + specific creative. See [[#Modern Meta playbook (Andromeda era — 2026+)]] below for the full reframe. Interest-stacking now actively hurts. |
+| **Google Search** | 40% | **60%** | Keywords are still the dominant signal — match-types, search-intent layering, and negative keywords still drive performance. Creative (RSA headlines) matters but is downstream of the keyword. |
+| **Google Performance Max / Demand Gen** | **70%** | 30% | Audience signals are advisory, not deterministic. Creative + product feed quality dominate. |
+| **LinkedIn** | 40% | **60%** | Job-title / company / industry filters still produce real precision because LinkedIn's identity data is high-quality. Creative makes the click; firmographics make the *right person* see it. |
+| **TikTok** | **70%** | 30% | Algorithm is closer to Meta's model — broad targeting + native-feeling creative wins. Some audience interests help but creative dominates. |
+| **Twitter/X** | 50% | 50% | Interest + follower targeting still meaningful, but creative differentiation is high-leverage given lower competition. |
+
+These ratios are directional, not precise. Test in your actual account.
+
+### Applying audience knowledge to creative
+
+Once you've gathered audience identifiers, here's how to put each kind into the creative:
+
+- **Demographic identifiers** (age, location, occupation) → embed as identity-trigger keywords in headlines (see [[#The one-keyword hack (identity-trigger keywords)]])
+- **Pain points + fears** → headline + first line of body copy (Sabri Suby's framing: "the verbatim words your customers use about the problem")
+- **Hopes / desired outcomes** → transformation copy + CTAs
+- **Objections + "why they didn't buy last time"** → objection-handling retargeting ads (see [[#The 4-component retargeting framework]])
+- **Their language / vocabulary** → the entire copy voice — never use industry jargon they don't
+- **Existing customer base** → still feed it for lookalike audiences (see Key Concepts below)
+- **Niche / segment they identify with** → identity-trigger keywords in headline ("for dentists" / "for B2B founders" / "for parents of toddlers")
+
+### Key Concepts (still apply)
+
+- **Lookalikes**: Base on best customers (by LTV), not all customers. Still high-value across platforms.
+- **Retargeting**: Segment by funnel stage (visitors vs. cart abandoners). See [[#Retarget with DIFFERENT offers (not the same one)]] and [[#The 4-component retargeting framework]] for the modern playbook.
+- **Exclusions**: Exclude existing customers and recent converters — showing ads to people who already bought wastes spend.
+
+### Common failure mode
+
+Trying to make up for weak creative with hyper-precise targeting. If your creative is generic but you stack 12 interests + 3 demographic filters + a custom audience, what you've built is a small audience that all see a bad ad. Better: gather the same audience identifiers, write 5 creative variants that each speak to a different segment, target broadly, let the algorithm match each creative to the right segment.
 
 **For detailed targeting strategies by platform**: See [references/audience-targeting.md](references/audience-targeting.md)
 


### PR DESCRIPTION
## Summary

Reconciles the existing `Audience Targeting Overview` section with the `Modern Meta Playbook (Andromeda)` section landed in #384. The two sections were soft-tensioned — the old table presented interest-stacking as a viable Meta approach while the new section calls it out as actively harmful in 2026.

The reframe: **audience knowledge is still the highest-leverage work — but the question is WHERE to apply it.** The default 2026 answer is creative-first, targeting-filters-second. How much that ratio tips toward creative varies meaningfully by platform.

### Key changes

- Renamed `Audience Targeting Overview` → `Audience Understanding & Targeting`
- Replaced the 3-row Platform Strengths table with a 6-row platform-by-platform table showing the creative-vs-filter ratio per platform:
  - **Meta (post-Andromeda):** 80%+ creative
  - **Google Search:** 60% filters (keywords still dominant)
  - **Google PMax / Demand Gen:** 70% creative
  - **LinkedIn:** 60% filters (firmographic identity still high-quality)
  - **TikTok:** 70% creative
  - **X / Twitter:** 50/50
- New `Applying audience knowledge to creative` subsection mapping each type of identifier (demographic, pain points, hopes, objections, language, niche) to where in the creative it belongs — with wikilinks to the relevant Modern Meta Playbook sections
- Preserved existing Key Concepts subsection (lookalikes, retargeting, exclusions) with wikilinks to the modern retargeting playbook
- New `Common failure mode` callout warning against compensating for weak creative with hyper-precise targeting

### What's NOT in this PR

- No content removed
- Existing `references/audience-targeting.md` reference link preserved
- The detailed targeting strategies file itself isn't touched (might warrant its own follow-up review)

## Test plan

- [ ] Skim the new platform ratios — directional, not precise. Adjust if any feel off for actual client patterns
- [ ] Verify the wikilinks (`[[#Section name]]`) render properly in the skill — they should resolve as in-doc anchors
- [ ] Confirm the new framing doesn't contradict anything in `references/audience-targeting.md` (might also need an update later)
- [ ] Optional: validate the Google Search / LinkedIn ratios with a real client account before promoting to a versioned release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
