### PR TITLE
test: add missing skill evals

### DIFF
--- a/skills/offers/evals/evals.json
+++ b/skills/offers/evals/evals.json
@@ -1,0 +1,90 @@
+{
+  "skill_name": "offers",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I sell a $3,000 cohort-based course for freelance designers. The curriculum is good but conversion is weak. Can you help me improve the offer?",
+      "expected_output": "Should check for product-marketing.md first. Should identify this as a course/cohort offer, not a SaaS pricing problem. Should state the current offer in plain language, then apply the value equation: dream outcome, perceived likelihood, time delay, effort and sacrifice. Should audit the six offer components: core deliverable, bonus stack, guarantee, scarcity or urgency, name, and price/payment structure. Should recommend one or two highest-leverage changes such as outcome-framed naming, proof, cohort scarcity, conditional guarantee, and targeted bonuses. Should avoid loud or manipulative direct-response language.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Identifies the business type as course/cohort",
+        "Applies the value equation",
+        "Audits all six offer components",
+        "Recommends targeted changes to the offer structure",
+        "Uses honest scarcity and guarantee guidance",
+        "Avoids manipulative or course-bro language"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "my offer isn't converting. it's a $5k done-for-you landing page service for B2B SaaS companies. right now it's basically 'we design and build your landing page in 3 weeks.'",
+      "expected_output": "Should trigger on casual phrasing. Should apply the diagnostic loop for a service/productized service offer. Should restate the offer plainly and identify missing anatomy: likely no named offer, no proof, no guarantee, no real scarcity, and no bonuses addressing objections. Should score or qualitatively assess the value-equation levers, especially perceived likelihood and effort/sacrifice. Should suggest productizing the service with a clearer outcome, scope, timeline, milestone guarantee or paid pilot guarantee, and objection-handling bonuses such as conversion teardown, copy brief, or implementation checklist. Should recommend fixing one binding constraint first rather than rebuilding everything.",
+      "assertions": [
+        "Triggers on casual phrasing",
+        "Applies service/productized service offer guidance",
+        "Restates the current offer in plain language",
+        "Identifies weak or missing offer anatomy components",
+        "Uses the value equation to find the binding constraint",
+        "Suggests a guarantee or pilot structure that matches the service",
+        "Recommends one focused iteration rather than changing everything"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We want to add scarcity to our evergreen consulting offer. Could we put a countdown timer on the page that resets every 24 hours?",
+      "expected_output": "Should reject fake scarcity clearly. Should explain that resetting countdown timers and false urgency torch trust and should not ship. Should look for real constraints instead: founder capacity, application windows, cohort dates, bonus expiry, seasonal availability, price-increase scheduling, or limited implementation slots. Should state that if no real constraint exists, the offer should skip scarcity and improve the value equation instead. Should provide a trustworthy alternative scarcity or urgency mechanism only if it can be enforced.",
+      "assertions": [
+        "Rejects resetting countdown timers",
+        "Explains why fake scarcity is harmful",
+        "Suggests honest scarcity formats",
+        "Connects scarcity to real enforceable constraints",
+        "Recommends skipping scarcity if no real constraint exists",
+        "Routes back to value-equation work when scarcity is not appropriate"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "I'm building a $497 template pack. I want to say it includes $25,000 in bonuses and a 100% lifetime guarantee. Is that a good idea?",
+      "expected_output": "Should flag bonus inflation and generic/lifetime guarantee language as low-trust. Should apply bonus-stacking guidance: bonuses should close specific objections, be things that could credibly sell separately, and generally total less than about 2x the core price. Should recommend 3-5 specific bonuses such as quick-start walkthrough, implementation map, examples library, or updates, with defensible stated values. Should apply guarantee-design guidance for low-ticket info products, suggesting a clear short refund window or first-step guarantee rather than vague lifetime promises. Should avoid inflated value claims.",
+      "assertions": [
+        "Flags inflated bonus values",
+        "Flags vague or lifetime guarantee language",
+        "Applies bonuses-as-objection-handlers",
+        "Keeps bonus value defensible relative to price",
+        "Recommends 3-5 specific bonuses",
+        "Suggests a guarantee suitable for low-ticket info products",
+        "Avoids inflated value claims"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "We're a self-serve SaaS with three monthly tiers. Should we use bonuses and guarantees to make the Pro plan convert better?",
+      "expected_output": "Should recognize that for pure self-serve SaaS, pricing and packaging usually do more work than offer-construction tactics. Should cross-reference or defer to pricing for tier structure, value metric, freemium, and packaging decisions. Should still use offer framing where appropriate: annual prepay as an offer lever, onboarding support, implementation guarantee, trial-to-paid transition, or plan-specific proof. Should avoid forcing direct-response bonus stacks or fake urgency onto SaaS tiers.",
+      "assertions": [
+        "Recognizes self-serve SaaS as primarily a pricing/packaging problem",
+        "Cross-references pricing",
+        "Uses offer design only as supplemental guidance",
+        "Mentions annual prepay or onboarding as possible offer levers",
+        "Avoids direct-response bonus stacking for SaaS tiers",
+        "Avoids fake urgency"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Write the sales page for my new coaching offer. I already know the offer; I just need the page copy.",
+      "expected_output": "Should recognize this is primarily a copywriting request, not offer construction. Should defer to or cross-reference the copywriting skill for writing the sales page. Should optionally offer to sanity-check the underlying offer anatomy first if the user wants, but should not run a full offer-design process unless the offer itself is unclear or weak.",
+      "assertions": [
+        "Recognizes sales page copy as copywriting scope",
+        "References or defers to copywriting",
+        "Does not run a full offer-design process by default",
+        "Optionally offers a light offer-anatomy sanity check"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/public-relations/evals/evals.json
+++ b/skills/public-relations/evals/evals.json
@@ -1,0 +1,92 @@
+{
+  "skill_name": "public-relations",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want press for our B2B SaaS launch next month. We have proprietary data about how support teams are using AI, a founder available for interviews, and a press page draft. Help us plan PR.",
+      "expected_output": "Should check for product-marketing.md first. Should identify this as earned media/PR work and recommend a mix of proactive pitching, owned press page/media kit, and possibly launch coordination. Should emphasize that the story is the data/trend/conflict, not just the product launch. Should build a 4-8 week pitching plan with a media list of journalists who actually cover the beat, scored by fit. Should suggest pitch angles such as data story, trend connector, and exclusive launch/milestone. Should include press page requirements and realistic measurement such as placements, backlink quality, referral traffic, brand search lift, AI citation rate, and sales conversations citing the article.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Identifies earned media/PR scope",
+        "Makes the story about data or trend rather than the product alone",
+        "Recommends proactive pitching and owned press assets",
+        "Builds a 4-8 week plan",
+        "Uses journalist fit scoring or targeted media-list building",
+        "Includes realistic PR measurement"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "A big regulation just dropped in our industry this morning. We're a compliance startup and want to newsjack it. What should we do in the next two hours?",
+      "expected_output": "Should apply the newsjacking detect -> score -> angle -> pitch loop. Should score whether the story is timely, relevant, has a contrarian or useful angle, and whether the company has credibility. Should move fast, recommending a quote-worthy angle, 3-5 relevant journalists currently covering the topic, a short pitch, and a public trail post on the company blog or LinkedIn. Should warn that speed matters and if they cannot draft and respond quickly, they should skip the pitch. Should avoid tragedy/politics/crisis exploitation if relevant.",
+      "assertions": [
+        "Applies the newsjacking loop",
+        "Uses newsworthiness scoring",
+        "Prioritizes speed and a sub-2-hour workflow",
+        "Develops a specific quote-worthy angle",
+        "Targets 3-5 relevant journalists",
+        "Recommends a public trail post",
+        "Includes skip criteria or sensitivity guardrails"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Find 500 journalists we can blast with our funding announcement.",
+      "expected_output": "Should reject the blast approach and explain that PR should target journalists who actually cover the beat. Should recommend building a focused list of roughly 20-40 journalists and scoring them by beat fit, recency, audience fit, and engagement. Should suggest personalized Tier 1 pitches for the top 20, lightly customized Tier 2 pitches, and skipping poor-fit journalists. Should mention checking each journalist's last 5 articles and respecting people who say no PR pitches. Should avoid generic editor-in-chief addresses and mass CC/BCC outreach.",
+      "assertions": [
+        "Rejects mass blasting journalists",
+        "Recommends a focused 20-40 person media list",
+        "Applies journalist fit scoring",
+        "Checks recent articles and beat fit",
+        "Segments pitch effort by fit tier",
+        "Avoids generic editor addresses and mass emails",
+        "Respects no-pitch preferences"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Can you help me answer this Qwoted request? Reporter wants a 200-word expert quote on AI adoption in marketing teams by tomorrow.",
+      "expected_output": "Should apply the press-platforms response workflow for Qwoted/HARO/Featured-style requests. Should assess fit, deadline, credentials, and whether the user has a specific POV. Should produce or outline a response under 200 words with a concrete credential, quotable specific answer, short bio, and contact details. Should avoid generic advice and PR fluff. Should recommend logging the response and tracking outcome.",
+      "assertions": [
+        "Recognizes Qwoted as inbound press-request workflow",
+        "Assesses fit and deadline",
+        "Keeps response under 200 words",
+        "Includes concrete credential",
+        "Provides a quotable specific answer",
+        "Avoids generic PR fluff",
+        "Recommends logging and tracking the response"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "We need to submit our startup to Product Hunt, BetaList, and a bunch of AI directories. Is this PR?",
+      "expected_output": "Should recognize that startup/SaaS/AI directory submissions are not the public-relations skill's scope. Should defer to or cross-reference directory-submissions. Should explain that PR handles earned media with journalists, podcasts, newsletters, newsjacking, and press requests, while directory submissions are a different intent and workflow. Should not build a media pitching plan for this request.",
+      "assertions": [
+        "Recognizes directory submissions as out of PR scope",
+        "References or defers to directory-submissions",
+        "Explains the difference between earned media and directories",
+        "Does not create a journalist pitching plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Draft a press pitch for TechCrunch. Our product is revolutionary, game-changing, and disruptive. We just launched and want coverage.",
+      "expected_output": "Should improve the pitch quality rather than echoing banned vocabulary. Should avoid words like revolutionary, game-changing, disruptive, and synergy. Should ask or infer the real story hook: data, milestone, customer impact, trend, conflict, or founder POV. Should keep the pitch short, ideally under 150 words, with a subject line specific enough to predict the article. Should make clear that TechCrunch or any outlet requires a journalist-fit check, not a publication-level blast. Should include a clear ask such as interview, exclusive, quote, or embargo only when appropriate.",
+      "assertions": [
+        "Avoids banned PR vocabulary",
+        "Finds or asks for the real story hook",
+        "Keeps the pitch concise",
+        "Creates a specific subject line",
+        "Focuses on journalist fit rather than publication-level pitching",
+        "Includes a clear ask",
+        "Does not claim launch alone is newsworthy"
+      ],
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Added a new eval suite for the `offers` skill with 6 scenarios covering offer diagnostics, value-equation analysis, honest scarcity, guarantee design, bonus stacking, SaaS scope boundaries, and copywriting handoff.
- Added a new eval suite for the `public-relations` skill with 6 scenarios covering PR planning, newsjacking, journalist targeting, Qwoted/HARO-style responses, directory-submission scope boundaries, and pitch-quality guardrails.

## Why

The repo had 47 skills but only 45 eval suites. `offers` and `public-relations` were the two skills missing `evals/evals.json`, so this fills the coverage gap and makes eval coverage consistent across the skill library.

## Fix

This adds the missing eval files under each skill:

- `skills/offers/evals/evals.json`
- `skills/public-relations/evals/evals.json`

The new cases follow the existing repo eval format: `skill_name`, `evals`, `prompt`, `expected_output`, `assertions`, and `files`.

## Verification

- Loaded both JSON files with Node: each reports 6 evals.
- Ran `./validate-skills.sh`: all 47 skills passed.
- Confirmed coverage count: 47 skills and 47 `evals.json` files.
