### PR TITLE
docs: clarify npx skills install directories per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,14 @@ npx skills add coreyhaines31/marketingskills --skill cro copywriting
 npx skills add coreyhaines31/marketingskills --list
 ```
 
-This automatically installs to your `.agents/skills/` directory (and symlinks into `.claude/skills/` for Claude Code compatibility).
+The CLI detects which agents you have installed and asks where to install. For Claude Code it installs into `.claude/skills/`; universal agents share `.agents/skills/`.
+
+> [!TIP]
+> If you run the command from **inside** an agent session (e.g., asking Claude Code to install the skills for you), the CLI runs non-interactively and may only install to the universal `.agents/skills/` directory, which Claude Code does not read. Pass the agent explicitly:
+>
+> ```bash
+> npx skills add coreyhaines31/marketingskills -a claude-code
+> ```
 
 ### Option 2: Claude Code Plugin
 


### PR DESCRIPTION
## Summary
Verified the `npx skills add coreyhaines31/marketingskills` install path end-to-end (skills CLI 1.5.15, Claude Code 2.1.173):

- ✅ `--list` discovers all 47 skills
- ✅ Selective install (`--skill cro copywriting`) works
- ✅ Full install of all 47 skills works
- ✅ `-a claude-code` installs correctly into `.claude/skills/`

But the README claimed the CLI "automatically installs to `.agents/skills/` and symlinks into `.claude/skills/`" — that's no longer accurate. Claude Code only gets `.claude/skills/` when selected (interactive prompt or `-a claude-code`). When the CLI is invoked from *inside* an agent session it runs non-interactively and can install universal-only to `.agents/skills/`, which Claude Code does not read (verified empirically with a canary skill).

This PR corrects the install-directory description and adds a tip to pass `-a claude-code` when installing from inside an agent session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)