### PR TITLE
fix: validate-skills.sh false-negatives (consecutive hyphens + top-level version) + correct CLI tool count

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,29 @@
+name: Regression Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "validate-skills.sh"
+      - "tests/**"
+      - ".github/workflows/regression-tests.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "validate-skills.sh"
+      - "tests/**"
+      - ".github/workflows/regression-tests.yml"
+
+concurrency:
+  group: regression-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-skills-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run validate-skills.sh regression tests
+        run: bash tests/run-regression.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ marketingskills/
 │   └── skill-name/
 │       └── SKILL.md       # Required skill file
 ├── tools/
-│   ├── clis/              # Zero-dependency Node.js CLI tools (51 tools)
+│   ├── clis/              # Zero-dependency Node.js CLI tools (64 tools)
 │   ├── composio/          # Composio integration layer (quick start + toolkit mapping)
 │   ├── integrations/      # API integration guides per tool
 │   └── REGISTRY.md        # Tool index with capabilities

--- a/tests/fixtures/invalid/page--cro/SKILL.md.fixture
+++ b/tests/fixtures/invalid/page--cro/SKILL.md.fixture
@@ -1,0 +1,11 @@
+---
+name: page--cro
+description: Regression fixture — use this when verifying that validate-skills.sh rejects a name with consecutive hyphens. See PR #451 / issue #450.
+---
+
+# page--cro (regression fixture)
+
+Intentionally invalid: the `name` contains consecutive hyphens (`--`), which is
+not allowed. `validate-skills.sh` must reject this. Not a real skill — the file is
+named SKILL.md.fixture so it is not picked up by the validator or CI directly; the
+regression runner copies it into a temp SKILL.md before validating.

--- a/tests/fixtures/invalid/page--cro/expected-error.txt
+++ b/tests/fixtures/invalid/page--cro/expected-error.txt
@@ -1,0 +1,1 @@
+consecutive hyphens ('--' not allowed)

--- a/tests/fixtures/invalid/versiontest/SKILL.md.fixture
+++ b/tests/fixtures/invalid/versiontest/SKILL.md.fixture
@@ -1,0 +1,12 @@
+---
+name: versiontest
+description: Regression fixture — use this when verifying that validate-skills.sh rejects a top-level version field with no metadata block. See PR #451 / issue #450.
+version: 1.0.0
+---
+
+# versiontest (regression fixture)
+
+Intentionally invalid: `version:` is declared at the top level with no `metadata:`
+block. `validate-skills.sh` must reject this. Not a real skill — the file is named
+SKILL.md.fixture so it is not picked up by the validator or CI directly; the
+regression runner copies it into a temp SKILL.md before validating.

--- a/tests/fixtures/invalid/versiontest/expected-error.txt
+++ b/tests/fixtures/invalid/versiontest/expected-error.txt
@@ -1,0 +1,1 @@
+'version' is top-level (should be under 'metadata:')

--- a/tests/run-regression.sh
+++ b/tests/run-regression.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Regression tests for validate-skills.sh false-negatives (issue #450 / PR #451).
+#
+# Guards two bugs where spec-violating skills used to PASS the validator:
+#   1. a `name` with consecutive hyphens (e.g. page--cro)
+#   2. a top-level `version:` with no `metadata:` block
+#
+# Each fixture lives in its own directory under tests/fixtures/invalid/:
+#   <name>/SKILL.md.fixture   the intentionally-invalid skill (named .fixture so
+#                             it is not treated as a real skill by the validator
+#                             or the SKILL.md-triggered CI workflow)
+#   <name>/expected-error.txt the error substring validate-skills.sh must emit
+#
+# For each fixture the runner builds a temp skills dir containing only that skill
+# and points validate-skills.sh at it via the SKILLS_DIR override, then asserts a
+# non-zero exit with the expected error.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$ROOT/tests/fixtures/invalid"
+fail=0
+ran=0
+
+echo "Running validate-skills.sh regression tests..."
+echo ""
+
+for fixture_dir in "$FIXTURES"/*/; do
+    name="$(basename "$fixture_dir")"
+    src="$fixture_dir/SKILL.md.fixture"
+    expected_file="$fixture_dir/expected-error.txt"
+
+    if [[ ! -f "$src" || ! -f "$expected_file" ]]; then
+        echo "FAIL: '$name' — fixture is missing SKILL.md.fixture or expected-error.txt"
+        fail=1
+        continue
+    fi
+    expected="$(cat "$expected_file")"
+
+    tmp="$(mktemp -d)"
+    mkdir "$tmp/$name"
+    cp "$src" "$tmp/$name/SKILL.md"
+
+    out="$(cd "$ROOT" && SKILLS_DIR="$tmp" bash validate-skills.sh 2>&1)"
+    code=$?
+    rm -rf "$tmp"
+    ((ran++))
+
+    if [[ $code -eq 0 ]]; then
+        echo "FAIL: '$name' — validator exited 0, expected non-zero"
+        fail=1
+        continue
+    fi
+    if ! grep -qF "$expected" <<<"$out"; then
+        echo "FAIL: '$name' — missing expected error: $expected"
+        echo "----- validator output -----"
+        echo "$out"
+        echo "----------------------------"
+        fail=1
+        continue
+    fi
+    echo "PASS: '$name' rejected (exit $code): $expected"
+done
+
+echo ""
+if [[ $ran -eq 0 ]]; then
+    echo "No fixtures found under $FIXTURES — nothing to test."
+    exit 1
+fi
+if [[ $fail -eq 0 ]]; then
+    echo "All $ran regression test(s) passed."
+else
+    echo "Regression tests FAILED."
+fi
+exit $fail

--- a/validate-skills.sh
+++ b/validate-skills.sh
@@ -7,7 +7,8 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-SKILLS_DIR="skills"
+# Directory to audit; overridable so regression tests can point at fixtures.
+SKILLS_DIR="${SKILLS_DIR:-skills}"
 ISSUES=0
 WARNINGS=0
 PASSED=0

--- a/validate-skills.sh
+++ b/validate-skills.sh
@@ -60,6 +60,8 @@ for skill_dir in "$SKILLS_DIR"/*/; do
         skill_errors+=("Name mismatch: directory='$skill_name' but frontmatter='$name_in_file'")
     elif ! [[ "$name_in_file" =~ ^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$ ]]; then
         skill_errors+=("Invalid name format: '$name_in_file' (must be lowercase, alphanumeric + hyphens only)")
+    elif [[ "$name_in_file" == *--* ]]; then
+        skill_errors+=("Invalid name: '$name_in_file' has consecutive hyphens ('--' not allowed)")
     elif [[ ${#name_in_file} -lt 1 || ${#name_in_file} -gt 64 ]]; then
         skill_errors+=("Name length invalid: ${#name_in_file} chars (must be 1-64)")
     fi
@@ -100,14 +102,18 @@ for skill_dir in "$SKILLS_DIR"/*/; do
         skill_warnings+=("License '$license' is non-standard (default: MIT)")
     fi
 
+    # Check version placement — 'version' must live under 'metadata:', never at
+    # the top level. Checked unconditionally: the mistake this catches is a
+    # top-level version with no 'metadata:' block at all.
+    if echo "$frontmatter" | grep -q "^version:"; then
+        skill_errors+=("'version' is top-level (should be under 'metadata:')")
+    fi
+
     # Check metadata structure
     metadata=$(echo "$frontmatter" | grep -A 10 "^metadata:")
     if [[ -n "$metadata" ]]; then
-        # If metadata exists, check for version placement
-        if echo "$frontmatter" | grep -q "^version:"; then
-            skill_errors+=("'version' is top-level (should be under 'metadata:')")
-        fi
         # Could add more metadata validation here
+        :
     fi
 
     # ===== FILE STRUCTURE VALIDATION =====


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in `validate-skills.sh` (both let spec-violating skills **pass**) and one stale count in `AGENTS.md`.

Fixes #450

## Changes

**1. `validate-skills.sh` — reject consecutive hyphens in `name` (major)**
The name-format regex `^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$` allows `--`, so `page--cro` passed — even though `AGENTS.md` lists it as an explicit *invalid* example ("No consecutive hyphens (`--`)"). Added an explicit `--` check:

```bash
elif [[ "$name_in_file" == *--* ]]; then
    skill_errors+=("Invalid name: '$name_in_file' has consecutive hyphens ('--' not allowed)")
```

**2. `validate-skills.sh` — always flag a top-level `version:` (major)**
The "`version` should be under `metadata:`" error was nested inside `if [[ -n "$metadata" ]]`, so a top-level `version:` with **no** `metadata:` block — the exact mistake it targets — was never caught. Moved the check out of the guard so it runs unconditionally.

**3. `AGENTS.md` — correct CLI tool count (minor)**
`tools/clis/` has 64 `.js` tools; the structure diagram said 51. Updated 51 → 64.

## Verification

```
$ bash validate-skills.sh          # all existing skills
  ✓ Passed: 47
  All skills are valid! ✓
```

The two fixtures from #450 are now correctly rejected:

```
❌ page--cro
   Error: Invalid name: 'page--cro' has consecutive hyphens ('--' not allowed)
❌ versiontest            # top-level version, no metadata block — previously passed
   Error: 'version' is top-level (should be under 'metadata:')
```

## Checklist
- [x] Changes are focused and minimal
- [x] No skills modified; all 47 still pass the validator
- [x] No sensitive data or credentials
- [x] Tested locally
