### PR TITLE
release: v2.8.9 — prospecting demand-signal discovery branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.8",
+    "version": "2.8.9",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -39,7 +39,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | pricing | 2.0.1 | 2026-06-16 |
 | product-marketing | 2.0.0 | 2026-05-05 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
-| prospecting | 1.0.0 | 2026-05-26 |
+| prospecting | 1.1.0 | 2026-07-13 |
 | public-relations | 1.0.0 | 2026-06-10 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
@@ -53,6 +53,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.0.1 | 2026-05-18 |
 
 ## Recent Changes
+
+### 2.8.9 (2026-07-13)
+
+- **prospecting** (1.0.0 → 1.1.0): added a **fourth branch — Demand-signal discovery (find your first customers)**, the early-stage motion that finds first customers / design partners / beta users from recent public pain-demand-timing signals rather than firmographic list-building (re-expressed from the open-source `first-customer-finder` Codex skill, Kappaemme/MIT, credited; extended with our live-recency tooling). New `references/demand-signals.md`: how the branch differs from list-building (starts from a described problem, sources public discourse, wins on 10 strong evidence-backed matches over coverage), a product brief gate, the five signal query buckets (explicit demand / pain / workaround / switching / timing) with our tooling edge called out (last30days for Reddit/HN/X/web recency, social-fetch to read original threads, scraping/Firecrawl/Browserbase over snippets, deep-research, competitor-profiling, customer-research), a public-only source mix, a **demand-fit scoring rubric** (pain 25% / product fit 25% / timing 20% / reachability 15% / evidence quality 15%, 0-100 with bands — distinct from the ICP-fit Hot/Warm/Cold), prospect stages (high intent / problem aware / trigger present / potential fit), a per-prospect evidence ledger, manual-only source-based openers (never auto-send), the evidence-report structure (verdict → ICP → top prospect → shortlist → repeated patterns → 7-day manual outreach plan → limits), and the honesty rules (a cited signal is the entry ticket; label 'potential customer based on public signals,' never 'will buy'). SKILL.md adds the branch to the Pick-the-Branch table + deep-dive pointers and 'find my first customers,' 'early adopters,' 'design partners,' 'beta users,' 'who has this problem' triggers. Also closes two **compliance-guardrail gaps** across all branches: no data brokers / leaked datasets, and never target or infer sensitive/protected traits (health, financial hardship, political belief, sexuality, religion). New eval (id 7) covers branch selection, signal mining, demand-fit scoring, and the never-auto-send rule. Closes #447.
 
 ### 2.8.8 (2026-07-12)
 

--- a/skills/prospecting/SKILL.md
+++ b/skills/prospecting/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: prospecting
-description: When the user wants to find, qualify, and build a list of prospects to reach out to — across B2B SaaS, general B2B, or local small businesses. Also use when the user mentions "prospecting," "build a prospect list," "find prospects," "find leads," "lead gen list," "find SaaS companies that," "find B2B companies," "find local businesses," "ICP-fit accounts," "who should we go after," "outbound list," "target account list," "find clients near me," "businesses without websites," "prospect research," or "qualified leads." Use this for the list-building and qualification phase. For writing the outbound copy after the list is built, see cold-email. For deep competitive research on specific accounts, see competitor-profiling.
+description: When the user wants to find, qualify, and build a list of prospects to reach out to — across B2B SaaS, general B2B, or local small businesses. Also use when the user mentions "prospecting," "build a prospect list," "find prospects," "find leads," "lead gen list," "find SaaS companies that," "find B2B companies," "find local businesses," "ICP-fit accounts," "who should we go after," "outbound list," "target account list," "find clients near me," "businesses without websites," "prospect research," "qualified leads," "find my first customers," "early adopters," "design partners," "beta users," or "who has this problem." Use this for the list-building and qualification phase. For writing the outbound copy after the list is built, see cold-email. For deep competitive research on specific accounts, see competitor-profiling.
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Prospecting
 
-You are an expert at building qualified prospect lists across three motions: B2B SaaS, general B2B, and local small businesses. Your goal is to turn an ICP definition into a verified, scored, ready-to-outreach lead sheet — using the right data sources, qualification signals, and compliance posture for each motion.
+You are an expert at building qualified prospect lists across four motions: B2B SaaS, general B2B, local small businesses, and early-stage demand-signal discovery (finding your first customers from public pain signals). Your goal is to turn an ICP definition into a verified, scored, ready-to-outreach lead sheet — using the right data sources, qualification signals, and compliance posture for each motion.
 
 ## Before Starting
 
@@ -23,13 +23,15 @@ Prospecting motions differ enough that the workflow forks at intake. Pick **one*
 | **SaaS** | Other SaaS companies / digital businesses | ICP fit + tech stack match + growth signals (funding, hiring, product velocity) | LinkedIn, BuiltWith, Crunchbase, Apollo, Clay, Clearbit, ProductHunt |
 | **B2B** | Non-SaaS B2B (services, manufacturers, enterprises, mid-market) | Industry + size + geographic fit + buying signals (trigger events, vendor changes) | Apollo, ZoomInfo, Clay, Clearbit, LinkedIn Sales Nav, industry directories |
 | **Local SMB** | Local small businesses (shops, gyms, restaurants, clinics, salons, services) | Active business + website status + proximity + decision-maker access | Google Maps, Yelp, local directories, Facebook, business websites |
+| **Demand-signal** | Early-stage: your first customers, design partners, or beta users | Evidence of the exact pain/demand/timing signal — a cited public source, not just firmographic fit | Forums, communities, reviews, GitHub issues, job posts, launch announcements (via last30days, social-fetch, scraping) |
 
-If the user describes a hybrid motion (e.g., "SMBs that are also SaaS"), pick the dominant branch and pull in qualification signals from the other.
+If the user describes a hybrid motion (e.g., "SMBs that are also SaaS"), pick the dominant branch and pull in qualification signals from the other. If the user is early-stage and needs their *first* customers or design partners — evidence of demand over list coverage — use the **Demand-signal** branch.
 
 For the branch-specific deep dives:
 - **SaaS** → see [references/saas-prospecting.md](references/saas-prospecting.md)
 - **B2B** → see [references/b2b-prospecting.md](references/b2b-prospecting.md)
 - **Local SMB** → see [references/local-prospecting.md](references/local-prospecting.md)
+- **Demand-signal** (find your first customers) → see [references/demand-signals.md](references/demand-signals.md)
 
 ---
 
@@ -71,7 +73,7 @@ For email contacts (B2B / SaaS branches), **always verify deliverability before 
 
 ### Phase 4 — Score and prioritize
 
-Apply this rubric across all branches:
+Apply this rubric for the **SaaS, B2B, and Local SMB** branches. The **Demand-signal** branch scores differently — 0–100 demand-fit, not Hot/Warm/Cold — see [references/demand-signals.md](references/demand-signals.md).
 
 | Score | Definition |
 |-------|------------|
@@ -83,6 +85,8 @@ Apply this rubric across all branches:
 Branch-specific signals refine the scoring — see each reference file. Default ratio target: ~20% Hot, ~30% Warm, rest Cold/Skip.
 
 ### Phase 5 — Output the lead sheet
+
+(SaaS / B2B / Local SMB. The **Demand-signal** branch ships an evidence report instead — see [references/demand-signals.md](references/demand-signals.md).)
 
 Default to a markdown table in chat. Switch to CSV when the list is >25 rows or the user explicitly asks for a file.
 
@@ -103,6 +107,8 @@ These apply to every branch. **Read first, every engagement.**
 4. **GDPR / CAN-SPAM / CASL aware.** Capture and retain the source URL and date for every contact you add to a list — required for downstream outreach compliance.
 5. **No reselling extracted data** from Google Maps, LinkedIn, or any platform whose terms prohibit it. List building for the user's own outreach is fine; productizing the list to sell is not.
 6. **Rate limit yourself.** Even on public sources, space requests. Don't fingerprint as a bot.
+7. **No breached, leaked, or unprovenanced data.** Don't source prospects from breached datasets, scraped-contact marketplaces, or list brokers with no source lineage. Licensed B2B data providers (Apollo, ZoomInfo, Clearbit, Clay) are fine when used within their ToS and with a lawful basis — the ban is on illicit/unprovenanced data, not on legitimate enrichment vendors.
+8. **Never target or infer sensitive traits.** Don't qualify, segment, or personalize on health, financial hardship, political belief, sexuality, religion, or other protected/sensitive attributes — even when a public post reveals them.
 
 For the full compliance reference (GDPR, CAN-SPAM, CASL, LinkedIn ToS, Google Maps ToS, Clay/Apollo/ZoomInfo use restrictions): see [references/compliance.md](references/compliance.md).
 
@@ -112,7 +118,7 @@ For the full compliance reference (GDPR, CAN-SPAM, CASL, LinkedIn ToS, Google Ma
 
 If missing, ask once, then infer reasonable defaults and continue:
 
-- **Branch** (SaaS / B2B / Local SMB) — usually inferable from context
+- **Branch** (SaaS / B2B / Local SMB / Demand-signal) — usually inferable from context; pick Demand-signal for early-stage first-customer discovery
 - **ICP description** — pull from `product-marketing.md` if present
 - **Target count** — default 25 for SaaS / B2B, 15 for Local SMB
 - **Geography** (essential for Local SMB; useful for B2B; less critical for SaaS)
@@ -214,7 +220,7 @@ score,business,category,area,distance_km,website_status,website_url,social_urls,
 
 ## Task-Specific Questions
 
-1. Which branch — SaaS, B2B, or Local SMB?
+1. Which branch — SaaS, B2B, Local SMB, or Demand-signal (early-stage, finding your first customers)?
 2. What's your ICP? (Or: should I pull from your product-marketing context?)
 3. How many qualified leads do you want?
 4. What tools do you have access to (Apollo / Clay / ZoomInfo / Hunter / Truelist / browser only)?

--- a/skills/prospecting/evals/evals.json
+++ b/skills/prospecting/evals/evals.json
@@ -102,6 +102,21 @@
         "References truelist.md or data-sources.md"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "I just built a tool that automates failed-payment follow-up for gym owners. I have no customers yet. Help me find my first ten — the people who are actually dealing with this problem right now.",
+      "expected_output": "Should select the Demand-signal branch (early-stage, first customers, evidence-of-demand) and load references/demand-signals.md — NOT the SMB/B2B list-building branches. Should start with a product brief, then mine the five signal buckets (explicit demand / pain / workaround / switching / timing) across public discourse (forums, communities, reviews, GitHub issues, job posts) — using last30days for recency, social-fetch/scraping to read original pages, not qualifying from snippets. Should score prospects on demand-fit (pain 25 / product fit 25 / timing 20 / reachability 15 / evidence quality 15, 0-100 with bands) rather than ICP-fit Hot/Warm/Cold, and require a cited public signal for every primary-shortlist prospect. Should draft source-based openers but never auto-send. Should produce an evidence report (verdict → ICP → top prospect → shortlist with sources+scores → repeated patterns → 7-day manual outreach plan → limits) and label prospects as 'potential customers based on public signals,' not confirmed buyers. Should honor the compliance guardrails including no data brokers/leaked data and no sensitive-trait targeting.",
+      "assertions": [
+        "Selects the Demand-signal branch, not the SMB/B2B/SaaS list-building branches",
+        "Mines the five signal buckets from public discourse rather than contact databases",
+        "Uses recency/original-source tooling (last30days, social-fetch, scraping) and does not qualify from snippets",
+        "Scores on the demand-fit rubric (0-100 weighted), not ICP-fit Hot/Warm/Cold",
+        "Requires a cited public signal for every primary-shortlist prospect",
+        "Drafts openers but never auto-sends; labels prospects as potential-based-on-public-signals",
+        "Produces the evidence report structure with a 7-day manual outreach plan and limits"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/prospecting/references/demand-signals.md
+++ b/skills/prospecting/references/demand-signals.md
@@ -1,0 +1,129 @@
+# Demand-Signal Discovery (Find Your First Customers)
+
+The other three branches build a list from who *fits* (firmographics, technographics, proximity). This branch builds a list from who is *already showing the pain* — the early-stage motion where you have a product and a hunch but no customer base yet, and you need your first ten real conversations. You are not filtering a database; you are mining recent public discourse for people describing the exact problem you solve, then linking every prospect to the evidence.
+
+Use this branch when the user is pre-product-market-fit, launching something new, or looking for **design partners, beta users, or first customers** rather than a scaled outbound list. It reuses the shared five phases and every compliance guardrail in SKILL.md; what changes is where you look, how you score, and what you ship.
+
+Pattern credit: the framework here is re-expressed from the open-source `first-customer-finder` Codex skill (Kappaemme, MIT), extended with our live-recency tooling.
+
+## What makes this branch different
+
+| | List-building branches (SaaS / B2B / SMB) | Demand-signal discovery |
+|---|---|---|
+| Starts from | A firmographic ICP | A described problem |
+| Sources | Contact databases (Apollo, ZoomInfo, Clay) | Public discourse (forums, reviews, issues, posts) |
+| Contact step | Enrich + verify email deliverability | None — reach them where they already posted |
+| Wins on | Coverage at scale | 10 strong evidence-backed matches over a long list |
+| Output | A scored lead sheet | An evidence report + manual outreach plan |
+
+A prospect here without a cited pain, need, or timing signal is a speculative fit — it does **not** belong in the primary shortlist. Evidence is the entry ticket.
+
+## Step 1 — Product brief (before any searching)
+
+Define, specifically enough to *reject* weak matches:
+
+- product and the promised outcome
+- primary user and the economic buyer (often different)
+- the urgent job to be done
+- the current alternative or workaround being replaced
+- the likely adoption trigger (what makes now the moment)
+- geography / language constraint
+- clear disqualifiers
+
+Don't start broad collection until the brief is sharp. Pull from `.agents/product-marketing.md` if it exists.
+
+## Step 2 — Mine the five signal buckets
+
+Search several angles, not one query repeated. Adapt wording to how the audience actually talks (mine their vocabulary from organic content first — see the ad-creative hook-system's organic-language note for the same idea).
+
+1. **Explicit demand** — "looking for," "recommend a tool for," "alternative to [X]," "does anything exist that," "how do you all handle."
+2. **Pain** — "takes hours," "so manual," "hate that," "keeps breaking," "biggest frustration with," "why is there no."
+3. **Workaround** — spreadsheets, copy-paste, a VA, a Zapier chain, a script, a template, any repeated manual step that your product would replace.
+4. **Switching** — cancellation, migration, "moving off [competitor]," a missing feature, a pricing complaint, competitor frustration.
+5. **Timing** — a public launch, a new hire for the relevant function, expansion, a new workflow or regulation, an integration announcement — a *current* event that makes the product relevant now.
+
+**Use our live-recency edge.** A generic skill relies on whatever a web search surfaces; you have better:
+- **last30days** — Reddit, Hacker News, X, YouTube, and web signals from the last 30 days. This is the single highest-value tool for this branch: recency *is* the timing signal.
+- **social-fetch** — pull the full content of a specific post/thread you find, normalized.
+- **scraping** / **Firecrawl** / **Browserbase** — read the original public page (a forum thread, a GitHub issue, a review), never qualify from a search snippet alone.
+- **deep-research** — for a multi-source sweep with adversarial verification when the wedge is broad.
+- **competitor-profiling** / **customer-research** — competitor switching signals and review-mining for the pain language.
+
+## Step 3 — Source mix (public only)
+
+Forums and public community threads · public social posts and replies · product and app-marketplace reviews · GitHub issues and feature requests · public company pages, job posts, changelogs, launch announcements · "looking for a tool" posts and directories.
+
+Avoid private groups, gated communities, data brokers, leaked datasets, and any source whose terms prohibit access — the same compliance guardrails as every other branch (see SKILL.md), including the no-sensitive-traits rule.
+
+**Business/professional context only.** Qualify and reach out only where someone is posting in a professional or business capacity about a work problem (a founder in an indie-hackers thread, a developer in a GitHub issue, an ops lead in a subreddit for their role). Exclude personal-distress contexts entirely — health, financial hardship, addiction, grief, or any consumer support forum where people are venting personal problems, even if your product is tangentially relevant. When the motion is genuinely consumer (B2C), a public pain post is not on its own a lawful basis for cold outreach — reach people through the channel's own norms (reply publicly where replying is expected) and never DM a stranger off a personal post.
+
+Quote minimally, paraphrase by default, and link every material pain or timing signal.
+
+## Step 4 — Score on demand-fit (not ICP-fit)
+
+The list-building branches score Hot/Warm/Cold on ICP fit. This branch scores 0–100 on **demand fit** — how strongly the evidence says this specific prospect wants this specific thing now. Score each dimension 0–5:
+
+| Dimension | Weight | What it measures |
+|---|---|---|
+| **Pain strength** | 25% | Directness, severity, repetition, and cost of the stated problem |
+| **Product fit** | 25% | How directly your product solves the evidenced job |
+| **Timing** | 20% | Freshness + a current trigger present |
+| **Public reachability** | 15% | A natural, relevant public/professional contact path exists |
+| **Evidence quality** | 15% | Specificity, source reliability, confidence the signal is really theirs |
+
+```
+score = pain/5*25 + fit/5*25 + timing/5*20 + reachability/5*15 + evidence/5*15
+```
+
+| Band | Meaning |
+|---|---|
+| **80–100** | Strong first-customer candidate |
+| **65–79** | Promising — validate fast |
+| **50–64** | Plausible but missing a material signal |
+| **Below 50** | Do not include in the primary shortlist |
+
+An old explicit request can still count — but lower the timing score and label the date. A company that merely matches the industry with no evidenced trigger is *not* a qualified prospect here.
+
+### Prospect stages
+
+- **High intent** — publicly requesting a solution or actively switching
+- **Problem aware** — clearly describing the pain or an expensive workaround
+- **Trigger present** — a current business event makes the product relevant
+- **Potential fit** — ICP match, incomplete evidence → keep *outside* the primary shortlist
+
+### Evidence ledger (per qualified prospect)
+
+Displayed name (company/project/public professional) · source title + URL · visible publication date or "date unavailable" · source type · the concise pain/timing signal · observed evidence vs. inference (label which) · score breakdown · freshness warning when the signal is stale.
+
+## Step 5 — Draft outreach, never send it
+
+Recommend the most natural channel *already associated with the source*, and only where a reply is a normal part of that channel (reply in the public thread, respond via a public professional profile). Don't turn a public post into a private DM the poster didn't invite, and never contact someone off a personal-distress post. Draft one opener, under ~90 words, in this shape:
+
+1. mention the public context naturally
+2. connect it to the exact problem
+3. explain the product in one sentence
+4. ask one low-friction question
+
+Never claim familiarity you don't have, never fabricate personal details, and never auto-send: no messages, connects, follows, comments, form submissions, or CRM records unless the user separately authorizes that action. This is the manual/gated posture from the marketing-loops guardrails.
+
+## Step 6 — Ship the evidence report
+
+Lead with the most actionable evidence, in this order:
+
+1. **Verdict** — does the product have reachable early-customer signal, or not yet? (An honest "not yet, here's why" is a valid answer.)
+2. **ICP** — buyer, job, trigger, disqualifiers.
+3. **Top prospect** — the single strongest evidence-backed candidate and why now.
+4. **Prospect shortlist** — per prospect: source, pain signal, demand-fit score, stage, why-now, channel, opener.
+5. **Repeated patterns** — pains and triggers recurring across prospects (these are your positioning and messaging gold).
+6. **Seven-day manual outreach plan** — a low-volume validation sequence (e.g., contact the top 3 with one source-based question; share a mockup only after they confirm the pain; target three conversations and one design-partner commitment).
+7. **Limits** — what evidence is missing and what must be confirmed through real conversations.
+
+For a shareable standalone HTML version of this report, the JSON→HTML generator pattern in ad-creative's [creative-review-page.md](../../ad-creative/references/creative-review-page.md) is the model (escape every value; keep it self-contained).
+
+## The honesty rules (non-negotiable)
+
+- Every primary prospect links to at least one real public signal. No signal, no shortlist.
+- Label the output **"potential customer based on public signals"** — never "interested," "will buy," or "has consented."
+- Prefer ten strong matches over a long generic list. Make uncertainty and stale evidence visible.
+- Personalize from the cited source, not from invented assumptions.
+- Treat the shortlist as a research hypothesis to validate through conversations, not a customer database.


### PR DESCRIPTION
## Release v2.8.9

One z-release since v2.8.8:

- **2.8.9 — prospecting 1.1.0** (#448): new **Demand-signal discovery branch** — the early-stage "find your first customers / design partners / beta users from public pain-demand-timing signals" motion (five signal buckets, a 0-100 demand-fit scoring rubric, evidence ledger, manual-only source-based openers, an evidence report), leveraging last30days / social-fetch / scraping. Also closes two compliance-guardrail gaps across all branches: no breached/leaked/unprovenanced data (licensed vendors still valid), and no sensitive/protected-trait targeting. Learned from and credited to the MIT `first-customer-finder` Codex skill. Codex-reviewed (three over-generalization contradictions caught and fixed).

plugin.json / marketplace.json at 2.8.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
