### PR TITLE
release: add Vercel OSS Program badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,3 +316,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding or improving ski
 ## License
 
 [MIT](LICENSE) - Use these however you want.
+
+<br />
+<br />
+<a href="https://vercel.com/open-source-program">
+  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
+</a>


### PR DESCRIPTION
## Summary

Badge-only release. Ships #392 — the Vercel Open Source Program badge at the bottom of the README, required to be visible on the default branch for the 12-month program membership.

No skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)