### PR TITLE
feat(video): reverse-engineer a viral edit into a reusable edit spec (2.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.10",
+    "version": "2.8.11",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.10",
+  "version": "2.8.11",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -50,9 +50,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
 | social | 2.2.0 | 2026-07-09 |
-| video | 2.0.1 | 2026-05-18 |
+| video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.8.11 (2026-07-14)
+
+- **video** (2.0.1 → 2.1.0): added **reverse-engineering a viral edit into a reusable edit spec** (the tool-agnostic decomposition behind "copy any viral edit" — pattern from Arcads' skill, whose Omni generation model is proprietary/MCP-gated; we build only the decomposition, credited). New `references/edit-anatomy.md`: pull the reference with watch-video (visual/multimodal to read frames + caption style + cut timing) or social-fetch, extract the edit anatomy beat by beat across nine dimensions (shot/framing, cut rhythm/cuts-per-second, on-screen text, caption style, motion/punch-ins, b-roll/overlays, sound design, the first-2s hook, pacing curve), and output a per-beat **beat sheet** table plus a **style summary** of the 3–5 signature moves that make the edit recognizable (patterns over instance-logging). Includes the review-once gate (approve the beat sheet — on-screen text + scene-change placement — before executing in Remotion/Hyperframes, CapCut, or an AI restyle tool) and a hard originality guardrail (copy the editing grammar applied to your own footage/message, never the reference's footage, script, voiceover, or music). SKILL.md adds a Reverse-Engineer a Viral Edit workflow and 'copy this edit,' 'match this video style,' 'reverse-engineer this video,' 'edit like this reference' triggers. New eval (id 7). Closes #456.
 
 ### 2.8.10 (2026-07-14)
 

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: video
-description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
+description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' 'copy this edit,' 'match this video style,' 'reverse-engineer this video,' 'edit like this reference,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
 metadata:
-  version: 2.0.1
+  version: 2.1.0
 ---
 
 # Video
@@ -243,6 +243,10 @@ CapCut: Add captions, effects, platform styling
     ↓
 Distribute: TikTok, Reels, Shorts, LinkedIn
 ```
+
+### Reverse-Engineer a Viral Edit
+
+To replicate the *style* of a video edit you admire — the cut rhythm, caption treatment, punch-ins, on-screen text, sound design — decompose it into a reusable **edit spec** (a beat sheet) and apply it to your own footage. Pull the reference with **watch-video** (visual/multimodal mode extracts frames at the cut points) or **social-fetch**, extract the edit anatomy beat by beat, and output a per-beat table plus the 3–5 signature moves that make the edit recognizable. Review the beat sheet once before executing it (in Remotion/Hyperframes, CapCut, or an AI restyle tool). Copies the editing grammar, never the reference's footage/script/music. Full method: [references/edit-anatomy.md](references/edit-anatomy.md).
 
 ---
 

--- a/skills/video/evals/evals.json
+++ b/skills/video/evals/evals.json
@@ -83,6 +83,21 @@
         "Asks about stack or animation needs"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "There's a TikTok edit style I love — fast cuts, one-word captions that pop, a whoosh on every scene change. I have my own talking-head clip. Break down how that edit works so I can replicate the style. Here's the reference: [link]",
+      "expected_output": "Should apply references/edit-anatomy.md (reverse-engineer the edit into a reusable spec), not just describe it. Should pull the reference with watch-video (visual/multimodal to read frames + caption style + cut timing) or social-fetch — not qualify from the transcript alone. Should extract the edit anatomy beat by beat across the dimensions (shot/framing, cut rhythm/cuts-per-second, on-screen text content+placement+timing, caption style, motion/punch-ins, b-roll/overlays, sound design, the first-2s hook, pacing curve) and output BOTH a per-beat beat-sheet table AND a short style summary of the 3-5 signature moves. Should emphasize patterns over instance-logging. Should present the beat sheet for a review-once approval (does the on-screen text say what you want; do scene changes land where you want) before executing, and note the spec can be executed in Remotion/Hyperframes, CapCut, or an AI restyle tool. Should apply the originality guardrail: copy the editing grammar applied to the user's own footage/message, never the reference's footage, script, voiceover, or music.",
+      "assertions": [
+        "Applies the edit-anatomy reverse-engineering method, not a plain description",
+        "Pulls the reference with watch-video/social-fetch to read the actual frames, not just the transcript",
+        "Extracts the edit anatomy across the dimensions and expresses patterns (not a raw list of cut timestamps)",
+        "Outputs a per-beat beat sheet AND a style summary of the signature moves",
+        "Presents the beat sheet for a review-once approval before executing",
+        "Notes execution paths (Remotion/Hyperframes, CapCut, or AI restyle tool)",
+        "Applies the originality guardrail — copies editing grammar applied to the user's own footage, never the reference's footage/script/music"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/video/references/edit-anatomy.md
+++ b/skills/video/references/edit-anatomy.md
@@ -1,0 +1,84 @@
+# Reverse-Engineering an Edit (The Beat Sheet)
+
+A viral short-form video usually isn't winning on the footage — it's winning on the *edit*: the cut rhythm, the caption style, the punch-ins, the on-screen text landing on the exact word, the b-roll cutaways, the sound design. This reference turns a reference edit you admire into a **reusable edit spec** — a beat sheet you (or an editing tool) can execute against your own footage — without copying a single frame of theirs.
+
+This is the tool-agnostic half of "copy any viral edit": the *decomposition*. The generation is whatever you edit with afterward — CapCut, Premiere, Remotion/Hyperframes, or an AI restyle tool. The spec is the deliverable.
+
+## When to use it
+
+- A competitor's or creator's edit keeps stopping your scroll and you want to understand *why* and replicate the technique
+- You have raw footage (a talking-head clip, a demo) and a reference edit whose style you want to match
+- You're briefing an editor or a template and need the edit decisions written down, not vibes
+
+Don't use it to copy someone's actual creative — this extracts the *editing grammar* (structure, rhythm, caption treatment), not the script, footage, or brand. Same rule as mining organic content for vocabulary in the hook system: take the technique, never the creative.
+
+## Step 1 — Pull the reference so you can actually read the edit
+
+You cannot decompose an edit from a description of it. Get the frames and the timing:
+
+- **watch-video** (visual or multimodal mode) — extracts the transcript *and* samples frames at the cut points, so you can read on-screen text, caption style, and shot changes. This is the primary tool.
+- **social-fetch** — pull the post for the caption, engagement, and the media URL when the reference is a specific tweet/Reel/TikTok.
+- Screenshots of key frames also work if the user supplies them — you need the visual, not just the words.
+
+Note the total duration and roughly how many cuts there are before you start — cuts-per-second is the single most telling number about an edit's energy.
+
+## Step 2 — Extract the anatomy, beat by beat
+
+Walk the reference from 0:00 and log every editing decision. The dimensions that define a short-form edit:
+
+| Dimension | What to read off the reference |
+|---|---|
+| **Shot & framing** | Talking head / screen recording / b-roll / text card; close-up vs. wide; headroom, rule-of-thirds, or dead-center |
+| **Cut rhythm** | Where each cut lands and how fast (cuts-per-second); is it on the beat, on the word, or on the breath? |
+| **On-screen text** | The words, when each appears/disappears, and *where* on the frame (top-third caption vs. big centered statement) |
+| **Caption style** | Font, weight, color, outline/box, and animation (word-by-word pop, karaoke highlight, whole-line) |
+| **Motion** | Punch-ins / zoom pushes, shakes, whip-transitions, speed ramps — where and how aggressive |
+| **B-roll & overlays** | Cutaways, stickers, arrows, emoji, screenshots, meme inserts — what's laid over the base footage and when |
+| **Sound design** | Music choice and where it hits, SFX (whooshes, dings, risers), and deliberate silence before a beat |
+| **Hook (first 2s)** | The single most-copied element — what's on screen and said in the opening two seconds, before anyone's committed |
+| **Pacing curve** | Does it stay frantic, or fast-hook → slower-body → fast-CTA? Map the energy over the runtime |
+
+Read the *pattern*, not just the instances: "a hard cut + punch-in on every new sentence," "caption is one word at a time, yellow, karaoke-highlighted, bottom third," "a whoosh SFX on every scene change." Patterns are what make an edit replicable; a list of 40 individual cuts is not.
+
+## Step 3 — Write the beat sheet
+
+Two artifacts: a per-beat table and a short style summary.
+
+**The beat sheet** — one row per beat (a beat = a cut or a distinct edit event):
+
+```
+| Beat | Time      | Shot            | On-screen text        | Caption style        | Transition / motion   | Audio            |
+|------|-----------|-----------------|-----------------------|----------------------|-----------------------|------------------|
+| 1    | 0:00–0:02 | CU talking head | "STOP doing this"     | word-pop, yellow, ctr| hard in, slow push    | music in + riser |
+| 2    | 0:02–0:04 | screen record   | (caption only)        | karaoke, white, btm  | hard cut + whoosh     | click SFX        |
+| …    |           |                 |                       |                      |                       |                  |
+```
+
+**The style summary** — the 3–5 *signature moves* that make this edit recognizable, stated so they're reusable:
+- e.g. "Every sentence gets a hard cut + a 5% punch-in." / "Captions are one word at a time, bottom-third, karaoke-highlighted." / "A whoosh SFX on every cut; music drops out for 0.5s before the CTA." / "The hook is a bold centered statement on frame 1, no logo."
+
+The signature moves are the real deliverable — someone can apply those five rules to any footage and get the style. The table is the detailed backup.
+
+## Step 4 — Review once, then execute
+
+Show the beat sheet before anyone edits anything — the same review-once gate as the ad-creative creative review page. The reviewer checks two things:
+
+- **The on-screen text says what you want** (mapped to your message, not the reference's)
+- **The scene changes land where you want them** (your footage's beats, not a blind copy of the reference's timing)
+
+Approve, then execute the spec with your footage:
+- **Remotion / Hyperframes** — when you want the edit templated and data-driven (see the programmatic-video section in SKILL.md); the beat sheet *is* the composition spec.
+- **CapCut / Premiere / an editor** — hand off the beat sheet + style summary as the brief.
+- **An AI restyle tool** — feed the style summary as the target style.
+
+## Originality guardrail
+
+You are copying the *edit*, not the content. The beat sheet describes technique (cut rhythm, caption treatment, motion, sound design) applied to **your** footage and **your** message. Never reuse the reference's actual clips, voiceover, script lines, music (license your own), or brand elements. An edit style is not protectable; a specific creative is. If the reference's "style" is really a specific bit or sketch, that's their creative — draw inspiration, don't reproduce it.
+
+## Common mistakes
+
+- **Describing instead of reading** — you can't extract caption style or cut timing from the transcript alone; pull the frames (watch-video).
+- **Logging instances, not patterns** — 40 cut timestamps isn't a spec; "hard cut + punch-in per sentence" is.
+- **Copying the reference's timing onto different footage** — beats land on *your* words and *your* cuts; the reference gives you the grammar, not the calendar.
+- **Skipping the hook** — the first 2 seconds carry most of the retention; decode them in the most detail.
+- **Reproducing the creative** — matching the edit is fine; re-shooting their exact bit, script, or using their footage/music is not.

--- a/skills/video/references/edit-anatomy.md
+++ b/skills/video/references/edit-anatomy.md
@@ -73,7 +73,7 @@ Approve, then execute the spec with your footage:
 
 ## Originality guardrail
 
-You are copying the *edit*, not the content. The beat sheet describes technique (cut rhythm, caption treatment, motion, sound design) applied to **your** footage and **your** message. Never reuse the reference's actual clips, voiceover, script lines, music (license your own), or brand elements. An edit style is not protectable; a specific creative is. If the reference's "style" is really a specific bit or sketch, that's their creative — draw inspiration, don't reproduce it.
+You are copying the *edit*, not the content. The beat sheet describes technique (cut rhythm, caption treatment, motion, sound design) applied to **your** footage and **your** message. General editing techniques and style cues are usually reusable — U.S. copyright protects expression, not procedures or methods (17 U.S.C. §102(b)) — but the reference's specific creative expression is not, and closely reproducing a finished video's exact selection and arrangement of choices can still create risk. So copy the grammar, not the finished work: use your own footage, message, script, voiceover, licensed music/SFX/samples, and brand elements. If the reference's "style" is really a specific bit or sketch, that's their creative — draw inspiration, don't reproduce it.
 
 ## Common mistakes
 
@@ -81,4 +81,4 @@ You are copying the *edit*, not the content. The beat sheet describes technique 
 - **Logging instances, not patterns** — 40 cut timestamps isn't a spec; "hard cut + punch-in per sentence" is.
 - **Copying the reference's timing onto different footage** — beats land on *your* words and *your* cuts; the reference gives you the grammar, not the calendar.
 - **Skipping the hook** — the first 2 seconds carry most of the retention; decode them in the most detail.
-- **Reproducing the creative** — matching the edit is fine; re-shooting their exact bit, script, or using their footage/music is not.
+- **Reproducing the creative** — matching the edit is fine; re-shooting their exact bit, script, or using their footage/music/SFX is not.


### PR DESCRIPTION
## Summary

Adds **reverse-engineering a viral edit into a reusable edit spec** to the video skill (2.0.1 → 2.1.0). Closes #456. Repo release **2.8.11**.

Learned from Arcads' "Copy Any Viral Edit" Claude skill. Their generation runs on a proprietary MCP-gated model (Omni) we can't replicate — but the genuinely transferable, tool-agnostic step is the **decomposition**: break a reference edit into a beat-by-beat plan before executing. That's the buildable half, and it fills a real gap (we reverse-engineer posts/carousels in `social`, but nothing decomposes a video *edit*).

- **`references/edit-anatomy.md`** — pull the reference with **watch-video** (visual/multimodal to read frames + caption style + cut timing) or **social-fetch**; extract the edit anatomy beat by beat across nine dimensions (shot/framing, cut rhythm/cuts-per-second, on-screen text, caption style, motion/punch-ins, b-roll/overlays, sound design, the first-2s hook, pacing curve); output a per-beat **beat sheet** table plus a **style summary** of the 3–5 signature moves (patterns over instance-logging). Includes the review-once gate (approve the beat sheet before executing in Remotion/Hyperframes, CapCut, or an AI restyle tool) and a hard originality guardrail.
- **video SKILL.md** — Reverse-Engineer a Viral Edit workflow + 'copy this edit,' 'match this video style,' 'reverse-engineer this video,' 'edit like this reference' triggers. New eval (id 7).

## Review

Codex review: one FIX — the originality guardrail's "edit style is not protectable" was too absolute. Softened per 17 U.S.C. §102(b) (techniques/methods usually reusable, but closely reproducing a finished work's specific selection/arrangement still carries risk) and added SFX/samples to the licensing note. Codex confirmed the method is genuinely distinct from `social/reverse-engineering.md` (corpus-level post mining vs. artifact-level edit decomposition). Mechanical consistency verified directly (versions aligned, SKILL.md 347 lines / desc 763, workflow+trigger+link wired, evals unique) since codex hung on the longer review prompt before succeeding on a compact one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
