### PR TITLE
docs: add Vercel OSS Program badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,3 +316,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding or improving ski
 ## License
 
 [MIT](LICENSE) - Use these however you want.
+
+<br />
+<br />
+<a href="https://vercel.com/open-source-program">
+  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
+</a>


### PR DESCRIPTION
## Summary

Adds the Vercel Open Source Program badge to the bottom of the README, as required for the 12-month program membership.

- Uses Vercel's official snippet (linked `program-badge-2026.svg`)
- The badge SVG adapts to the viewer's color scheme, so it renders correctly in both GitHub themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)