### PR TITLE
release: v2.8.7 — creative strategy loop + hook system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.6",
+    "version": "2.8.7",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,7 +5,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | Skill | Version | Last Updated |
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
-| ad-creative | 2.5.0 | 2026-07-09 |
+| ad-creative | 2.6.0 | 2026-07-10 |
 | ai-seo | 2.2.0 | 2026-07-09 |
 | analytics | 2.0.0 | 2026-05-05 |
 | aso | 2.0.0 | 2026-05-05 |
@@ -19,7 +19,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
 | cro | 2.0.0 | 2026-05-05 |
-| customer-research | 2.0.0 | 2026-05-05 |
+| customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
@@ -28,7 +28,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
-| marketing-loops | 1.1.0 | 2026-07-05 |
+| marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
@@ -53,6 +53,12 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.8.7 (2026-07-10)
+
+- **ad-creative** (2.5.0 → 2.6.0): added **Mode 4 — the Creative Strategy Loop**, the upstream workflow layer for deciding which ads are worth making (built so the same capability ships in any agent running the library, incl. Magister; workflow shapes informed by public creative-strategist practice, expressed originally). New `references/creative-roadmap.md`: three-signal synthesis (account performance via the platform CLIs; customer/brand language via the Grounded Inputs corpus + customer-research; external organic via scraping, social listening, and competitor-profiling) on a monthly-deep-dive + weekly-refresh cadence with a receipts rule (no insight enters the icebox without its source); concepts as segment × motivation × angle × format hypotheses ranked on a six-tier evidence scale; **account-state branching** (exploration state: wide net-new mix, per-metric win redefinition, iterate only on hits, four root causes to check; scaling state: winner-variation-heavy mix with visually-distinct variations, sub-angle probes, a standing exploration allocation); the **roadmap artifact** (icebox → quarterly themes → monthly slate with T1 iteration / T2 remix / T3 production tiers and a hard capacity check); per-concept briefs handed to Modes 1–3; and the **monthly creative retro** (winners/losers/metric-wins/learnings/kills, judged at concept level, every learning landing as an icebox update, re-rank, or kill). New `references/hook-system.md`: hooks as three components (visual action / spoken line / caption) with the no-duplication rule; the segment → motivation → format → hook generation pipeline output as a hook matrix; an eight-move opening menu; the **diagnostic funnel** mapping thumbstop/hold/CTR/CVR to which component to fix; the **on-ramp rule** (every hook test is an on-ramp test); fidelity laddering tied to production tiers; and inherited grounding rules plus organic language mining. SKILL.md adds the Mode 4 section and 'creative strategy,' 'creative roadmap,' 'creative retro,' 'hook writing' triggers. New eval (id 9) covers exploration-state diagnosis, evidence-ranked slates, and the receipts rule.
+- **customer-research** (2.0.0 → 2.0.1): added the **zero-review persona fallback** to Persona Generation — a four-step proxy ladder (own differentiator → direct competitors' reviews → marketplace comparables → adjacent brands sharing the audience) with provisional-persona tagging and replacement as first-party evidence arrives.
+- **marketing-loops** (1.1.0 → 1.2.0): added **the monthly-creative-retro loop** to the Paid section of `references/loop-catalog.md` — closes ad-creative's Mode 4 loop on a schedule: pulls last month's performance, drafts the retro artifact and next month's capacity-checked slate, flags the account-state call for human confirmation, one-retro-per-month idempotency, and never launches or pauses ads. Closes #434.
 
 ### 2.8.6 (2026-07-09)
 

--- a/skills/ad-creative/SKILL.md
+++ b/skills/ad-creative/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ad-creative
-description: "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' 'static ads,' 'static ad concepts,' 'ad templates,' 'iMessage ad,' 'chat reveal ad,' 'text message ad,' 'fake DM ad,' 'ChatGPT ad,' 'Apple Notes ad,' 'motion video ad,' 'faceless video ad,' 'animated explainer ad,' 'motion collage ad,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see ads. For landing page copy, see copywriting."
+description: "When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad variations — for any paid advertising platform. Also use when the user mentions 'ad copy variations,' 'ad creative,' 'generate headlines,' 'RSA headlines,' 'bulk ad copy,' 'ad iterations,' 'creative testing,' 'ad performance optimization,' 'write me some ads,' 'Facebook ad copy,' 'Google ad headlines,' 'LinkedIn ad text,' 'static ads,' 'static ad concepts,' 'ad templates,' 'iMessage ad,' 'chat reveal ad,' 'text message ad,' 'fake DM ad,' 'ChatGPT ad,' 'Apple Notes ad,' 'creative strategy,' 'creative roadmap,' 'creative retro,' 'hook writing,' 'motion video ad,' 'faceless video ad,' 'animated explainer ad,' 'motion collage ad,' or 'I need more ad variations.' Use this whenever someone needs to produce ad copy at scale or iterate on existing ads. For campaign strategy and targeting, see ads. For landing page copy, see copywriting."
 metadata:
-  version: 2.5.0
+  version: 2.6.0
 ---
 
 # Ad Creative
@@ -46,7 +46,7 @@ Gather this context (ask if not provided):
 
 ## How This Skill Works
 
-This skill supports three modes:
+This skill supports four modes:
 
 ### Mode 1: Generate from Scratch
 When starting fresh, you generate a full set of ad creative based on product context, audience insights, and platform best practices.
@@ -62,6 +62,9 @@ Pull performance data → Identify winning patterns → Generate new variations 
 
 ### Mode 3: Scaled Static Batches (Grounded)
 For recurring static ad production at volume (e.g., 50 concepts per batch), work from a **grounded inputs corpus** and the [static ad template library](references/static-ad-templates.md). Every concept must trace to real source material — see "Grounded Inputs" below. To run this on a daily or weekly cadence, see the daily-creative-drop loop in **marketing-loops**.
+
+### Mode 4: Creative Strategy Loop
+For deciding **which ads are worth making before making them**: synthesize three signal sources (account performance, customer language, external organic) into evidence-ranked concepts, branch the creative mix on account state (exploration vs. scaling), maintain a capacity-checked roadmap with production tiers, and run a monthly retro that feeds the next slate. The full system lives in [references/creative-roadmap.md](references/creative-roadmap.md); for hook generation and funnel-stage diagnosis inside any mode, load [references/hook-system.md](references/hook-system.md).
 
 ---
 

--- a/skills/ad-creative/evals/evals.json
+++ b/skills/ad-creative/evals/evals.json
@@ -115,6 +115,21 @@
         "Gives surface-selection reasoning (ChatGPT vs Notes) instead of treating formats as interchangeable"
       ],
       "files": []
+    },
+    {
+      "id": 9,
+      "prompt": "Our Meta account is stuck — we've tested 30 ads over two months and nothing beats the control. I have our reviews exported and access to our ad account data. Build me a creative plan for next month.",
+      "expected_output": "Should apply Mode 4 / references/creative-roadmap.md rather than jumping straight to generating ads. Should identify the account as exploration state (nothing working) and shape the plan accordingly: mostly net-new concepts across different segments/angles, minimal iterations, per-metric win redefinition (a hold-rate lift or CPC drop counts as a hit worth pulling on). Should synthesize the three signals (account performance from the ad data, customer language from the reviews, external organic — asking for or mining niche organic content) into concepts ranked by evidence tier, each with a cited source. Should produce a capacity-checked monthly slate with production tiers (favoring T1/T2 low-fidelity tests per the fidelity ladder) and flag the common exploration-state root causes to check (boring creative, overcomplicated message, unclear UVP, punishing CPMs). Should end with the retro plan for judging the slate at month end. Should not invent customer language or claims — insights must trace to the provided reviews/data.",
+      "assertions": [
+        "Applies the creative strategy loop (Mode 4) instead of only generating ad copy",
+        "Diagnoses exploration state and recommends a wide, net-new-heavy mix with minimal iterations",
+        "Redefines wins per-metric for a stuck account",
+        "Synthesizes all three signal sources or explicitly requests the missing one",
+        "Concepts are evidence-ranked with cited sources (no invented insights)",
+        "Monthly slate is capacity-checked and production-tiered, favoring low-fidelity tests",
+        "Includes a month-end retro plan that feeds the next slate"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/ad-creative/references/creative-roadmap.md
+++ b/skills/ad-creative/references/creative-roadmap.md
@@ -1,0 +1,118 @@
+# The Creative Strategy Loop
+
+Generation (Modes 1–3) answers "make me ads." This reference answers the question that comes first: **which ads are worth making, in what order, at what production cost** — and the retro that turns each month's results into next month's plan. It's the standing operating loop of a creative strategist, run by an agent with a human deciding.
+
+```
+Signals → Concepts (evidence-ranked) → Roadmap (tiered, capacity-checked) → Briefs → [Modes 1–3 produce] → Monthly retro → back into the icebox
+```
+
+---
+
+## Step 1: Read the Three Signals
+
+Creative direction comes from synthesis across three independent signal sources. One source alone misleads: the account tells you what worked *among things you've tried*, customers tell you why they buy *in their words*, and organic content tells you what the audience *chooses to watch when nobody's paying*.
+
+| Signal | What to pull | How |
+|---|---|---|
+| **Account performance** | Winners/losers by angle, hook, format; funnel metrics per concept (see [hook-system.md](hook-system.md) diagnostic funnel); fatigue state | `google-ads` / `meta-ads` / `linkedin-ads` / `tiktok-ads` CLIs (see Tool Integrations in SKILL.md) |
+| **Customer/brand** | Verbatim pain/desire/objection language; unexpected use cases; who's *actually* buying vs. who's targeted | The Grounded Inputs corpus (`inputs/reviews/`, `inputs/comments/`), sales-call notes, support themes — per **customer-research** |
+| **External organic** | What the niche watches unpaid: top organic content, its hooks, formats, vocabulary; competitor ads running long enough to be presumed working | **scraping**, the social listening tooling in **social**, ad libraries, **competitor-profiling** |
+
+**Cadence:** a monthly deep dive (60–90 min, all three sources, feeds the monthly roadmap) plus a weekly ~20-minute refresh (what changed: new winners/losers, new review themes, anything spiking organically). Research beyond what the next decision needs is busywork — every synthesis session should end in concepts, not notes.
+
+**Trust rule:** every insight the agent surfaces must carry its receipt — which review, which ad's metrics, which organic post. An insight without a source doesn't enter the icebox. (Same grounding rules as everything else in this skill.)
+
+---
+
+## Step 2: Turn Signals into Evidence-Ranked Concepts
+
+A **concept** is one testable creative hypothesis: *segment × motivation × angle × format*, with its evidence attached. "UGC for moms" is not a concept; "new-parent insomniacs (per 40+ reviews mentioning 3am feeds) × 'quiet enough to not wake the baby' × before/after demo × POV night-shot video" is.
+
+Rank every concept by the strongest evidence supporting it:
+
+| Tier | Evidence | Weight |
+|---|---|---|
+| 1 | Your own account: a converting ad with the same angle/segment | Strongest — iterate and extend |
+| 2 | Your customers verbatim: recurring review/call language | Strong — build new creative on it |
+| 3 | Competitor creative running 60+ days (presumed working) | Good — adapt the angle, never the ad |
+| 4 | Organic engagement in the niche (unpaid views/saves on the theme) | Moderate — validate cheaply first |
+| 5 | Cross-niche pattern (worked in an adjacent category) | Weak — icebox until corroborated |
+| 6 | Team hunch, no external signal | Weakest — low-fi test or drop |
+
+Higher evidence earns roadmap *priority* — an earlier slot in the slate. Production tier is a separate call, set by validation strength, existing assets, capacity, and risk: even a tier-2 customer-language concept starts low-fidelity until it shows a funnel signal. Hunches aren't banned — they're just cheap and last.
+
+---
+
+## Step 3: Branch on Account State
+
+The right creative mix depends on which of two states the account is in. Diagnose before roadmapping — a plan built for the wrong state wastes the month.
+
+**Exploration state** — nothing (or nothing new) is working:
+- Go **wide, not deep**: mostly net-new concepts across different segments and angles; keep iterations to a small minority — iterating on losers multiplies losers
+- **Redefine "win" per-metric**: with no full-funnel winners, a single-metric improvement (a hold-rate lift, a CPC drop, a CVR bump) on any test is a hit worth pulling on — see the diagnostic funnel
+- Iterate **only on hits**; everything else stays exploratory
+- Common root causes to check while testing: the creative is boring (safe, seen-before), the message is overcomplicated, the offer/UVP is unclear, or CPMs are punishing a too-narrow audience
+
+**Scaling state** — one or more concepts are converting profitably:
+- Go **deep on the winner** while it's open: a winner-led slate of visually-distinct variations of the winning concept (same message, new execution — near-duplicates mostly cannibalize the original's reach and teach you nothing new, so variations must look meaningfully different), plus a remix lane (tonal/emotional re-executions of it) and sub-angle probes drilling *into* the winning segment; tune the split to budget, fatigue speed, and production velocity
+- Keep a small exploration allocation alive even mid-scale — winners fatigue, and the next winner is rarely an iteration of the current one
+- Speed matters more in this state: a scaling window is finite
+
+---
+
+## Step 4: The Roadmap Artifact
+
+Maintain one living document (suggested: `roadmap.md` beside the Grounded Inputs corpus) with three horizons:
+
+```
+## Icebox        — every concept, evidence tier + source attached, nothing scheduled
+## This quarter  — 2-4 themes chosen from the icebox (the bets), with why-now
+## This month    — the slate: concept | evidence tier | production tier | owner | status
+```
+
+Each monthly-slate concept gets a **production tier**:
+
+| Tier | Cost | What it is | Use for |
+|---|---|---|---|
+| **T1 — Iteration** | Hours | New hook/caption/crop on an existing asset | Extending proven winners |
+| **T2 — Remix** | Days | New creative from existing footage/assets/AI generation | Concepts with decent evidence or a first low-fi signal |
+| **T3 — Production** | Weeks | Net-new shoot, creators, full build | Only angles with own-account proof or a prior low-fi funnel signal (fidelity ladder in [hook-system.md](hook-system.md)) |
+
+**Capacity check — the rule that keeps roadmaps honest:** count what the team (or the AI pipeline) can produce *at quality* this month, and roadmap to that number. A 20-concept slate against 8 concepts of real capacity doesn't produce 20 ads; it produces 20 compromised ones and a burned-out team. Cut by evidence rank until the slate fits.
+
+From the slate, generate **one brief per concept** (segment, motivation + verbatim source, angle, format, hook matrix rows, production tier, success metric) and hand each to Modes 1–3 for production.
+
+---
+
+## Step 5: The Monthly Creative Retro
+
+Last step of the loop, first input of the next one. One artifact per month (suggested: `retros/YYYY-MM.md`):
+
+```
+## Winners     — concept, the funnel numbers, and the WHY (which element earned it)
+## Losers      — concept, where in the funnel it died, hypothesis for why
+## Metric wins — full-funnel losers with one strong metric (these are leads, not losses)
+## Learnings   — pattern-level notes → written back into the icebox as new/revised concepts
+## Kills       — concepts retired from the icebox, with reason
+## Next slate  — first draft of next month, updated evidence ranks
+```
+
+Retro rules:
+
+- **Judge concepts, not ads.** Three executions of one concept failing says the concept is wrong; one failing says the execution was.
+- **Read the funnel, not the ROAS column.** The diagnostic funnel says *what* to fix; ROAS alone says only *that* something is broken.
+- **Enough data before verdicts** — respect the impression/spend thresholds in Common Mistakes and the **ads** skill's decision systems; a two-day read is a coin flip.
+- **Every learning lands somewhere**: icebox update, evidence re-rank, or kill. A retro that changes nothing in the roadmap was a meeting, not a retro.
+
+To run this loop on a schedule (retro on the 1st, weekly refresh Mondays, daily batches via Mode 3), see the creative loops in **marketing-loops**.
+
+---
+
+## Failure Modes
+
+- **Roadmapping without a diagnosis** — a slate built before reading the three signals is a wish list; testing without a diagnosis isn't strategy
+- **Iteration-heavy slates in exploration state** — polishing losers while the real problem (angle, offer, audience) goes untested
+- **Ignoring capacity** — the plan the team can't produce at quality is a plan to produce slop
+- **Evidence-free concepts jumping the queue** — the loudest stakeholder's hunch ships as a T3 shoot while tier-2 customer language sits in the icebox
+- **Retro as theater** — winners celebrated, nothing re-ranked, icebox untouched
+- **Scaling-state complacency** — 100% of the slate on winner variations; when the winner fatigues, the pipeline is empty

--- a/skills/ad-creative/references/hook-system.md
+++ b/skills/ad-creative/references/hook-system.md
@@ -1,0 +1,115 @@
+# The Hook System
+
+The first three seconds decide whether the rest of the ad exists. Hooks are the highest-leverage unit of paid creative work — and hook *diversity* is what earns incremental learning: distinct hooks reach distinct pockets of the audience, while near-identical openings mostly re-test what you already know about the same one. This reference is a complete system for generating, diagnosing, and iterating hooks — not a list of one-liners.
+
+Use it inside Mode 1/3 generation (hooks for new concepts), Mode 2 iteration (diagnosing why an ad underperforms), and the creative strategy loop in [creative-roadmap.md](creative-roadmap.md).
+
+---
+
+## A Hook Is Three Components, Not a Line
+
+In video, the hook is the simultaneous combination of:
+
+| Component | What it is | Job |
+|---|---|---|
+| **Visual action** | What is literally happening on screen in seconds 0–3 | Stop the thumb |
+| **Spoken line** | The first words of VO or dialogue | Open the loop |
+| **Caption text** | On-screen header/overlay text | Anchor the claim for sound-off viewers |
+
+**The no-duplication rule:** the three components must complement, never repeat. If the VO says "I stopped paying $200/mo for my gym" while the caption reads "I stopped paying $200/mo" over a static talking head, two of the three slots are wasted. Strong hooks split the work — visual shows the cancellation email, VO says the line, caption names the alternative. When writing hooks, write all three columns explicitly; a hook spec with one column filled in is a third of a hook.
+
+Static ads collapse this to two components (visual + headline) — the same rule applies: the headline must not caption the image.
+
+---
+
+## The Generation Pipeline
+
+Work top-down; hooks written without the upstream steps read like everyone else's ads.
+
+```
+Segment → Motivation → Format → Hook (three components)
+```
+
+1. **Segment** — which specific buyer this hook addresses. Not the whole ICP: a slice with a shared situation (from the Grounded Inputs corpus: reviews, comments, sales-call language). The narrower the segment, the sharper the hook.
+2. **Motivation** — the single pain, desire, or objection that moves this segment, in *their* words. Pull verbatim phrases from reviews and comments; the corpus language always outperforms marketing paraphrase.
+3. **Format** — the delivery vehicle: street interview, POV selfie, screen recording, unboxing, side-by-side demo, text-on-screen static, founder-to-camera, reaction stitch. Pick the format *before* writing the line — the same motivation reads completely differently as a street-interview answer vs. a confession-to-camera.
+4. **Hook** — now write the three components for this segment × motivation × format cell.
+
+**Output as a hook matrix** so coverage is visible:
+
+```
+| # | Segment | Motivation (verbatim source) | Format | Visual action | Spoken line | Caption |
+```
+
+Generate across the matrix, not down a single column — ten hooks for ten segment×motivation cells beat thirty rewordings of one cell. This is the same angle-diversity principle as the static template library: matrix diversity is audience diversity.
+
+---
+
+## Hook Opening Moves
+
+A menu of proven opening structures. Cycle through them like the static templates — don't cluster on favorites:
+
+| Move | Shape | Watch out |
+|---|---|---|
+| **Curiosity gap** | Withhold the noun: "Nobody tells you what actually causes this" | Must pay off within the ad or it's clickbait that poisons CVR |
+| **Bold claim** | A specific, falsifiable statement: "This replaced my entire morning routine" | Needs substantiation on screen or in the on-ramp |
+| **First-person confession** | "I was doing [common thing] completely wrong" | Reads fake without lived-in detail |
+| **Contrast / before-after** | Two states shown or named in the first beat | The transformation must be visually honest — see compliance notes in SKILL.md |
+| **Relatability / POV** | Mirror a hyper-specific situation: "POV: it's 3pm and you're on your fourth coffee" | Specificity is the entire mechanic; generic POV is invisible |
+| **Question** | Ask the exact question the buyer types into search or ChatGPT | Use their phrasing verbatim from the corpus |
+| **Countdown / gamified** | A timer or on-screen challenge that promises a payoff at the end | Payoff must exist; hold-rate collapses on cheats |
+| **Proof-first** | Lead with the receipt — the result screenshot, the stat, the demo money-shot | Strongest when the proof brags by itself |
+
+---
+
+## The Diagnostic Funnel
+
+Each metric in the delivery funnel isolates a different component. When an ad underperforms, read the funnel to find *which part* to fix instead of scrapping the whole ad:
+
+| Stage | Metric | If it's weak, the problem is | Fix |
+|---|---|---|---|
+| Stop | Thumbstop / 3-sec view rate | **Visual action** (and caption) | New visual opening; same everything else |
+| Stay | Hold rate (3s → 15s / 50% view) | **The on-ramp** — what follows the hook | Rework seconds 3–15, not the hook |
+| Click | CTR | Desire/offer clarity mid-ad | Sharpen the promise, CTA, or proof |
+| Convert | CVR post-click | Congruence — the page doesn't continue the ad | Fix the landing page or the claim, per **cro** |
+
+Two rules this table enforces:
+
+- **A great thumbstop is not a great ad.** A clickbait visual that attracts the wrong viewers shows up as high thumbstop + collapsed hold/CVR. Read the whole funnel before declaring a winning hook.
+- **One component per iteration.** Change the visual OR the on-ramp OR the offer framing per test cycle — matching the one-variable rule in Common Mistakes.
+
+---
+
+## The On-Ramp Rule
+
+The on-ramp is seconds ~3–15: the bridge from hook to body. **A good on-ramp logically extends the hook's premise; a bad one pivots to a product pitch that abandons it.** If the hook promises "what actually causes this," the next beat must start explaining the cause — not introduce the brand story.
+
+Corollary: **every hook test is also an on-ramp test.** Swapping a new hook onto an existing ad body usually breaks the premise-bridge; when testing hooks, re-write the on-ramp to match each one. Hold rate is the on-ramp's metric — diagnose it separately from thumbstop.
+
+---
+
+## Fidelity Laddering
+
+Match production cost to evidence strength (production tiers are defined in [creative-roadmap.md](creative-roadmap.md)):
+
+- **Hunches ship low-fidelity within a day or two:** statics, text-on-screen video, voiceover-over-b-roll, remixes of existing footage. The goal is a cheap signal on the *angle*, not a polished ad.
+- **Validated angles earn high-fidelity:** creator shoots, street interviews, staged demos. Only spend production budget on hooks whose low-fi version already showed a funnel signal (even a single-metric win — a hold-rate spike on an ugly static is evidence).
+
+Testing a hunch with an expensive shoot and testing a proven angle with a throwaway static are both mistakes — the ladder runs in one direction.
+
+---
+
+## Grounding Rules (inherited, non-negotiable)
+
+Hooks inherit every grounding rule from SKILL.md: every hook cites the corpus source its motivation came from; no invented claims, stats, or testimonials; verbatim customer language over paraphrase. Additionally, mine **organic content in the niche** (top-performing TikToks/Reels/posts, via the **scraping** skill or the social listening tooling in **social**) for the audience's actual vocabulary — the words the niche uses ("GLP-1" vs. the clinical term, the slang for the pain) belong in the caption and spoken line. Organic mining is language research, not copying: take the vocabulary and the visual conventions, never a creator's specific creative.
+
+---
+
+## Common Failure Modes
+
+- **Thirty rewordings of one cell** — variation without matrix coverage; diversity of segment×motivation is the point
+- **Components duplicating each other** — three slots saying one thing
+- **Hook tested, on-ramp inherited** — premise-bridge broken, hold rate blamed on the hook
+- **Funnel read stops at thumbstop** — clickbait winners scale into CVR craters
+- **Polished hunches** — high-fidelity production spent on unvalidated angles
+- **Marketing-voice captions** — the corpus and the niche's organic content define the vocabulary; "revolutionary formula" appears in neither

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -2,7 +2,7 @@
 name: customer-research
 description: When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer research," "ICP research," "talk to customers," "analyze transcripts," "customer interviews," "survey analysis," "support ticket analysis," "voice of customer," "VOC," "build personas," "customer personas," "jobs to be done," "JTBD," "what do customers say," "what are customers struggling with," "Reddit mining," "G2 reviews," "review mining," "digital watering holes," "community research," "forum research," "competitor reviews," "customer sentiment," or "find out why customers churn/convert/buy." Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see cro.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Customer Research
@@ -169,6 +169,18 @@ After gathering from multiple sources, synthesize into:
 ---
 
 ## Persona Generation
+
+### When there are no reviews yet
+
+Early-stage products (or new categories) lack first-party review data. Don't invent personas — walk outward through proxy sources, in order:
+
+1. **Your own differentiator** — what the product does differently defines who feels that difference most; write the hypothesis down as a hypothesis
+2. **Direct competitors' reviews** — their customers describe the problem space in their words (note what's praised and what's missing)
+3. **Comparable products on marketplaces** — Amazon/app-store reviews for adjacent solutions to the same job
+4. **Adjacent brands sharing the audience** — what else this buyer buys; their reviews reveal the buyer's broader language and values
+
+Personas built this way are provisional: tag each with its proxy source, and replace proxy evidence with first-party evidence as real reviews arrive.
+
 
 Personas should be built from research, not invented. Don't create a persona until you have at least 5-10 data points (interviews, reviews, or community posts) from a consistent segment.
 

--- a/skills/marketing-loops/SKILL.md
+++ b/skills/marketing-loops/SKILL.md
@@ -2,7 +2,7 @@
 name: marketing-loops
 description: "When the user wants to set up a recurring, self-running marketing workflow — a repeatable loop an AI agent runs on a cadence (weekly, daily, on a trigger) rather than a one-off task. Also use when the user mentions 'marketing loop,' 'recurring marketing workflow,' 'automate my marketing,' 'marketing on autopilot,' 'weekly marketing review,' 'ad fatigue check,' 'content refresh loop,' 'churn watch,' 'ranking drop alert,' 'always-on marketing,' 'marketing automation workflow,' or 'run this every week.' Use this to pick, adapt, and schedule an ongoing marketing loop that orchestrates the other marketing skills. For one-off marketing ideas, see marketing-ideas. For the experimentation loop specifically, see ab-testing."
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Marketing Loops

--- a/skills/marketing-loops/references/loop-catalog.md
+++ b/skills/marketing-loops/references/loop-catalog.md
@@ -149,6 +149,21 @@ Loops are grouped by function. Naming follows the "The X loop" convention.
 - **Output**: A dated folder of grounded static ad concepts + index, ready for human selection.
 - **Input freshness (companion cadence)**: Weekly, refresh `inputs/winning-ads/` with anything that scaled and prune stale examples; monthly, refresh `inputs/reviews/` and `inputs/comments/` and re-check the voice doc. Stale inputs are this loop's failure mode — output quality tracks input freshness, not run count.
 
+### The monthly-creative-retro loop
+- **Check cadence**: Monthly (first business day, reading the prior month)
+- **Acts when**: The account had meaningful creative activity last month — new concepts launched with enough delivery to judge (respect the impression/spend thresholds in `ads`). If nothing launched or nothing cleared thresholds, note that and skip.
+- **Purpose**: Close the creative strategy loop — turn last month's results into next month's evidence-ranked slate, so the roadmap learns instead of drifting.
+- **Skills used**: `ad-creative` (Mode 4 + creative-roadmap reference), `ads` (decision thresholds), `analytics`
+- **Loop body**:
+  1. Pull last month's ad performance via the platform CLIs; map results to the month's roadmap concepts.
+  2. Draft the retro artifact (`retros/YYYY-MM.md`): winners with the why, losers with funnel-stage diagnosis, single-metric wins, learnings, kills.
+  3. Update the roadmap: re-rank icebox evidence, write learnings in as new/revised concepts, draft next month's capacity-checked slate.
+  4. Flag the account-state call (exploration vs. scaling) for human confirmation — the mix recommendation depends on it.
+- **Self-check**: Are verdicts on concepts (not single executions)? Did every learning land somewhere — icebox update, re-rank, or kill? Did anything clear thresholds, or is this month a skip?
+- **State / idempotency**: One retro per month — skip if `retros/YYYY-MM.md` exists. The roadmap file is the shared state; never fork it.
+- **Stop / bail-out**: Stages analysis and a draft slate only — the human approves the slate and the account-state call; the loop **never launches or pauses ads**. If retros go unread for two cycles, pause and ask.
+- **Output**: The monthly retro artifact + an updated roadmap with a draft slate for the coming month.
+
 ### The paid-search query-mining loop
 - **Check cadence**: Weekly
 - **Acts when**: Search-term reports reveal wasted spend or new intent.


### PR DESCRIPTION
## Release v2.8.7

One z-release since v2.8.6:

- **2.8.7 — ad-creative 2.6.0 + customer-research 2.0.1 + marketing-loops 1.2.0** (#436): the creative strategy loop (Mode 4) — three-signal synthesis with a receipts rule, evidence-ranked concepts, exploration-vs-scaling account-state branching, capacity-checked roadmap with production tiers, and a monthly creative retro — plus the complete hook system (three-component rule, hook matrix pipeline, diagnostic funnel, on-ramp rule, fidelity ladder). customer-research adds the zero-review persona fallback; marketing-loops adds the monthly-creative-retro loop. IP-scanned original expression.

plugin.json / marketplace.json at 2.8.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
