### PR TITLE
feat(social): integrate X algorithm insights from xai-org/x-algorithm

### DIFF
--- a/skills/social/SKILL.md
+++ b/skills/social/SKILL.md
@@ -2,12 +2,14 @@
 name: social
 description: "When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram, TikTok, Facebook, or other platforms, or wants to do social listening and engagement triage. Also use when the user mentions 'LinkedIn post,' 'Twitter thread,' 'social media,' 'content calendar,' 'social scheduling,' 'engagement,' 'viral content,' 'what should I post,' 'repurpose this content,' 'tweet ideas,' 'LinkedIn carousel,' 'social media strategy,' 'grow my following,' 'TikTok video,' 'Reels,' 'Shorts,' 'video script,' 'video hook,' 'short-form video,' 'create a reel,' 'social listening,' 'brand mentions,' 'competitor monitoring,' 'top posts to comment on,' or 'find people asking for.' Use this for social media content creation, repurposing, scheduling, short-form video scripting, and social listening. For broader content strategy, see content-strategy. For paid ads, see ad-creative. For earned media, see public-relations."
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Social Content
 
 You are an expert social media strategist. Your goal is to help create engaging content that builds audience, drives engagement, and supports business goals.
+
+Whatever the platform, storytelling and connecting with your audience come first. The better the user can share their story, the better their posts will perform — platform tactics and algorithm mechanics amplify a good story; they never replace one. Keep this at the center of every recommendation below.
 
 ## Before Creating Content
 
@@ -51,6 +53,8 @@ Gather this context (ask if not provided):
 **For detailed platform strategies**: See [references/platforms.md](references/platforms.md)
 
 **For hashtag limits and character counts**: See [references/platform-limits.md](references/platform-limits.md)
+
+**For X (Twitter) ranking mechanics** — the For You feed signals from xAI's open-sourced algorithm, and the 10 posting rules they imply: See [references/x-algorithm.md](references/x-algorithm.md). Use it whenever the task involves posting on X.
 
 ---
 

--- a/skills/social/evals/evals.json
+++ b/skills/social/evals/evals.json
@@ -87,6 +87,36 @@
         "May note social-to-email bridge context"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "I'm posting on X 5 times every morning between 9 and 10am and my reach keeps dropping. I mostly post quick thoughts and hot takes. What am I doing wrong?",
+      "expected_output": "Should apply the X algorithm reference (references/x-algorithm.md). Should identify post clustering as the primary problem: the author-diversity scorer decays scores of repeated authors within a feed response, so 5 posts in an hour cannibalize each other — recommend spacing original posts ~60 minutes apart or spreading across the day. Should also check hook mechanics (specific claim in the first 8 words, topic named early so topic-based distribution can route the post) and presence (staying available to reply for the first 30 minutes after each post rather than batch-firing and leaving). Should reframe goals toward DM-shares, follows, and profile clicks rather than likes, since those are separately scored signals. Should note weight values are unpublished and recommendations are directional.",
+      "assertions": [
+        "References X algorithm mechanics from x-algorithm.md",
+        "Identifies post clustering / author-diversity decay as the main issue",
+        "Recommends ~60 minute spacing between original posts",
+        "Addresses hook structure (specific claim in first 8 words)",
+        "Mentions topic-anchoring for topic-based distribution",
+        "Recommends being present to reply after posting",
+        "Reframes toward shares/follows/profile clicks over likes"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Write an X post announcing our new AI feature. Draft: 'We're so excited to announce something HUGE is coming... 🔥🔥 You won't want to miss this. Like and retweet if you're ready!!'",
+      "expected_output": "Should rewrite rather than lightly edit, and explain why using X ranking mechanics: the draft has no specific claim in the first 8 words, doesn't name the topic (so topic-based distribution can't route it), names nothing specific (no product, no capability), and 'like and retweet if you're ready' is engagement bait — the algorithm predicts negative actions (not interested, mute, block) and subtracts them, and baity phrasing risks muted-keyword filtering. Rewrite should open with the specific capability and name the product/tools involved, make the post DM-forwardable (specific, useful claim), and optionally suggest posting mechanics: don't cluster with other posts, stay present for the first 30 minutes, and if including video make it 8+ seconds with captions.",
+      "assertions": [
+        "Rewrites the post rather than approving it",
+        "Flags the missing specific claim in the first 8 words",
+        "Flags engagement bait and explains predicted negative-action penalties",
+        "Names the specific feature/product in the rewrite",
+        "Explains topic-anchoring for distribution",
+        "Optimizes for shareability over like-solicitation",
+        "Includes posting mechanics guidance (spacing, first-30-minutes presence)"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/social/references/platforms.md
+++ b/skills/social/references/platforms.md
@@ -2,6 +2,8 @@
 
 Detailed strategies for each major social platform.
 
+One thing holds on every platform below: storytelling and connecting with your audience are always key. Formats, cadences, and algorithm mechanics differ platform to platform, but the better you share your story, the better the posts perform — the platform-specific tactics amplify a story worth telling; they don't substitute for one.
+
 ## Contents
 - LinkedIn
 - Twitter/X
@@ -69,17 +71,21 @@ Detailed strategies for each major social platform.
 - Scheduling everything (no real-time presence)
 
 **Format tips:**
-- Tweets under 100 characters get more engagement
+- Open with a specific claim in the first 8 words — the hook is the post
+- Name your topic in the first 10 words (enables topic-based distribution)
+- Name specific tools, companies, and numbers instead of vague nouns
 - Threads: Hook in tweet 1, promise value, deliver
-- Quote tweets with added insight beat plain retweets
-- Use visuals to stop the scroll
+- Quote tweets with added insight beat plain retweets — quote engagement scores twice
+- Video needs ~8+ seconds and captions to earn video credit
 
-**Algorithm tips:**
-- Replies and quote tweets build authority
-- Threads keep people on platform (rewarded)
-- Images and video get more reach
-- Engagement in first 30 min matters
-- Twitter Blue/Premium may boost reach
+**Algorithm tips** (from xAI's open-sourced For You algorithm):
+- Write for the DM-share and the follow, not the like — both are separately scored signals
+- Profile clicks boost the post: make readers curious, keep bio and pinned post strong
+- Wait ~60 minutes between original posts — same-author posts decay each other's scores
+- Be present for the first 30 minutes after posting; early replies compound
+- Avoid engagement-bait phrasing — predicted mutes/blocks/"not interested" subtract from your score, and muted keywords filter you out entirely
+
+**For ranking signals and the full playbook**: See [x-algorithm.md](x-algorithm.md)
 
 ---
 

--- a/skills/social/references/x-algorithm.md
+++ b/skills/social/references/x-algorithm.md
@@ -1,0 +1,69 @@
+# X (Twitter) Algorithm Playbook
+
+How the X "For You" feed ranks posts, based on xAI's open-sourced algorithm ([xai-org/x-algorithm](https://github.com/xai-org/x-algorithm), May 2026 release — the Phoenix ranker and Grox content-understanding pipeline), and what to change in your posting practice because of it.
+
+**Sourcing note:** the release publishes the ranking *structure* (which signals are scored and how they combine) but not the weight *values* (`params.rs` is withheld). Rules below are tagged **[verified]** when the mechanism is visible in the code, **[reported]** when the specific number or magnitude comes from secondary analysis of the release. Structure changes slowly; reported numbers age fast — treat them as directionally true.
+
+## How ranking works (60-second version)
+
+1. Candidate posts come from two sources: accounts the viewer follows (Thunder) and ML-retrieved posts from the global corpus (Phoenix retrieval). You are always competing for out-of-network reach, not just your followers' feeds.
+2. Filters remove ineligible posts *before* scoring: too old, already seen or served, muted keywords, blocked/muted authors.
+3. The Phoenix transformer predicts a probability for each engagement type — not one "quality score" but ~15 separate predictions.
+4. Final score = weighted sum of those probabilities. Positive actions add; predicted negative actions (not-interested, mute, block, report) subtract.
+5. An author-diversity scorer then decays the scores of repeated authors within a feed response, so your posts compete with each other.
+
+The model has no hand-engineered "quality" features — it learns entirely from engagement histories. You can't optimize for the algorithm directly; you optimize for the specific *behaviors* it predicts. And notice what those behaviors are: staying to read, sending to a friend, following the author, joining the conversation. Those are the things a well-told story produces. Storytelling and genuine connection with your audience aren't a separate strategy from the mechanics below — they're what the mechanics reward. The rules tune distribution; the story earns the engagement.
+
+## The signals your post is scored on [verified]
+
+Every signal below is a separate weighted term in the scoring code:
+
+| Signal | What to notice |
+|--------|---------------|
+| Favorite (like) | The baseline — and the weakest lever, given how many other signals exist |
+| Reply | Conversation-starting posts earn a distinct signal |
+| Repost | Public amplification |
+| Quote **and** quoted-click | Two separate terms: engagement on a quote post *and* clicks through to the quoted post both score |
+| Click | Opening the post detail |
+| Profile click | Clicking through to your profile is its own scored action |
+| Share, share-via-DM, share-via-copy-link | **Three separate share signals** — private sharing is explicitly modeled, not lumped into one |
+| Video quality view | Only paid if video duration exceeds a minimum threshold (`MIN_VIDEO_DURATION_MS`); short clips earn zero video credit |
+| Dwell (two forms) | Time spent reading is scored both as a threshold and as continuous time |
+| Photo expand | Tapping to enlarge an image |
+| Follow author | A post that converts a viewer into a follower earns its own signal |
+| Not interested / mute / block / report | **Negative weights** — the model predicts these too, and they subtract from your score |
+
+## The 10 rules
+
+1. **Open with a specific claim in the first 8 words.** [reported] Dwell is scored two ways [verified], and scroll-past is the dwell-killer. Don't warm up — the hook *is* the post.
+
+2. **Wait ~60 minutes between original posts.** [reported number] The author-diversity scorer is verified: within a feed response, each additional post from the same author gets a decayed score. Clustered posts cannibalize each other's reach.
+
+3. **Name your topic in the first 10 words.** [reported] Topic-based candidate sourcing and followed-topic hydration are verified in the pipeline — the algorithm routes posts to topic followers, but only if it can tell what the topic is. Vague musings don't get routed.
+
+4. **Write for the DM-forward, not the like.** [verified structure; relative weight reported] Share-via-DM is its own scored signal. The test for every post: "would someone send this to a friend?" beats "would someone like this?"
+
+5. **Quote tweets score twice.** [verified structure] Quote engagement and quoted-click are separate terms. Quoting with added insight beats plain reposting — for both parties.
+
+6. **Write for the follow.** [verified structure] Follow-author is a distinct signal. Posts that make a stranger think "I want more of this" outperform posts that make them think "ha, nice."
+
+7. **Make them curious enough to click your profile.** [verified structure] Profile clicks are scored. This is the mechanical argument for a strong bio and pinned post: the algorithm rewards posts that trigger the click, and your profile converts it.
+
+8. **Name specific things.** [verified mechanism] Two reasons: specificity is what enables topic routing (rule 3), and the muted-keyword filter removes posts *pre-scoring* — generic engagement-bait phrases are commonly muted; specific nouns ("Claude", "Stripe") rarely are.
+
+9. **Video must clear the minimum duration — with captions.** [verified mechanism; ~8s reported] The video-quality-view weight only applies above `MIN_VIDEO_DURATION_MS`. Below the threshold, video earns zero video credit. Captions serve the dwell signals (most viewing is muted).
+
+10. **Be present for the first 30 minutes.** [reported] Early replies compound: each reply you answer is a fresh engagement event, and reply chains feed the dwell and conversation signals. Post when you can stay, not when the scheduler fires.
+
+## What kills reach [verified]
+
+- **Muted keywords** — filtered before scoring even happens. Spammy CTA phrases and rage-bait vocabulary are widely muted.
+- **Predicted negative actions** — if your post pattern-matches to content people block, mute, or hit "not interested" on, it's penalized *before anyone acts*. Engagement bait doesn't just annoy humans; it's a modeled negative.
+- **Posting bursts** — author-diversity decay (rule 2). Your second post in an hour starts handicapped.
+- **Already-seen content** — reposting the same content quickly hits the previously-seen/served filters. Evergreen reruns need spacing.
+
+## Caveats
+
+- **Weights are unpublished.** Claims like "shares are worth N× likes" are inference, not source. The safe conclusion is which behaviors are scored *at all* — and that private shares, follows, profile clicks, and dwell each matter independently.
+- **This ages fast.** The repo gets updated releases; if you're reading this long after May 2026, check [xai-org/x-algorithm](https://github.com/xai-org/x-algorithm) for changes before treating numbers as current.
+- **These rules are X-specific.** The general principles (hook early, specificity, reply presence) travel to other platforms; the mechanics (60-minute spacing, quote-double-counting, video minimums) do not.


### PR DESCRIPTION
## Skill Update

**Skill:** `skills/social`

## Summary

Closes #310.

Per the issue's ask, I read the actual `xai-org/x-algorithm` source rather than relying on the 10-rule summary, and tagged every claim **[verified]** (mechanism visible in code) or **[reported]** (from secondary analysis — the release withholds `params.rs`, so weight values aren't public).

- **New:** `references/x-algorithm.md` — ranking pipeline, the full scored-signal table, the 10 rules with sourcing tags, reach-killers, caveats
- **Updated:** `references/platforms.md` Twitter/X section (replaces the stale tips, e.g. "Twitter Blue may boost reach")
- **Updated:** `SKILL.md` — pointer to the new reference, a storytelling-first framing note, bump to 2.2.0
- **Added:** 2 X-specific evals (post-clustering reach diagnosis, engagement-bait rewrite)

Fun finds from the code: quote engagement is scored twice (`quote_score` + `quoted_click_score` are separate weighted terms), DM-share is one of *three* separate share signals, and `MIN_VIDEO_DURATION_MS` really does gate all video credit.

Kept this single-skill for easy review — happy to follow up on the issue's cross-skill ripple items (`copywriting` hook guidance, `launch` day cadence) if you want them.

## Type of update

- [ ] Bug fix
- [x] Improved instructions
- [x] Added references/scripts
- [ ] Other

## Checklist

- [x] Changes are focused and minimal
- [x] `SKILL.md` is still under 500 lines (415)
- [x] No sensitive data or credentials
- [x] Tested locally with AI agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)