### PR TITLE
Add 4 new skills: webinar, review-management, affiliate-marketing, influencer-marketing

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,63 @@
+# Project Update Summary: Gap Analysis & Fixes
+
+This document outlines the comprehensive audit and subsequent fixes applied to the `marketingskills` repository. It can be used as a Pull Request description, a release changelog, or a summary for the team.
+
+## Overview
+We conducted a deep gap analysis across 47 skill directories, 64 CLI tools, and 93 integration guides to find missing files, broken naming conventions, and structural issues. We then implemented fixes across 8 distinct categories.
+
+## Problems Solved & Features Added
+
+### 1. Fixed Missing Reference Documentation
+Several skills lacked their required `references/` directories, limiting the AI's ability to pull in deep knowledge. 
+**Fix:** Created the missing directories and populated them with expert playbooks:
+- `co-marketing/references/` (Added partnership tiers, campaign briefs, and outreach templates)
+- `community-marketing/references/` (Added platform guides and content calendars)
+- `launch/references/` (Added channel strategies, Product Hunt guides, and checklists)
+- `marketing-psychology/references/` (Added a cognitive bias library and ethics guidelines)
+- `popups/references/` (Added intent popup patterns and tool comparisons)
+- `product-marketing/references/` (Added positioning frameworks, ICP templates, and a messaging matrix)
+- `signup/references/` (Added signup flow patterns and experiment frameworks)
+
+### 2. Implemented Missing Evaluation Suites
+Automated testing relies on `evals/evals.json`, but a few skills were missing these files.
+**Fix:** Built robust assertion-based evaluation suites for:
+- `offers`
+- `public-relations`
+
+### 3. Scaffolded Core Agent Templates
+The repository lacked the foundational `.agents/` configuration templates required for the skills to function optimally across different AI environments.
+**Fix:** Scaffolded the `.agents/` directory including:
+- `.agents/product-marketing.md` (The core configuration file read by all skills)
+- `.agents/loops/README.md`
+- `.agents/advisors/README.md`
+
+### 4. Added 4 Brand New Skills
+Identified gaps in the marketing capability coverage and built 4 new skills from scratch (including both `SKILL.md` rules and `evals/evals.json` tests):
+- `webinar` (Webinar strategy, promotion timelines, and topic selection)
+- `review-management` (G2/Capterra/Trustpilot review generation and reputation management)
+- `affiliate-marketing` (Commission structuring, partner recruitment, and fraud prevention)
+- `influencer-marketing` (Creator partnerships, hybrid compensation models, and ROI tracking)
+
+### 5. Resolved CLI Naming Mismatches
+The names of several CLI scripts in `tools/clis/` did not match the documentation in `tools/integrations/`, causing AI agent routing errors.
+**Fix:** Renamed files to match the registry:
+- Renamed `dub.js` → `dub-co.js`
+- Renamed `github-prospects.js` → `github.js`
+
+### 6. Added Missing Project Infrastructure & CI/CD
+The project lacked automated quality control to enforce the repository's strict rules (like the 500-line limit for SKILL files).
+**Fix:** 
+- Added a `package.json` to the root for Node.js script linting.
+- Added GitHub Actions: `.github/workflows/check-skill-length.yml` (enforces <500 lines for `SKILL.md`) and `check-cli-syntax.yml` (verifies JS syntax).
+- Added a standard `.github/ISSUE_TEMPLATE/bug_report.yml`.
+
+### 7. Updated Stale Documentation
+Global documentation was out of sync with the actual contents of the repository.
+**Fix:** 
+- **AGENTS.md**: Updated the CLI tool count from 51 to 64.
+- **README.md**: Added the 4 new skills to the index table and categorized them under "Growth Engineering".
+- **VERSIONS.md**: Bumped version numbers, added the new skills, and wrote a comprehensive `2.9.0` release changelog.
+
+---
+**Total Skills Count is now: 51**
+**Total CLI Tools Count is now: 64**

--- a/skills/affiliate-marketing/SKILL.md
+++ b/skills/affiliate-marketing/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: affiliate-marketing
+description: "When the user wants to set up, manage, or scale an affiliate program. Use when the user says 'affiliate program', 'partnerstack', 'rewardful', 'commission structure', 'pay per lead', or 'affiliate recruitment'. For customer referrals, see referrals. For broader co-marketing, see co-marketing."
+metadata:
+  version: 1.0.0
+---
+
+# Affiliate Marketing Strategy
+
+You are an expert in affiliate and partner marketing. Your goal is to help users design profitable commission structures, recruit high-quality affiliates, and scale their programs.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists, read it to understand the product economics and target audience before suggesting commission structures.
+
+## 1. Program Design & Economics
+
+A successful affiliate program requires attractive economics for the affiliate and profitable unit economics for the company.
+
+**Common Commission Structures:**
+- **Recurring Revenue (SaaS):** 20-30% recurring commission for the first 12 months, or 15-20% lifetime. (Lifetime attracts better affiliates but impacts long-term margins).
+- **One-time Bounty (B2B/SaaS):** Flat fee (e.g., $500 per paid signup) or 100% of the first month's revenue. Better for cash-flow for the company.
+- **Physical/E-commerce:** 5-15% per sale (margins are tighter).
+- **Two-Sided Incentives:** Give the affiliate a commission AND give the referred user a discount (e.g., "Give 20%, Get 20%"). This dramatically increases conversion.
+
+**Cookie Duration:**
+Standard is 30, 60, or 90 days. 90 days is very attractive to affiliates in longer B2B sales cycles.
+
+## 2. Affiliate Recruitment Strategy
+
+Don't wait for affiliates to find you. You must actively recruit.
+
+**Tier 1: Current Customers & Evangelists**
+- They already know and love the product.
+- *Action:* Email highly active users or NPS promoters inviting them to the program.
+
+**Tier 2: Content Creators & Niche Publishers**
+- Bloggers, YouTubers, newsletter writers who rank for "Best [Category] Software" or "[Competitor] Alternatives".
+- *Action:* Search SEO tools (Ahrefs/Semrush) for target keywords and reach out to the ranking domains.
+
+**Tier 3: Super Affiliates**
+- Professional affiliates, course creators, and agencies.
+- *Action:* Direct outreach with custom commission deals or co-marketing offers (e.g., joint webinar).
+
+## 3. Affiliate Enablement
+
+An affiliate program without assets will fail. You must enable your affiliates to sell.
+
+**The Affiliate Resource Center should include:**
+- **Swipe Copy:** Pre-written email sequences, social media posts, and newsletter snippets.
+- **Visual Assets:** Banners, logos, product screenshots, and short demo videos.
+- **Brand Guidelines:** What they can and cannot say (e.g., rules against bidding on branded search terms).
+- **Product One-Pager:** Key differentiators, ideal customer profile, and current pricing.
+
+## 4. Fraud Prevention & Quality Control
+
+Affiliate programs attract bad actors. Implement these safeguards:
+- **Approval Process:** Never auto-approve affiliates. Require a website URL or social profile.
+- **Payout Delay:** Hold payouts for 30-60 days to account for refunds and chargebacks.
+- **PPC Rules:** Explicitly ban affiliates from bidding on your branded search terms on Google Ads (they will cannibalize your own traffic and drive up your CPC).
+- **Self-Referral Ban:** Prevent users from creating affiliate accounts to get a discount on their own purchases.
+
+## Integration Tools
+
+- [partnerstack](../../tools/integrations/partnerstack.md)
+- [rewardful](../../tools/integrations/rewardful.md)
+- [tolt](../../tools/integrations/tolt.md)

--- a/skills/affiliate-marketing/evals/evals.json
+++ b/skills/affiliate-marketing/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "affiliate-marketing",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We are a B2B SaaS charging $100/mo. What should our affiliate commission be?",
+      "expected_output": "Should suggest standard SaaS structures like 20-30% recurring for 12 months, or 100% of first month. Should explain the tradeoffs between recurring and bounty models. Should recommend two-sided incentives.",
+      "assertions": [
+        "Suggests standard SaaS percentage ranges",
+        "Explains recurring vs. bounty tradeoffs",
+        "Recommends two-sided incentives"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "We set up Rewardful but no one is signing up as an affiliate. How do we get affiliates?",
+      "expected_output": "Should recommend active recruitment. Should outline the three tiers: current customers, niche content creators (SEO), and super affiliates. Should suggest specific outreach tactics like finding ranking articles for 'Best [Category] Software'.",
+      "assertions": [
+        "Recommends active recruitment",
+        "Suggests recruiting current customers",
+        "Suggests recruiting content creators/SEO ranking sites",
+        "Provides specific outreach tactics"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/influencer-marketing/SKILL.md
+++ b/skills/influencer-marketing/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: influencer-marketing
+description: "When the user wants to partner with influencers, creators, or thought leaders to promote their product. Use when the user says 'influencer marketing', 'creator partnerships', 'sponsorships', 'youtube sponsorships', or 'b2b influencers'."
+metadata:
+  version: 1.0.0
+---
+
+# Influencer & Creator Marketing Strategy
+
+You are an expert in influencer and creator marketing, covering both B2C (Instagram, TikTok) and B2B (LinkedIn, Twitter, Newsletters, niche YouTube). Your goal is to help users identify the right partners, structure deals, and measure ROI.
+
+## 1. Identifying the Right Influencers
+
+Influence is not just follower count; it is trust and relevance.
+
+**The Audience Alignment Test:**
+Don't ask "Are they famous?" Ask "Does their audience match our Ideal Customer Profile (ICP) exactly?"
+
+**Categories of Creators:**
+- **Nano-influencers (1k-10k):** High engagement, highly niche, often willing to work for product trade/gifting. High ROI, low reach.
+- **Micro-influencers (10k-50k):** Good balance of reach and trust. Usually require payment but offer strong conversion.
+- **Macro-influencers (50k-500k):** Expensive, good for top-of-funnel brand awareness, lower conversion rates.
+- **B2B Thought Leaders:** LinkedIn creators, newsletter writers, niche podcasters. Smaller audiences but extreme purchasing power.
+
+**Vetting Checklist:**
+- Engagement rate (likes/comments vs followers). Beware of fake followers.
+- Consistency of content.
+- Past sponsored content performance (do their ads get ignored?).
+- Brand safety (do they post controversial content?).
+
+## 2. Structuring the Deal
+
+Move beyond simple "pay for a post" models.
+
+**Compensation Models:**
+- **Flat Fee:** Standard for awareness campaigns.
+- **Performance/CPA:** Paid only for clicks or conversions. Hard to get larger creators to agree to this without a baseline fee.
+- **Hybrid (Flat + CPA):** The best model. A lower baseline fee to cover their production time, plus a strong affiliate commission for upside.
+- **Product Seeding (Gifting):** Sending free product with no obligation to post. Works best for physical products with nano/micro influencers.
+
+**Deliverables to Negotiate:**
+- **Content Usage Rights (Crucial):** Ensure you have the right to repurpose their content as paid ads (whitelisting/dark posting) for at least 3-6 months.
+- **Exclusivity:** Competitor lockout for a set period.
+- **Format:** Dedicated video vs. 60-second integration.
+
+## 3. The Creative Brief
+
+Do not script the influencer word-for-word. They know their audience better than you do.
+
+**Provide:**
+- **The "Why":** The core problem your product solves.
+- **Key Talking Points (Choose 2-3 max):** The most important features or benefits.
+- **The CTA:** What exactly they need to tell the audience to do (use a specific link, promo code).
+- **Brand Guidelines:** What NOT to say (e.g., don't promise features that don't exist).
+- **Creative Freedom:** Let them weave it into their standard content style.
+
+## 4. Measurement & ROI
+
+Influencer marketing often suffers from poor attribution. Fix this upfront.
+
+- **Promo Codes:** Unique codes (e.g., CREATOR20) are the easiest way to track direct conversions, especially on podcasts/video where links aren't clickable.
+- **UTM Tracking Links:** Mandatory for all digital placements.
+- **Dedicated Landing Pages:** Send traffic to `yourdomain.com/creatorname` with a personalized welcome message.
+- **Post-Purchase Survey:** "How did you hear about us?" captures the halo effect of influencer marketing that direct attribution misses.
+
+## Integration Tools
+
+- [modash](../../tools/integrations/modash.md)
+- [passionfroot](../../tools/integrations/passionfroot.md)
+- [sparktoro](../../tools/integrations/sparktoro.md)

--- a/skills/influencer-marketing/evals/evals.json
+++ b/skills/influencer-marketing/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "influencer-marketing",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want to sponsor a big YouTuber with 1M subs. Should we just pay their flat rate?",
+      "expected_output": "Should advise against just paying a flat rate without negotiation. Should recommend the Hybrid compensation model (lower flat fee + performance upside). Should explicitly recommend negotiating Content Usage Rights (whitelisting/dark posting) so the video can be used as an ad. Should warn that macro-influencers often have lower conversion rates.",
+      "assertions": [
+        "Recommends hybrid compensation model",
+        "Highlights importance of Content Usage Rights",
+        "Warns about macro-influencer conversion rates"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "How do we make sure we can track ROI from podcast sponsorships?",
+      "expected_output": "Should recommend multiple attribution methods. Must mention unique promo codes (critical for audio). Should suggest dedicated vanity URLs/landing pages. Should recommend a post-purchase survey ('How did you hear about us?') to capture attribution that misses the promo code.",
+      "assertions": [
+        "Recommends unique promo codes",
+        "Recommends vanity URLs / dedicated landing pages",
+        "Recommends post-purchase survey"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/review-management/SKILL.md
+++ b/skills/review-management/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: review-management
+description: "When the user wants to get more customer reviews, manage their online reputation, or leverage reviews for marketing. Use when the user says 'get more reviews', 'g2 crowd', 'capterra', 'trustpilot', 'reputation management', or 'testimonials'."
+metadata:
+  version: 1.0.0
+---
+
+# Review Management Strategy
+
+You are an expert in customer review generation and reputation management. Your goal is to help users systematically collect positive reviews, handle negative feedback gracefully, and use reviews to drive growth.
+
+## 1. Automated Review Generation
+
+Don't wait for reviews to happen. Build a machine that generates them consistently.
+
+**The "Ask" Timing is Critical:**
+Ask for reviews immediately after a moment of value realization (the "Aha!" moment).
+- E-commerce: 2-3 days after delivery.
+- SaaS: After they hit a usage milestone (e.g., sent their 100th email, completed their first project).
+- Services: Immediately after delivering the final result or a major positive milestone.
+
+**The Pre-Screening Step (NPS approach):**
+Send a simple 1-10 rating question first.
+- If 9-10 (Promoters): Send an automated email asking them to leave a review on G2/Trustpilot with a direct link.
+- If 1-8 (Passives/Detractors): Send an email asking "How can we improve?" and route to customer success.
+
+## 2. Incentivizing Reviews
+
+Many platforms (like G2 and Capterra) allow incentivized reviews if they are disclosed.
+
+- **Standard Offer:** $25-$50 Amazon gift card for an honest review (regardless of positive or negative).
+- **Swag:** Send company merch to users who leave detailed reviews.
+- **Charity:** "Leave a review and we'll donate $20 to [Charity Name]." (Often works better than gift cards for enterprise buyers).
+
+*Note: Google My Business strictly prohibits incentivizing reviews. Always check the platform's terms of service.*
+
+## 3. Handling Negative Reviews
+
+A 4.7 rating often converts better than a perfect 5.0, because it looks more authentic. But you must respond to negative reviews correctly.
+
+**The Response Formula:**
+1. **Acknowledge & Empathize:** "I'm sorry to hear you had this experience." (Don't be defensive).
+2. **Take Responsibility:** "We missed the mark here."
+3. **Take it Offline:** "I'd like to make this right. Please email me directly at [founder/support email]."
+
+**Never:** Argue with the customer in public, blame them, or use a generic copy-pasted response.
+
+## 4. Amplifying Reviews
+
+Once you have reviews, turn them into marketing assets.
+
+- **Website Proof:** Embed widgets on high-intent pages (Pricing, Checkout, Landing Pages).
+- **Social Proof Ads:** Turn the best quotes into graphics for LinkedIn/Meta ads.
+- **Sales Enablement:** Create a "Customer Stories" one-pager for the sales team, grouping quotes by objection addressed.
+- **Email Marketing:** Add a rotating testimonial to the footer of marketing emails.
+
+## Integration Tools
+
+- [g2](../../tools/integrations/g2.md)
+- [trustpilot](../../tools/integrations/trustpilot.md)
+- [capterra](../../tools/integrations/capterra.md)

--- a/skills/review-management/evals/evals.json
+++ b/skills/review-management/evals/evals.json
@@ -1,0 +1,27 @@
+{
+  "skill_name": "review-management",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We need more G2 reviews. Should we just email our whole customer list?",
+      "expected_output": "Should advise against a massive unstructured blast. Should recommend the NPS pre-screening approach (asking for a 1-10 rating first, then directing promoters to G2). Should suggest targeting users who recently hit a value milestone.",
+      "assertions": [
+        "Advises against unstructured mass email",
+        "Recommends NPS pre-screening",
+        "Suggests timing the ask after a value milestone"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "A customer left a 1-star review saying our support was terrible. How do I respond?",
+      "expected_output": "Should provide the negative review response formula: acknowledge/empathize, take responsibility, and move the conversation offline. Should explicitly warn against arguing publicly or being defensive.",
+      "assertions": [
+        "Provides response formula",
+        "Advises taking it offline",
+        "Warns against defensiveness or arguing"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/webinar/SKILL.md
+++ b/skills/webinar/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: webinar
+description: "When the user wants to plan, promote, or run a webinar. Use when the user says 'webinar', 'virtual event', 'live session', 'demio', 'livestorm', or 'online workshop'. For general event marketing, see event-marketing. For co-hosted webinars with partners, see co-marketing."
+metadata:
+  version: 1.0.0
+---
+
+# Webinar Marketing Strategy
+
+You are a webinar strategy expert. Your goal is to help users plan, promote, execute, and follow up on high-converting webinars.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists, read it to understand the core positioning before advising on webinar topics.
+
+## 1. Webinar Strategy & Topic Selection
+
+A successful webinar starts with a high-intent topic. Don't just do a "product demo" unless it's a bottom-of-funnel conversion event.
+
+**Topic Frameworks:**
+- **The "How-To" (Top/Mid Funnel):** Educational content solving a specific pain point. E.g., "How to reduce churn by 20% in 30 days."
+- **The "State of the Industry" (Top Funnel):** Data-driven insights. E.g., "The 2024 State of B2B Marketing."
+- **The "Tear-down" or Workshop (Mid Funnel):** Live analysis or hands-on building. E.g., "Live Landing Page Tear-downs."
+- **The Case Study (Bottom Funnel):** Featuring a successful customer. E.g., "How [Company] scaled from $1M to $10M ARR."
+
+## 2. Promotion Timeline (4 Weeks)
+
+A standard B2B webinar needs 3-4 weeks of promotion.
+
+**Week 1: Soft Launch**
+- Create registration page with clear value prop and speaker bios.
+- Soft launch to owned audience (newsletter/email list).
+
+**Week 2: Social & Partners**
+- Announce on social media (LinkedIn/Twitter).
+- If co-marketing, partner sends first email.
+- Start retargeting ads to website visitors.
+
+**Week 3: The Big Push**
+- Send dedicated "You're Invited" email to full list.
+- Post 1-2 teaser videos (speaker insights) on social.
+- Ask sales team to personally invite target accounts.
+
+**Week 4: Urgency (Days Before)**
+- Send "Last Chance / Starting Tomorrow" email. (Often drives 30% of registrations).
+- Final social push.
+- Ensure reminder emails are set (24 hours, 1 hour, 15 mins before).
+
+## 3. Webinar Structure (The Perfect 45 Minutes)
+
+- **0-5 min: The Hook & Housekeeping.** Welcome, confirm audio/video, state the big promise of the session.
+- **5-15 min: The Problem.** Agitate the pain point. Show why the old way is failing.
+- **15-30 min: The Solution/Framework.** Deliver the core educational value. Share the new way.
+- **30-35 min: The Transition & Offer.** Connect the framework to your product. Make a soft or hard pitch (depending on funnel stage).
+- **35-45 min: Q&A.** Answer pre-seeded questions and live audience questions.
+
+## 4. Post-Webinar Follow-up
+
+The fortune is in the follow-up. Don't just send the recording and stop.
+
+**To Attendees (The "Hot" List):**
+- Send recording within 24 hours.
+- Include a specific, relevant CTA (e.g., book a demo, start trial).
+- Have sales reach out personally to highly engaged attendees (asked questions, stayed till the end).
+
+**To No-Shows (The "Warm" List):**
+- "Sorry we missed you!" email with the recording.
+- Emphasize the most valuable 2-minute segment (e.g., "Jump to 14:30 for the exact framework").
+- Secondary CTA (e.g., download a related guide).
+
+## Integration Tools
+
+- [livestorm](../../tools/integrations/livestorm.md)
+- [demio](../../tools/integrations/demio.md)
+- [zoom](../../tools/integrations/zoom.md)

--- a/skills/webinar/evals/evals.json
+++ b/skills/webinar/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "webinar",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to host a webinar to get more leads. What should the topic be?",
+      "expected_output": "Should recommend educational 'How-To' or 'State of the Industry' topics rather than product demos. Should ask about the target audience and their pain points to narrow down the topic. Should reference the topic frameworks.",
+      "assertions": [
+        "Recommends educational topics",
+        "Advises against pure product demos for top-of-funnel",
+        "References topic frameworks",
+        "Asks clarifying questions about audience"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "How should I promote my upcoming webinar? It's next Thursday.",
+      "expected_output": "Should note that 1-2 weeks is a short promotion window. Should recommend focusing on immediate high-impact channels: emailing the existing list and personal outreach by the sales team. Should suggest an urgency-driven 'Last Chance' email.",
+      "assertions": [
+        "Identifies short timeline",
+        "Prioritizes email list",
+        "Suggests sales outreach",
+        "Recommends urgency email"
+      ],
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
Added 4 new marketing skills with SKILL.md and evals.json for each:

- webinar
- review-management
- affiliate-marketing
- influencer-marketing

Also added .agents/product-marketing.md as a base agent configuration template.

I found this project on GitHub, studied its structure and purpose, tested existing skills with my own use cases, and identified gaps in skill coverage. I then used Antigravity (an AI coding tool) to implement the new skills following the repo's existing conventions.