### PR TITLE
release: v2.8.6 — citations vs. recommendations (ai-seo)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ Current versions of all skills. Agents can compare against local versions to che
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
 | ad-creative | 2.5.0 | 2026-07-09 |
-| ai-seo | 2.1.0 | 2026-06-15 |
+| ai-seo | 2.2.0 | 2026-07-09 |
 | analytics | 2.0.0 | 2026-05-05 |
 | aso | 2.0.0 | 2026-05-05 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
@@ -14,7 +14,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | cold-email | 2.0.0 | 2026-05-05 |
 | community-marketing | 2.0.0 | 2026-05-05 |
 | competitor-profiling | 2.0.0 | 2026-05-05 |
-| competitors | 2.0.0 | 2026-05-05 |
+| competitors | 2.0.1 | 2026-07-09 |
 | content-strategy | 2.0.0 | 2026-05-05 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
@@ -53,6 +53,11 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.8.6 (2026-07-09)
+
+- **ai-seo** (2.1.0 → 2.2.0): added **citations vs. recommendations** — the correction to citation-centric AEO strategy. New `references/citations-vs-recommendations.md` (grounded in Lily Ray's (Amsive) 100-query B2B study, Scrunch and SimilarWeb behavioral studies, and Growth Plays commentary): the **AI visibility ladder** (retrieved → cited → mentioned → recommended, each governed by different criteria, plus the shadow rung of being *recommended against* on requirements-heavy prompts), the **self-promotional listicle risk** (69% of the AI Overview citations earned by self-promotional "best [category]" listicles — 224 of 323 — appeared in answers that excluded the publisher from the recommendations; for emerging brands a self-ranked guide can act as a vote for competitors), **stage-dependent buyer's-guide strategy** (leaders get cited and recommended; emerging brands get citation and category framing — still worth publishing, with rebalanced expectations), **what earns recommendations** (offsite consensus: reviews, analysts, communities, earned media, video — with the test "if a model ignored everything on our domain, would the rest of the web still shortlist us?"), and **what a recommendation is worth** (Scrunch, observational: ~2× behavior lift vs. a passing mention; for users with no recent observed brand engagement, +182% branded searches / +117% site visits / +185% product views within a week; SimilarWeb: ~2.5× more new visitors — with only ~9% visible as AI traffic, the attribution blind spot) plus the measurement triad (prompt tracking with mention framing, self-reported attribution, call recordings). SKILL.md adds a compact citation-≠-recommendation pointer, a Recommendation-rate row in Monitoring, and caveats on the Listicle Block (content-patterns.md) and educational-content goals (content-types.md).
+- **competitors** (2.0.0 → 2.0.1): added an **AI-answer expectations-by-stage** caveat to the alternatives-page format — these pages often earn AI citations, but recommendation depends on offsite consensus; for emerging brands a self-ranked list can surface competitors in the answer. Cross-references ai-seo's citations-vs-recommendations reference. Closes #427.
 
 ### 2.8.5 (2026-07-09)
 

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -2,7 +2,7 @@
 name: ai-seo
 description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' 'optimize for Claude/Gemini,' 'llms.txt,' 'OKF,' 'Open Knowledge Format,' 'knowledge bundle,' or 'agent-readable site.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # AI SEO
@@ -381,6 +381,8 @@ Not all content is equally citable. Prioritize these formats:
 - Content without dates or author attribution
 - PDF-only content (harder for AI to parse)
 
+**Citation ≠ recommendation.** Getting cited means your content was useful to consult; getting *recommended* — onto the buyer's actual shortlist — is governed by web-wide consensus (reviews, forums, analysts, press) and is largely independent of your own content. Self-promotional "best [category]" listicles can even backfire for emerging brands: in one 100-query B2B study, 69% of the AI Overview citations that self-promotional listicles earned came in answers that recommended competitors instead of the publishing brand. See [references/citations-vs-recommendations.md](references/citations-vs-recommendations.md) for the visibility ladder (retrieved → cited → mentioned → recommended), stage-dependent buyer's-guide strategy, what earns recommendations, and the attribution blind spot.
+
 ---
 
 ## Monitoring AI Visibility
@@ -393,6 +395,7 @@ Not all content is equally citable. Prioritize these formats:
 | Brand citation rate | How often you're cited in AI answers | AI visibility tools (see below) |
 | Share of AI voice | Your citations vs. competitors | Peec AI, Otterly, ZipTie |
 | Citation sentiment | How AI describes your brand | Manual review + monitoring tools |
+| Recommendation rate | Whether you're on the shortlist, not just cited (see [citations-vs-recommendations.md](references/citations-vs-recommendations.md)) | Prompt tracking + mention framing |
 | Source attribution | Which of your pages get cited | Track referral traffic from AI sources |
 
 ### AI Visibility Monitoring Tools

--- a/skills/ai-seo/evals/evals.json
+++ b/skills/ai-seo/evals/evals.json
@@ -85,6 +85,21 @@
         "May mention AI search as one factor to consider"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're a seed-stage data-quality startup (barely anyone knows us yet). Plan: publish 20 'best data quality tools' style listicles ranking ourselves #1 so ChatGPT and AI Overviews recommend us. Good idea?",
+      "expected_output": "Should apply references/citations-vs-recommendations.md rather than endorsing the plan as-is. Should explain the citation vs. recommendation distinction — self-promotional listicles from low-authority brands often earn citations while the AI answer recommends the competitors named in the guide instead (cites the study directionally: ~69% of self-promotional listicle citations — 224 of 323 — excluded the publisher from recommendations). Should present the visibility ladder (retrieved → cited → mentioned → recommended) and explain recommendation is governed by offsite consensus (reviews, forums, analysts, press). Should NOT say 'don't publish guides' — should reframe: publish a small number of genuinely useful guides for category framing, and rebalance investment toward reviews/communities/earned media. Should mention the attribution blind spot (AI-influenced visits mostly appear as branded search/direct; only a small share is visible AI traffic) and the measurement triad (prompt tracking, self-reported attribution, call recordings).",
+      "assertions": [
+        "Does not endorse 20 self-ranked listicles as a path to AI recommendations for a low-authority brand",
+        "Distinguishes citations from recommendations with the different governing criteria",
+        "References the visibility ladder (retrieved/cited/mentioned/recommended)",
+        "Warns the guides may surface competitors in AI answers (vote-for-competitors mechanism)",
+        "Recommends offsite consensus building (reviews, communities, analysts, or PR) as the recommendation lever",
+        "Does not tell the user to stop publishing buyer's guides entirely — reframes expectations toward citation and category framing",
+        "Mentions the attribution blind spot and at least two of: prompt tracking, self-reported attribution, call recordings"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/ai-seo/references/citations-vs-recommendations.md
+++ b/skills/ai-seo/references/citations-vs-recommendations.md
@@ -1,0 +1,85 @@
+# Citations vs. Recommendations: The AI Visibility Ladder
+
+Being cited by an AI engine and being recommended by it are **two different outcomes governed by two different systems**. A citation means your page was useful enough to pull information from. A recommendation means the model put your brand on the buyer's shortlist. Optimizing for the first does not automatically earn the second — and for smaller brands, conflating them leads to content strategies that can actively help competitors.
+
+Source note: the analysis and data in this reference draw on Lily Ray's (Amsive) 2026 study of B2B "best [category] software" queries, behavioral studies by Scrunch and SimilarWeb, and commentary by John-Henry Scherck (Growth Plays).
+
+---
+
+## The Visibility Ladder
+
+AI visibility is a ladder, not a binary. Each rung has different selection criteria and different measurement:
+
+| Rung | What it means | What governs it | How to see it |
+|---|---|---|---|
+| **1. Retrieved** | The model read your content while building its answer, without citing it | Crawlability, parseable structure, query relevance | Mostly invisible; bot logs hint at it |
+| **2. Cited** | Your page appears as a source in the answer | Content usefulness: structure, statistics, clarity, freshness | Prompt-tracking tools, AI Overview source lists |
+| **3. Mentioned** | Your brand is named in the answer text | Entity recognition + how the web talks about you | Prompt-tracking tools |
+| **4. Recommended** | Your product is on the shortlist the buyer actually considers | **Aggregate web consensus** — reviews, forums, analysts, press, video — largely independent of your own content | Prompt tracking + the framing around the mention |
+
+Rungs 1–3 are legitimate signals your content is working, and most prompt-tracking tools report them. But rung 4 is where buying behavior changes, and it's earned differently: **citation is about whether your content is useful to consult; recommendation is mostly a reflection of what the broader web says about you** — whether you published a guide on the topic or not.
+
+There is also a shadow rung: **recommended against**. On detailed, requirements-heavy prompts, models increasingly name products a buyer should *avoid* for their use case, with sources. The downside of weak third-party consensus is no longer just absence from the shortlist — it can be an explicit rule-out. This makes monitoring the *framing* around your mentions (favorable / neutral / hedged / negative), not just counting them, part of the job.
+
+---
+
+## The Self-Promotional Listicle Risk
+
+The common tactic — publish a "best [category] software" guide, rank yourself #1, and let it shape both organic search and AI answers — now has a stage-dependent payoff.
+
+**The data:** Lily Ray (Amsive) analyzed 100 B2B "best [category] software" queries across three dates in spring 2026. Across the dataset, self-promotional listicles earned 323 citations in AI Overviews — and in 224 of them (**69% of the citations**), the answer left the publishing brand out of the recommendations, pointing buyers to competitors instead.
+
+**The mechanism:** the model treats your guide as a source about the *category*. It happily extracts the competitor names, comparisons, and evaluation criteria you compiled — then makes its recommendation from web-wide consensus, where the established players dominate. For an emerging brand, a self-promotional buyer's guide can function as **a vote for your competitors**: you did the research that helps the model describe them.
+
+**The split by stage:**
+
+- **Established category leaders** get both outcomes. Their guides earn citations *and* their brands get recommended — because analysts, review sites, and forum discussions already validate them. For leaders, a definitive buyer's guide is highly advantageous: it shapes how the whole category (competitors included) gets described.
+- **Emerging brands** may win the citation and even shape the category's framing, but miss the recommendation. That's not a wasted outcome — influencing how an LLM defines the category and its evaluation criteria is real positioning work — but it is not the shortlist placement the tactic promises.
+
+**What this changes (and doesn't):** genuinely useful buyer's guides still belong in a B2B content strategy at any stage. What changes is the expectation and the investment split. If you're not yet the consensus pick, weight effort toward the offsite signals that actually govern recommendations (below) rather than publishing a plethora of self-ranked listicles.
+
+---
+
+## What Earns Recommendations
+
+Recommendation is a consensus signal. The inputs the models weigh live mostly off your site:
+
+| Channel | Why it moves recommendations | Related skill |
+|---|---|---|
+| **Review platforms** (G2, Capterra, TrustRadius, app stores) | Third-party validation models treat as evidence of legitimacy | customer-research (review generation loops) |
+| **Analyst coverage** (Gartner, Forrester, industry reports) | High-authority category framing; models echo analyst shortlists | public-relations |
+| **Communities and forums** (Reddit, HN, Slack/Discord, niche forums) | Unprompted practitioner discussion is heavily retrieved and hard to fake | community-marketing |
+| **Earned media and PR** | Independent sources repeating your positioning beyond your own site | public-relations |
+| **Video and podcasts** | Increasingly retrieved; transcripts carry brand + category associations | video, social |
+
+The test to apply before investing in another self-ranked guide: *if a model ignored everything on our domain, would the rest of the web still put us on the shortlist?* If not, that gap is the priority. AEO discourse often stops at "are we in the answer?" — the better question is "are we credible enough to be recommended?"
+
+The encouraging flip side: earning an AI recommendation is harder to game than a top search ranking ever was. The durable strategy is the same at every stage — be the best fit for a clear set of buyers, and give those buyers reasons to talk about you in public, where the models can retrieve it.
+
+---
+
+## What a Recommendation Is Worth
+
+Two behavioral studies quantified the gap between rungs:
+
+- **Scrunch** (opt-in panel linking AI conversations to subsequent web behavior, compared against each user's own baseline — observational, not a controlled experiment): a genuine recommendation ("a great option is X") was associated with people searching for, visiting, and evaluating a brand **about twice as often** as a passing mention. For users with no recent observed engagement with the brand, a recommendation was followed within a week by **+182% branded searches, +117% site visits, and +185% product views**.
+- **SimilarWeb** (thousands of real user journeys, seven days post-answer): when ChatGPT recommended a brand, it received **roughly 2.5× more new visitors** the following week than the competitors left off the list.
+
+**The attribution blind spot:** in the SimilarWeb data, only about **9%** of those post-recommendation visits arrived as visible AI referral traffic; the largest share arrived via branded search, with direct and other channels making up the rest — indistinguishable from ordinary organic visitors. AI recommendations are already sending real, engaged buyers, but standard attribution underreports the AI touch.
+
+**Measurement triad** (no single signal is complete; together they give a reliable read):
+
+1. **AI prompt tracking** — whether and how you're mentioned/recommended in LLM answers, even when no click ever lands (tools in SKILL.md's Monitoring section). Track the framing around mentions — recommended, neutral, hedged, or recommended-against — not just the count.
+2. **Self-reported attribution** — a "how did you hear about us?" field catches buyers whose journey started in an AI chat but arrived via branded search or direct.
+3. **Sales call recordings** — buyers' own language often reveals an AI conversation shaped the shortlist long before any form fill.
+
+Also watch **branded search volume** as a proxy: sustained lifts without a matching campaign are increasingly AI-influence showing up under another name.
+
+---
+
+## Applying This
+
+- **Auditing an established brand:** buyer's guides and comparison content are high-leverage — publish the definitive version and shape the category's evaluation criteria.
+- **Auditing an emerging brand:** publish the genuinely useful guides your ICP needs, but set expectations (citation and framing, not near-term recommendation) and rebalance investment toward reviews, communities, analysts, and earned media.
+- **Reporting:** report the ladder, not a single "AI visibility" number — retrieved/cited/mentioned/recommended plus mention framing. A rising citation count with a flat recommendation rate is a specific, diagnosable gap: the web doesn't yet corroborate your content.
+- **Risk check:** for requirements-heavy queries in your category, check whether models recommend *against* you, and trace the sources they cite when they do.

--- a/skills/ai-seo/references/content-patterns.md
+++ b/skills/ai-seo/references/content-patterns.md
@@ -136,6 +136,8 @@ Use for topic pages with multiple common questions. Essential for FAQ schema.
 
 Use for "Best [X]", "Top [X]", "[Number] ways to [X]" queries.
 
+**Caveat for self-promotional listicles:** ranking yourself #1 in your own "best [category]" guide gets the page *cited* far more reliably than it gets your brand *recommended* — for emerging brands, AI answers often harvest the competitor names from the guide and recommend them instead. See [citations-vs-recommendations.md](citations-vs-recommendations.md) before building these at scale.
+
 ```markdown
 ## [Number] Best [Items] for [Goal/Purpose]
 

--- a/skills/ai-seo/references/content-types.md
+++ b/skills/ai-seo/references/content-types.md
@@ -8,7 +8,7 @@ For the cross-cutting strategy, see [SKILL.md](../SKILL.md).
 
 ## SaaS Product Pages
 
-**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+**Goal:** Get cited in "What is [category]?" and "Best [category]" queries. (Citation is the realistic goal here; being *recommended* in the answer depends on offsite consensus — see [citations-vs-recommendations.md](citations-vs-recommendations.md).)
 
 **Optimize:**
 - Clear product description in first paragraph (what it does, who it's for)

--- a/skills/competitors/SKILL.md
+++ b/skills/competitors/SKILL.md
@@ -2,7 +2,7 @@
 name: competitors
 description: "When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when the user mentions 'alternative page,' 'vs page,' 'competitor comparison,' 'comparison page,' '[Product] vs [Product],' '[Product] alternative,' 'competitive landing pages,' 'how do we compare to X,' 'battle card,' or 'competitor teardown.' Use this for any content that positions your product against competitors. Covers four formats: singular alternative, plural alternatives, you vs competitor, and competitor vs competitor. For sales-specific competitor docs, see sales-enablement."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Competitor & Alternative Pages
@@ -103,6 +103,8 @@ Before creating competitor pages, understand:
 7. CTA
 
 **Important**: Include 4-7 real alternatives. Being genuinely helpful builds trust and ranks better.
+
+**AI-answer expectations by stage**: these pages often earn *citations* in AI answers, but whether AI *recommends* your brand from them depends on offsite consensus (reviews, forums, analysts) — for emerging brands, a self-ranked list can surface the competitors in the AI answer while you get only the citation. Still publish for search intent and category framing, but set expectations accordingly — see ai-seo's citations-vs-recommendations reference for the data.
 
 ---
 


### PR DESCRIPTION
## Release v2.8.6

One z-release since v2.8.5:

- **2.8.6 — ai-seo 2.2.0 + competitors 2.0.1** (#428): citations vs. recommendations — the AI visibility ladder (retrieved → cited → mentioned → recommended, plus "recommended against"), the self-promotional listicle risk (69% of AI Overview citations of self-ranked "best [category]" guides — 224 of 323 — excluded the publisher from recommendations), stage-dependent buyer's-guide strategy, offsite consensus as the recommendation lever, and the AI attribution blind spot with a measurement triad. All data verified against primary sources (Lily Ray/Amsive, Scrunch, SimilarWeb).

plugin.json / marketplace.json at 2.8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
