### PR TITLE
fix: add marketing-plan version metadata

### DIFF
--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: marketing-plan
 description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and an embedded 17-section current-state audit rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For positioning and ICP context before planning, see product-marketing. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
+metadata:
+  version: 1.1.0
 ---
 
 # Marketing Plan


### PR DESCRIPTION
## What changed

- Added `metadata.version: 1.1.0` to the `marketing-plan` skill frontmatter.

## Why

`VERSIONS.md` already lists `marketing-plan` as version `1.1.0`, but the skill frontmatter did not include a matching `metadata.version` field. Per-skill versions are used for installed-skill update checks, so this metadata should be present and aligned with the versions table.

## Fix

This mirrors the existing `VERSIONS.md` value into:

- `skills/marketing-plan/SKILL.md`

No behavior or instruction content changed.

## Verification

- Ran `./validate-skills.sh`: all 47 skills passed.
