### PR TITLE
fix: show CLI usage without credentials

### DIFF
--- a/tools/clis/activecampaign.js
+++ b/tools/clis/activecampaign.js
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.ACTIVECAMPAIGN_API_KEY
 const API_URL = process.env.ACTIVECAMPAIGN_API_URL
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ACTIVECAMPAIGN_API_KEY environment variable required' }))
   process.exit(1)
 }
 
-if (!API_URL) {
+if ((!API_URL) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ACTIVECAMPAIGN_API_URL environment variable required (e.g. https://yourname.api-us1.com)' }))
   process.exit(1)
 }
 
-const BASE_URL = `${API_URL.replace(/\/$/, '')}/api/3`
+const BASE_URL = API_URL ? `${API_URL.replace(/\/$/, '')}/api/3` : ''
 
 async function api(method, path, body) {
   if (args['dry-run']) {
@@ -56,7 +57,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/adobe-analytics.js
+++ b/tools/clis/adobe-analytics.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const ACCESS_TOKEN = process.env.ADOBE_ACCESS_TOKEN
 const CLIENT_ID = process.env.ADOBE_CLIENT_ID
 const COMPANY_ID = process.env.ADOBE_COMPANY_ID
 
-if (!ACCESS_TOKEN || !CLIENT_ID || !COMPANY_ID) {
+if ((!ACCESS_TOKEN || !CLIENT_ID || !COMPANY_ID) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ADOBE_ACCESS_TOKEN, ADOBE_CLIENT_ID, and ADOBE_COMPANY_ID environment variables required' }))
   process.exit(1)
 }
@@ -53,7 +54,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/ahrefs.js
+++ b/tools/clis/ahrefs.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.AHREFS_API_KEY
 const BASE_URL = 'https://api.ahrefs.com/v3'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'AHREFS_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -47,7 +48,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/airops.js
+++ b/tools/clis/airops.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.AIROPS_API_KEY
 const WORKSPACE_ID = process.env.AIROPS_WORKSPACE_ID
 const BASE_URL = 'https://api.airops.com/public_api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'AIROPS_API_KEY environment variable required' }))
   process.exit(1)
 }
 
-if (!WORKSPACE_ID) {
+if ((!WORKSPACE_ID) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'AIROPS_WORKSPACE_ID environment variable required' }))
   process.exit(1)
 }
@@ -56,7 +57,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/amplitude.js
+++ b/tools/clis/amplitude.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.AMPLITUDE_API_KEY
 const SECRET_KEY = process.env.AMPLITUDE_SECRET_KEY
 const INGESTION_URL = 'https://api2.amplitude.com'
 const QUERY_URL = 'https://amplitude.com/api/2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'AMPLITUDE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -73,7 +74,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/apollo.js
+++ b/tools/clis/apollo.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.APOLLO_API_KEY
 const BASE_URL = 'https://api.apollo.io/api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'APOLLO_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/beehiiv.js
+++ b/tools/clis/beehiiv.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.BEEHIIV_API_KEY
 const BASE_URL = 'https://api.beehiiv.com/v2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'BEEHIIV_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/brevo.js
+++ b/tools/clis/brevo.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.BREVO_API_KEY
 const BASE_URL = 'https://api.brevo.com/v3'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'BREVO_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/buffer.js
+++ b/tools/clis/buffer.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.BUFFER_API_KEY
 const BASE_URL = 'https://api.bufferapp.com/1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'BUFFER_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -73,7 +74,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/calendly.js
+++ b/tools/clis/calendly.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.CALENDLY_API_KEY
 const BASE_URL = 'https://api.calendly.com'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CALENDLY_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/clay.js
+++ b/tools/clis/clay.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.CLAY_API_KEY
 const BASE_URL = 'https://api.clay.com/v3'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CLAY_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/clearbit.js
+++ b/tools/clis/clearbit.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.CLEARBIT_API_KEY
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CLEARBIT_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/close.js
+++ b/tools/clis/close.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.CLOSE_API_KEY
 const BASE_URL = 'https://api.close.com/api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CLOSE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/coupler.js
+++ b/tools/clis/coupler.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.COUPLER_API_KEY
 const BASE_URL = 'https://api.coupler.io/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'COUPLER_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/crossbeam.js
+++ b/tools/clis/crossbeam.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.CROSSBEAM_API_KEY
 const BASE_URL = 'https://api.crossbeam.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CROSSBEAM_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/customer-io.js
+++ b/tools/clis/customer-io.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const APP_KEY = process.env.CUSTOMERIO_APP_KEY
 const SITE_ID = process.env.CUSTOMERIO_SITE_ID
 const API_KEY = process.env.CUSTOMERIO_API_KEY
@@ -10,7 +11,7 @@ const APP_URL = 'https://api.customer.io/v1'
 const hasTrackAuth = SITE_ID && API_KEY
 const hasAppAuth = APP_KEY
 
-if (!hasTrackAuth && !hasAppAuth) {
+if ((!hasTrackAuth && !hasAppAuth) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'CUSTOMERIO_APP_KEY (for App API) or CUSTOMERIO_SITE_ID + CUSTOMERIO_API_KEY (for Track API) environment variables required' }))
   process.exit(1)
 }
@@ -83,7 +84,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/dataforseo.js
+++ b/tools/clis/dataforseo.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const LOGIN = process.env.DATAFORSEO_LOGIN
 const PASSWORD = process.env.DATAFORSEO_PASSWORD
 const BASE_URL = 'https://api.dataforseo.com/v3'
 
-if (!LOGIN || !PASSWORD) {
+if ((!LOGIN || !PASSWORD) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD environment variables required' }))
   process.exit(1)
 }
@@ -51,7 +52,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/demio.js
+++ b/tools/clis/demio.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.DEMIO_API_KEY
 const API_SECRET = process.env.DEMIO_API_SECRET
 const BASE_URL = 'https://my.demio.com/api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'DEMIO_API_KEY environment variable required' }))
   process.exit(1)
 }
 
-if (!API_SECRET) {
+if ((!API_SECRET) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'DEMIO_API_SECRET environment variable required' }))
   process.exit(1)
 }
@@ -56,7 +57,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/dub.js
+++ b/tools/clis/dub.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.DUB_API_KEY
 const BASE_URL = 'https://api.dub.co'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'DUB_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/exa.js
+++ b/tools/clis/exa.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.EXA_API_KEY
 const BASE_URL = 'https://api.exa.ai'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'EXA_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -69,7 +70,7 @@ function buildContents(args) {
   return Object.keys(contents).length ? contents : null
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, ...rest] = args._
 
 async function main() {

--- a/tools/clis/g2.js
+++ b/tools/clis/g2.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_TOKEN = process.env.G2_API_TOKEN
 const BASE_URL = 'https://data.g2.com/api/v1'
 
-if (!API_TOKEN) {
+if ((!API_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'G2_API_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/ga4.js
+++ b/tools/clis/ga4.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const ACCESS_TOKEN = process.env.GA4_ACCESS_TOKEN
 const DATA_API = 'https://analyticsdata.googleapis.com/v1beta'
 const ADMIN_API = 'https://analyticsadmin.googleapis.com/v1beta'
 const MP_URL = 'https://www.google-analytics.com/mp/collect'
 
-if (!ACCESS_TOKEN) {
+if ((!ACCESS_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'GA4_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -69,7 +70,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/google-ads.js
+++ b/tools/clis/google-ads.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const TOKEN = process.env.GOOGLE_ADS_TOKEN
 const DEV_TOKEN = process.env.GOOGLE_ADS_DEVELOPER_TOKEN
 const CUSTOMER_ID = process.env.GOOGLE_ADS_CUSTOMER_ID
 const BASE_URL = 'https://googleads.googleapis.com/v14'
 
-if (!TOKEN || !DEV_TOKEN || !CUSTOMER_ID) {
+if ((!TOKEN || !DEV_TOKEN || !CUSTOMER_ID) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'GOOGLE_ADS_TOKEN, GOOGLE_ADS_DEVELOPER_TOKEN, and GOOGLE_ADS_CUSTOMER_ID environment variables required' }))
   process.exit(1)
 }
@@ -55,7 +56,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function daysToDateRange(days) {

--- a/tools/clis/google-search-console.js
+++ b/tools/clis/google-search-console.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const ACCESS_TOKEN = process.env.GSC_ACCESS_TOKEN
 const BASE_URL = 'https://searchconsole.googleapis.com'
 
-if (!ACCESS_TOKEN) {
+if ((!ACCESS_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'GSC_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function getDefaultDates() {

--- a/tools/clis/hotjar.js
+++ b/tools/clis/hotjar.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const CLIENT_ID = process.env.HOTJAR_CLIENT_ID
 const CLIENT_SECRET = process.env.HOTJAR_CLIENT_SECRET
 const OAUTH_URL = 'https://api.hotjar.io'
 const BASE_URL = 'https://api.hotjar.io/v2'
 
-if (!CLIENT_ID || !CLIENT_SECRET) {
+if ((!CLIENT_ID || !CLIENT_SECRET) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'HOTJAR_CLIENT_ID and HOTJAR_CLIENT_SECRET environment variables required' }))
   process.exit(1)
 }
@@ -68,7 +69,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/hunter.js
+++ b/tools/clis/hunter.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.HUNTER_API_KEY
 const BASE_URL = 'https://api.hunter.io/v2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'HUNTER_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/instantly.js
+++ b/tools/clis/instantly.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.INSTANTLY_API_KEY
 const BASE_URL = 'https://api.instantly.ai/api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'INSTANTLY_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -53,7 +54,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/intercom.js
+++ b/tools/clis/intercom.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.INTERCOM_API_KEY
 const BASE_URL = 'https://api.intercom.io'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'INTERCOM_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/keywords-everywhere.js
+++ b/tools/clis/keywords-everywhere.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.KEYWORDS_EVERYWHERE_API_KEY
 const BASE_URL = 'https://api.keywordseverywhere.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'KEYWORDS_EVERYWHERE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/kit.js
+++ b/tools/clis/kit.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_SECRET = process.env.KIT_API_SECRET
 const API_KEY = process.env.KIT_API_KEY
 const BASE_URL = 'https://api.convertkit.com/v3'
 
-if (!API_SECRET && !API_KEY) {
+if ((!API_SECRET && !API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'KIT_API_SECRET or KIT_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -76,7 +77,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/klaviyo.js
+++ b/tools/clis/klaviyo.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.KLAVIYO_API_KEY
 const BASE_URL = 'https://a.klaviyo.com/api'
 const REVISION = '2024-10-15'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'KLAVIYO_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -52,7 +53,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/lemlist.js
+++ b/tools/clis/lemlist.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.LEMLIST_API_KEY
 const BASE_URL = 'https://api.lemlist.com/api'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'LEMLIST_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -51,7 +52,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/linkedin-ads.js
+++ b/tools/clis/linkedin-ads.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const TOKEN = process.env.LINKEDIN_ACCESS_TOKEN
 const BASE_URL = 'https://api.linkedin.com/v2'
 
-if (!TOKEN) {
+if ((!TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'LINKEDIN_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/livestorm.js
+++ b/tools/clis/livestorm.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_TOKEN = process.env.LIVESTORM_API_TOKEN
 const BASE_URL = 'https://api.livestorm.co/v1'
 
-if (!API_TOKEN) {
+if ((!API_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'LIVESTORM_API_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/mailchimp.js
+++ b/tools/clis/mailchimp.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.MAILCHIMP_API_KEY
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'MAILCHIMP_API_KEY environment variable required' }))
   process.exit(1)
 }
 
-const dc = API_KEY.split('-').pop()
+const dc = API_KEY ? API_KEY.split('-').pop() : ''
 const BASE_URL = `https://${dc}.api.mailchimp.com/3.0`
 
 async function api(method, path, body) {
@@ -52,7 +53,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/mention-me.js
+++ b/tools/clis/mention-me.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.MENTIONME_API_KEY
 const BASE_URL = 'https://api.mention-me.com/api/v2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'MENTIONME_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/meta-ads.js
+++ b/tools/clis/meta-ads.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const TOKEN = process.env.META_ACCESS_TOKEN
 const DEFAULT_ACCOUNT_ID = process.env.META_AD_ACCOUNT_ID
 const BASE_URL = 'https://graph.facebook.com/v18.0'
 
-if (!TOKEN) {
+if ((!TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'META_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -51,7 +52,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function getAccountId() {

--- a/tools/clis/mixpanel.js
+++ b/tools/clis/mixpanel.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const TOKEN = process.env.MIXPANEL_TOKEN
 const API_KEY = process.env.MIXPANEL_API_KEY
 const SECRET = process.env.MIXPANEL_SECRET
@@ -7,7 +8,7 @@ const INGESTION_URL = 'https://api.mixpanel.com'
 const QUERY_URL = 'https://mixpanel.com/api/2.0'
 const EXPORT_URL = 'https://data.mixpanel.com/api/2.0'
 
-if (!TOKEN && !API_KEY) {
+if ((!TOKEN && !API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'MIXPANEL_TOKEN (for ingestion) or MIXPANEL_API_KEY + MIXPANEL_SECRET (for query/export) environment variables required' }))
   process.exit(1)
 }
@@ -105,7 +106,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/onesignal.js
+++ b/tools/clis/onesignal.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const REST_API_KEY = process.env.ONESIGNAL_REST_API_KEY
 const APP_ID = process.env.ONESIGNAL_APP_ID
 const BASE_URL = 'https://api.onesignal.com'
 
-if (!REST_API_KEY) {
+if ((!REST_API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ONESIGNAL_REST_API_KEY environment variable required' }))
   process.exit(1)
 }
 
-if (!APP_ID) {
+if ((!APP_ID) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ONESIGNAL_APP_ID environment variable required' }))
   process.exit(1)
 }
@@ -56,7 +57,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/optimizely.js
+++ b/tools/clis/optimizely.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.OPTIMIZELY_API_KEY
 const BASE_URL = 'https://api.optimizely.com/v2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'OPTIMIZELY_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/outreach.js
+++ b/tools/clis/outreach.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const ACCESS_TOKEN = process.env.OUTREACH_ACCESS_TOKEN
 const BASE_URL = 'https://api.outreach.io/api/v2'
 
-if (!ACCESS_TOKEN) {
+if ((!ACCESS_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'OUTREACH_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/paddle.js
+++ b/tools/clis/paddle.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.PADDLE_API_KEY
 const BASE_URL = process.env.PADDLE_SANDBOX === 'true'
   ? 'https://sandbox-api.paddle.com'
   : 'https://api.paddle.com'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'PADDLE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -51,7 +52,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function buildQuery() {

--- a/tools/clis/partnerstack.js
+++ b/tools/clis/partnerstack.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const PUBLIC_KEY = process.env.PARTNERSTACK_PUBLIC_KEY
 const SECRET_KEY = process.env.PARTNERSTACK_SECRET_KEY
 const BASE_URL = 'https://api.partnerstack.com/api/v2'
 
-if (!PUBLIC_KEY || !SECRET_KEY) {
+if ((!PUBLIC_KEY || !SECRET_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'PARTNERSTACK_PUBLIC_KEY and PARTNERSTACK_SECRET_KEY environment variables required' }))
   process.exit(1)
 }
@@ -52,7 +53,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 const limit = args.limit ? Number(args.limit) : 10
 

--- a/tools/clis/pendo.js
+++ b/tools/clis/pendo.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.PENDO_INTEGRATION_KEY
 const BASE_URL = 'https://app.pendo.io/api/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'PENDO_INTEGRATION_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/plausible.js
+++ b/tools/clis/plausible.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.PLAUSIBLE_API_KEY
 const BASE_URL = process.env.PLAUSIBLE_BASE_URL || 'https://plausible.io'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'PLAUSIBLE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/postmark.js
+++ b/tools/clis/postmark.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.POSTMARK_API_KEY
 const BASE_URL = 'https://api.postmarkapp.com'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'POSTMARK_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -60,7 +61,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/rankparse.js
+++ b/tools/clis/rankparse.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.RANKPARSE_API_KEY
 const BASE_URL = 'https://api.rankparse.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'RANKPARSE_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function requireDomain() {

--- a/tools/clis/resend.js
+++ b/tools/clis/resend.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.RESEND_API_KEY
 const BASE_URL = 'https://api.resend.com'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'RESEND_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/rewardful.js
+++ b/tools/clis/rewardful.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.REWARDFUL_API_KEY
 const BASE_URL = 'https://api.getrewardful.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'REWARDFUL_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/savvycal.js
+++ b/tools/clis/savvycal.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.SAVVYCAL_API_KEY
 const BASE_URL = 'https://api.savvycal.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SAVVYCAL_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/segment.js
+++ b/tools/clis/segment.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const WRITE_KEY = process.env.SEGMENT_WRITE_KEY
 const ACCESS_TOKEN = process.env.SEGMENT_ACCESS_TOKEN
 const TRACKING_URL = 'https://api.segment.io/v1'
 const PROFILE_URL = 'https://profiles.segment.com/v1'
 
-if (!WRITE_KEY && !ACCESS_TOKEN) {
+if ((!WRITE_KEY && !ACCESS_TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SEGMENT_WRITE_KEY (for tracking) or SEGMENT_ACCESS_TOKEN (for profiles) environment variable required' }))
   process.exit(1)
 }
@@ -77,7 +78,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/semrush.js
+++ b/tools/clis/semrush.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.SEMRUSH_API_KEY
 const BASE_URL = 'https://api.semrush.com/'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SEMRUSH_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -64,7 +65,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/sendgrid.js
+++ b/tools/clis/sendgrid.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.SENDGRID_API_KEY
 const BASE_URL = 'https://api.sendgrid.com/v3'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SENDGRID_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/similarweb.js
+++ b/tools/clis/similarweb.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.SIMILARWEB_API_KEY
 const BASE_URL = 'https://api.similarweb.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SIMILARWEB_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/snov.js
+++ b/tools/clis/snov.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const CLIENT_ID = process.env.SNOV_CLIENT_ID
 const CLIENT_SECRET = process.env.SNOV_CLIENT_SECRET
 const BASE_URL = 'https://api.snov.io/v1'
 
-if (!CLIENT_ID || !CLIENT_SECRET) {
+if ((!CLIENT_ID || !CLIENT_SECRET) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SNOV_CLIENT_ID and SNOV_CLIENT_SECRET environment variables required' }))
   process.exit(1)
 }
@@ -69,7 +70,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/supermetrics.js
+++ b/tools/clis/supermetrics.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.SUPERMETRICS_API_KEY
 const BASE_URL = 'https://api.supermetrics.com/enterprise/v2'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'SUPERMETRICS_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -51,7 +52,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/tiktok-ads.js
+++ b/tools/clis/tiktok-ads.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const TOKEN = process.env.TIKTOK_ACCESS_TOKEN
 const ADVERTISER_ID = process.env.TIKTOK_ADVERTISER_ID
 const BASE_URL = 'https://business-api.tiktok.com/open_api/v1.3'
 
-if (!TOKEN) {
+if ((!TOKEN) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'TIKTOK_ACCESS_TOKEN environment variable required' }))
   process.exit(1)
 }
@@ -52,7 +53,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 function getAdvertiserId() {

--- a/tools/clis/tolt.js
+++ b/tools/clis/tolt.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.TOLT_API_KEY
 const BASE_URL = 'https://api.tolt.io/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'TOLT_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -48,7 +49,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/trustpilot.js
+++ b/tools/clis/trustpilot.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.TRUSTPILOT_API_KEY
 const API_SECRET = process.env.TRUSTPILOT_API_SECRET
 const BUSINESS_UNIT_ID = process.env.TRUSTPILOT_BUSINESS_UNIT_ID
 const BASE_URL = 'https://api.trustpilot.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'TRUSTPILOT_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -87,7 +88,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/typeform.js
+++ b/tools/clis/typeform.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.TYPEFORM_API_KEY
 const BASE_URL = 'https://api.typeform.com'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'TYPEFORM_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -49,7 +50,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/wistia.js
+++ b/tools/clis/wistia.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.WISTIA_API_KEY
 const BASE_URL = 'https://api.wistia.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'WISTIA_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -50,7 +51,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 const page = args.page ? Number(args.page) : 1
 const perPage = args['per-page'] ? Number(args['per-page']) : 25

--- a/tools/clis/zapier.js
+++ b/tools/clis/zapier.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const API_KEY = process.env.ZAPIER_API_KEY
 const BASE_URL = 'https://api.zapier.com/v1'
 
-if (!API_KEY) {
+if ((!API_KEY) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ZAPIER_API_KEY environment variable required' }))
   process.exit(1)
 }
@@ -65,7 +66,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {

--- a/tools/clis/zoominfo.js
+++ b/tools/clis/zoominfo.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
+const rawArgs = process.argv.slice(2)
 const BASE_URL = 'https://api.zoominfo.com'
 
 let ACCESS_TOKEN = process.env.ZOOMINFO_ACCESS_TOKEN
 
-if (!ACCESS_TOKEN && !process.env.ZOOMINFO_USERNAME) {
+if ((!ACCESS_TOKEN && !process.env.ZOOMINFO_USERNAME) && rawArgs.length > 0) {
   console.error(JSON.stringify({ error: 'ZOOMINFO_ACCESS_TOKEN or ZOOMINFO_USERNAME + ZOOMINFO_PRIVATE_KEY environment variables required' }))
   process.exit(1)
 }
@@ -77,7 +78,7 @@ function parseArgs(args) {
   return result
 }
 
-const args = parseArgs(process.argv.slice(2))
+const args = parseArgs(rawArgs)
 const [cmd, sub, ...rest] = args._
 
 async function main() {


### PR DESCRIPTION
## What changed

- Updated the zero-dependency CLI scripts so running a CLI with no arguments reaches the built-in usage output instead of failing immediately on missing environment variables.
- Added a shared `rawArgs` capture in each credential-gated CLI and only enforce top-level credential checks when a command was actually provided.
- Adjusted `activecampaign` and `mailchimp` so derived module-level values do not read from missing env vars during no-arg usage output.

## Why

The repo docs say CLI tools should show usage when run without args, but most scripts checked credentials before command parsing. That meant commands like:

```bash
node tools/clis/ahrefs.js
```

returned an auth error instead of the usage block. This made the CLIs harder to discover and contradicted the documented behavior.

## Fix

No-arg invocations now bypass top-level auth guards and fall through to each CLI's existing default usage response. Real commands still fail fast if required credentials are missing.

## Verification

- Ran `node --check` across all `tools/clis/*.js`.
- Ran every CLI with no args and confirmed none exited non-zero.
- Spot-checked `activecampaign`, `ahrefs`, `airops`, `google-ads`, `mailchimp`, and `mixpanel` no-arg usage output.
- Spot-checked a real command without credentials still fails with the expected auth error.
