### PR TITLE
ads: separate brand from non-brand in measurement/optimization

### DIFF
--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -2,7 +2,7 @@
 name: ads
 description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' or 'should I run ads.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see cro."
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Paid Ads
@@ -342,7 +342,7 @@ The math: 3 simultaneous tests × ~10-20% lift each (compounding) = a fundamenta
 
 ### Weekly Review
 - Spend vs. budget pacing
-- CPA/ROAS vs. targets
+- CPA/ROAS vs. targets (split brand vs. non-brand — see below)
 - Top and bottom performing ads
 - Audience performance breakdown
 - Frequency check (fatigue risk)
@@ -354,6 +354,14 @@ The math: 3 simultaneous tests × ~10-20% lift each (compounding) = a fundamenta
 - Compare platform data to GA4
 - Look at blended CAC, not just platform CPA
 
+### Brand vs. non-brand (measure them separately)
+
+Wherever people can search your name — Google Ads especially, but any channel with branded demand — split brand from non-brand *before* you evaluate or optimize anything. A branded query is demand that already exists; someone typing your name is harvesting it, not incremental performance the campaign created. So a cheap brand CPA / high brand ROAS is a readout of your existing awareness, not of media efficiency.
+
+- **Report blended, optimize on non-brand.** Blended ROAS/CAC at the business level is the right *top-line health* number — it's the true efficiency of the whole account, and in considered / B2B purchases where touchpoints assist each other, blended is the honest view of the journey. But the metric you set targets, bids, and budgets against is **non-brand ROAS**, with brand stripped out.
+- **Why the split matters:** optimize against a blended number and brand's cheap conversions inflate it — you set non-brand targets too loosely, and non-brand inefficiency hides behind brand. Non-brand ROAS is the lever you can actually move; brand largely tracks demand you already own.
+- **Never report a low brand CPA as a win.** It only signals performance if you're explicitly measuring incrementality (e.g. a brand-campaign holdout test). Absent that, a "great" brand CPA just means people already knew you.
+
 ### Scaling discipline (net cash > ROAS percentage)
 
 The most common scaling failure: a business at a 40 ROAS spending $5k/month, refusing to scale because "if I spend more, my ROAS will drop." This is the wrong frame.
@@ -361,7 +369,7 @@ The most common scaling failure: a business at a 40 ROAS spending $5k/month, ref
 **Net cash flow > ROAS percentage at the business level:**
 - ROAS dropping from 10 → 5 sounds bad
 - But if spend goes from $10k → $100k, you net dramatically more total profit
-- The number to optimize is **blended ROAS at the business level**, not per-ad-set ROAS
+- Judge scaling headroom on **blended ROAS at the business level**, not per-ad-set ROAS — but optimize against **non-brand ROAS** (see Brand vs. non-brand above), so cheap brand traffic doesn't flatter the math
 - Even better: optimize **net free cash flow**, not ROAS at all
 
 **Find your break-even ROAS:**


### PR DESCRIPTION
**What & why**

The scaling guidance names blended ROAS as the optimization *target*. Blended ROAS/CAC is the right top-line health number, but the metric you set bids, budgets, and targets against should be **non-brand ROAS**, with brand stripped out.

Branded search captures demand that already exists — someone typing your name is harvesting it, not incremental performance the campaign created. If you optimize against a blended number, brand's cheap conversions inflate it: you set non-brand targets too loosely and non-brand inefficiency hides behind brand. This matters most in considered / B2B purchases, where blended is the honest view of the journey but non-brand is the only lever you can actually move.

**Changes** (`skills/ads/SKILL.md`, v2.1.0 → v2.2.0, docs-only):

- New **"Brand vs. non-brand (measure them separately)"** section under Reporting & Analysis — report blended / optimize on non-brand; never report a low brand CPA as a win absent an incrementality test.
- Weekly Review: split brand vs non-brand on the CPA/ROAS line.
- Scaling discipline: corrected the "number to optimize" bullet to judge headroom on blended but optimize against non-brand.

Framing from running brand + non-brand search across B2B/B2C client accounts at [Drak Marketing](https://drakmarketing.com).
