### PR TITLE
feat(ad-creative): faceless motion-style video ad format (2.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,8 @@
     "url": "https://corey.co"
   },
   "metadata": {
-    "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.1",
+    "description": "Marketing skills for AI agents \u2014 conversion optimization, copywriting, SEO, paid ads, and growth",
+    "version": "2.8.2",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://corey.co"
   },
   "metadata": {
-    "description": "Marketing skills for AI agents \u2014 conversion optimization, copywriting, SEO, paid ads, and growth",
+    "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
     "version": "2.8.2",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
-  "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.1",
+  "description": "Marketing skills for AI agents \u2014 conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
+  "version": "2.8.2",
   "author": {
     "name": "Corey Haines"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing-skills",
-  "description": "Marketing skills for AI agents \u2014 conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
+  "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
   "version": "2.8.2",
   "author": {
     "name": "Corey Haines"

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,7 +5,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | Skill | Version | Last Updated |
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
-| ad-creative | 2.2.0 | 2026-07-08 |
+| ad-creative | 2.3.0 | 2026-07-09 |
 | ai-seo | 2.1.0 | 2026-06-15 |
 | analytics | 2.0.0 | 2026-05-05 |
 | aso | 2.0.0 | 2026-05-05 |
@@ -53,6 +53,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.8.2 (2026-07-09)
+
+- **ad-creative** (2.2.0 → 2.3.0): added the **faceless motion-style video ad format**. New `references/motion-video-ads.md` (format popularized by @borjafat; original re-expression of the open Bomx `super-video-maker` motion-collage recipe, extended with production lessons from shipping it end-to-end): a fully generated 15–45s concept/explainer video — styled poster stills (one per beat, series-locked via reference images) → image-to-video "living" motion → TTS narration → whisper-word-timed captions — at roughly $3–6 and ~15 minutes per finished video. Covers the provider-agnostic pipeline with a one-key Gemini path (Nano Banana Pro + Veo 3.1 + Gemini TTS) and alternatives (GPT-Image/Flux, Seedance/Kling/Runway, ElevenLabs), a **five-style visual library** with fill-in prompt formulas (screen-print collage, flat vector explainer, papercraft diorama, pop-art comic, claymation), a motion prompt formula, hard-earned QC gotchas (image-to-video models inject photoreal "maker hands" — and negative prompts make it worse; always QC each clip's final 2 seconds; caption/label collision; TTS/whisper sound-alike words in CTAs), ad-specific rules (brand in the poster for sound-off autoplay, beat 1 is the 3-second hook, regenerate stills per aspect rather than cropping), and AI-content disclosure notes. SKILL.md wires the reference into Generating Ad Visuals and adds 'motion video ad,' 'faceless video ad,' 'animated explainer ad,' and 'motion collage ad' description triggers.
 
 ### 2.8.1 (2026-07-08)
 

--- a/skills/ad-creative/SKILL.md
+++ b/skills/ad-creative/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ad-creative
-description: "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' 'static ads,' 'static ad concepts,' 'ad templates,' 'iMessage ad,' 'chat reveal ad,' 'text message ad,' 'fake DM ad,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see ads. For landing page copy, see copywriting."
+description: "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' 'static ads,' 'static ad concepts,' 'ad templates,' 'iMessage ad,' 'chat reveal ad,' 'text message ad,' 'fake DM ad,' 'motion video ad,' 'faceless video ad,' 'animated explainer ad,' 'motion collage ad,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see ads. For landing page copy, see copywriting."
 metadata:
-  version: 2.2.0
+  version: 2.3.0
 ---
 
 # Ad Creative
@@ -151,6 +151,8 @@ For detailed specs and format variations, see [references/platform-specs.md](ref
 **For static ad structure**, use the 15-template library in [references/static-ad-templates.md](references/static-ad-templates.md) — layout frameworks (Us vs. Them, Stat Callout, Review Card, Before/After, Founder Message, FAQ Card, and more) with copy slots, DTC and SaaS examples, and per-concept output format. Cycle through all 15 rather than clustering on favorites: template diversity is angle diversity.
 
 **For iMessage chat-reveal video ads** — the 9:16 format where a scripted iMessage thread unfolds bubble-by-bubble (screenshot hook → friend asks "what app is that?" → brand + promo code reveal → end card) — see [references/imessage-video-ads.md](references/imessage-video-ads.md) for the six concept angles, script and pacing rules, production routes (off-the-shelf, Playwright + ffmpeg pipeline, Remotion), craft details that sell the illusion, and the grounding/compliance rules for dramatized conversations.
+
+**For faceless motion-style video ads** — fully generated 15–45s concept/explainer videos (styled poster stills → image-to-video "living" motion → TTS narration → word-timed captions; roughly $3–6 and ~15 minutes per finished video) — see [references/motion-video-ads.md](references/motion-video-ads.md) for the provider-agnostic pipeline, a five-style visual library with fill-in prompt formulas (screen-print collage, flat vector explainer, papercraft diorama, pop-art comic, claymation), the motion prompt formula, and hard-earned QC gotchas (maker-hands intrusion, final-two-seconds drift, caption/label collision, TTS/whisper sound-alikes).
 
 For image and video generation tools, see [references/generative-tools.md](references/generative-tools.md) for the complete guide covering:
 

--- a/skills/ad-creative/references/motion-video-ads.md
+++ b/skills/ad-creative/references/motion-video-ads.md
@@ -1,0 +1,91 @@
+# Motion-Style Video Ads (Faceless, Fully Generated)
+
+> Format popularized by Borja ([@borjafat](https://x.com/borjafat)) and the open `super-video-maker` motion-collage recipe by [Bomx](https://github.com/Bomx/super-video-maker-skill); this guide is an original re-expression of the method, extended with a multi-style library and production lessons from building and shipping it end-to-end.
+
+Produce a 15–45s faceless video ad or explainer from nothing but a concept: a styled
+poster still (image model) → brought to life with subtle motion (image-to-video model)
+→ narrated (TTS) → word-timed captions. No footage, no presenter, no editor. Cost per
+finished video is roughly $3–6 in API calls; wall-clock ~15 minutes.
+
+The format works because the *still* carries the idea (one literal, slightly surreal
+visual per beat) and the *motion* only makes it breathe. Resist the urge to make the
+video do the storytelling — this is animated poster design, not filmmaking.
+
+## When to use
+
+- Concept/explainer ads: one idea made concrete ("your CRM is a junk drawer")
+- Top-of-funnel social video (9:16 Reels/Shorts/TikTok, 4:5 and 1:1 feed)
+- Brand-response hybrids where a distinctive owned style beats stock UGC
+- NOT for: demo/proof ads (screen recordings win), testimonial/UGC formats,
+  anything requiring a real product shot as evidence
+
+## Pipeline (provider-agnostic)
+
+1. **Script** 3–6 beats, 20–45s of VO. One idea per beat. Calm and specific beats
+   hype. End on a single CTA line.
+2. **Poster stills** — one per beat, using a *style formula* (below). Generate beat 1,
+   approve it, then pass it as a reference image for every later beat so the set reads
+   as one series. Fix garbled label text by regenerating with a shorter phrase.
+3. **Animate** each approved still with an image-to-video model (5–8s per beat).
+   Motion belongs to the objects in the frame; the composition must not change.
+4. **VO + captions**: one continuous TTS take, transcribe with word timestamps
+   (whisper), cut beats at sentence boundaries, burn 2–3-word caption groups.
+5. **Assemble**: concat beats trimmed to their VO spans (hold the last frame to pad),
+   loudness-normalize to `I=-16:TP=-1.5:LRA=11`, export per-placement aspect.
+
+**Provider options** (any combination works; the recipe is model-agnostic):
+
+| Stage | One-key Gemini path | Alternatives |
+|---|---|---|
+| Stills | Nano Banana Pro (`gemini-3-pro-image-preview`) — excellent label typography | GPT-Image, Flux, Ideogram |
+| Motion | Veo 3.1 fast image-to-video (note: 1080p requires 8s clips) | Seedance 2.0 via fal.ai, Kling, Runway |
+| VO | Gemini TTS (calm voices: Charon/Kore) | ElevenLabs, OpenAI TTS |
+| Captions | whisper word timings + PIL/ASS burn-in | CapCut, platform auto-captions |
+
+## The style library
+
+Five proven looks. Each is a fill-in-the-slots prompt formula; keep ONE style per
+campaign so the account builds a recognizable visual identity. All five animate well.
+
+### A. Screen-print collage (editorial, "In a Nutshell" docu energy)
+> Flat screen-print collage poster, single saturated `<COLOR>` background, subtle newsprint grain. Centerpiece: a black-and-white halftone cutout of `<SUBJECT DOING THE LITERAL CONCEPT>`, treated as a paper sticker with a thin white die-cut outline, slightly torn edges, and a soft drop shadow. Visible halftone dot texture, vintage editorial photo feel, grayscale subject. Accent cutouts: 2–4 flat shapes (cream circle sun, black zigzag, scattered dots). A torn-paper label near the bottom with the words "`<LABEL>`" in bold condensed uppercase newspaper type. Matte printed risograph aesthetic, limited palette. No gradients, no glow, no 3D, no photorealism, no extra text.
+
+### B. Flat vector explainer (clean, techy, infinitely brandable)
+> Flat vector explainer illustration in the style of a premium animated science channel: a friendly simplified `<SUBJECT>`, bold flat shapes with clean rounded edges, solid `<BRAND COLOR>` background, limited palette of `<2-3 ACCENTS>`, flat geometric accents, soft long shadows, completely flat 2D design. A clean rectangular banner near the bottom reads "`<LABEL>`" in bold geometric sans-serif uppercase. No outlines, no 3D, no photorealism, no texture, no extra text.
+
+### C. Papercraft diorama (warm, tactile, premium-crafty)
+> Layered papercraft diorama: `<SUBJECT>`, every element hand-cut from colored construction paper with visible paper thickness and real drop shadows between layers, `<COLOR>` paper background with cut-paper accents, tactile handmade craft feel with slightly imperfect scissor cuts. A cut-paper banner near the bottom reads "`<LABEL>`" in chunky cut-out paper letters. Soft studio lighting on the paper layers. No digital gradients, no photorealistic humans, no extra text.
+
+### D. Pop-art comic (loud, scroll-stopping, promo-friendly)
+> Vintage pop-art comic panel: `<SUBJECT>`, bold black ink outlines, Ben-Day halftone dots shading, flat process colors (`<PALETTE>`), comic starburst accents, thick panel border, aged newsprint paper texture. A comic caption box near the bottom reads "`<LABEL>`" in bold comic lettering. 1960s printed comic aesthetic, slight ink misregistration. No 3D, no photorealism, no gradients, no extra text.
+
+### E. Claymation (charming, high pattern-interrupt)
+> Stop-motion claymation scene: a charming handmade plasticine `<SUBJECT>`, visible fingerprints and clay texture, `<COLOR>` clay backdrop and floor, chunky clay props, warm soft studio lighting like a stop-motion film set, shallow depth of field. A small clay sign near the bottom reads "`<LABEL>`" in hand-molded clay letters. Handcrafted miniature feel. No 2D illustration, no photorealistic humans, no extra text.
+
+## Motion prompt formula
+
+> Subtle living-`<style>` motion of the existing elements only. `<ONE literal motion tied to the concept: the pile inflates / the arrow creeps higher / the megaphone trembles with each shout>`. `<Secondary ambient motion: accents drift, gentle push-in>`. Every element that is visible now is the only thing that ever appears; the composition stays exactly as it is. Everything stays `<style descriptor: a flat printed collage / flat 2D vector / cut paper / printed comic / handmade clay>`. No camera whip, no scene change, no morphing, no added text.
+
+## Hard-earned gotchas
+
+- **Video models love adding photoreal "maker hands"** reaching into frame, especially
+  on pressing/handling motions — and *negative prompts make it worse* ("no hands" is an
+  attention trap). Never mention hands; describe motion as belonging to the objects,
+  and include "the composition stays exactly as it is."
+- **Always QC each clip's final 2 seconds** — that's where intruding objects and style
+  drift appear. Trim before them or regenerate; never ship a "realified" frame.
+- **One dominant motion per beat.** Two motions read as chaos at feed speed.
+- **TTS + whisper disagree on sound-alikes** ("laws" → "loss"). Read the transcript
+  against the script before burning captions; prefer phoneme-unambiguous CTA wording.
+- **Keep captions clear of the label band** (captions ~60% height, label ~80%).
+  Clamp caption groups so two never overlap; shrink-to-fit long groups.
+- **Ad-specific**: put the brand/label in the poster itself (it survives sound-off
+  autoplay), front-load the concept in beat 1 (the 3-second hook is the poster), and
+  export 9:16 + 4:5 + 1:1 from the same beats by regenerating stills per aspect
+  rather than cropping.
+
+## Compliance
+
+Fully synthetic characters — no likeness/UGC disclosure issues, but check platform
+AI-content disclosure requirements (Meta and TikTok label AI-generated media).
+Don't fabricate statistics or testimonials in the VO; ground every claim.


### PR DESCRIPTION
## Summary
- New `references/motion-video-ads.md` — fully generated faceless motion-style video ads: styled poster stills → image-to-video "living" motion → TTS narration → whisper-word-timed captions (~$3–6 and ~15 min per finished video)
- Five-style visual library with fill-in prompt formulas: screen-print collage, flat vector explainer, papercraft diorama, pop-art comic, claymation — all verified to generate with clean label typography
- Provider-agnostic: one-key Gemini path (Nano Banana Pro + Veo 3.1 + Gemini TTS) documented alongside GPT-Image/Flux, Seedance/Kling/Runway, ElevenLabs
- Production QC gotchas from shipping the format end-to-end twice: photoreal "maker hands" intrusion (negative prompts make it worse), final-2-seconds drift QC, caption/label collision, TTS/whisper sound-alike CTAs
- SKILL.md: wired into Generating Ad Visuals, new description triggers, 2.2.0 → 2.3.0; repo release 2.8.2 (plugin + marketplace + VERSIONS.md)

## Attribution
Format popularized by @borjafat; original re-expression of the open Bomx super-video-maker motion-collage recipe (same treatment as the iMessage reference in #412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)