### PR TITLE
release: v2.9.0 — bump plugin + marketplace versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.6.0",
+    "version": "2.9.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.6.0",
+  "version": "2.9.0",
   "author": {
     "name": "Corey Haines"
   },


### PR DESCRIPTION
Two-line version bump: `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` 2.6.0 → 2.9.0, catching up releases 2.7.0–2.9.0 (VERSIONS.md changelog already current). Precedes the development → main release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)