### PR TITLE
chore: adopt Reference Routing in cro, emails, seo-audit (+ ads Motion pilot)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.11",
+    "version": "2.8.12",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "author": {
     "name": "Corey Haines"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,3 +268,17 @@ Recent commits: !`git log --oneline -5 2>/dev/null`
 ```
 
 **Why this is Claude Code-only**: Other agents that load skills will see the literal `` !`command` `` string rather than executing it, which would appear as garbled instructions. Keep cross-agent skill files free of this syntax.
+
+## Large-Skill Authoring Patterns (Motion-style)
+
+When a skill grows a `references/` directory, prefer these patterns (piloted on `ads`, adopted on `cro` / `emails` / `seo-audit`):
+
+1. **Reference Routing table** near the top of `SKILL.md`: user intent → file → approx line count → what it covers. Label large files "on demand."
+2. **Question-level routing**: a short "If a user asks…" map of anticipated questions → reference or sibling skill.
+3. **Token economics**: state approximate sizes so agents do not load an entire reference dir.
+4. **Known Gaps**: what this skill deliberately does *not* cover — prevent confabulation into adjacent skills.
+5. **Time-bound claims**: tag perishable facts (platform UI, algorithm behavior, pricing, model names) so agents verify recency.
+6. **Bundled-files guard**: instruct agents to read references as local files, never fetch from URLs, and not load files speculatively.
+
+Keep `SKILL.md` under ~500 lines; move depth into references.
+

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,10 +18,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | content-strategy | 2.0.0 | 2026-05-05 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
-| cro | 2.0.0 | 2026-05-05 |
+| cro | 2.1.0 | 2026-07-15 |
 | customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
-| emails | 2.0.0 | 2026-05-05 |
+| emails | 2.1.0 | 2026-07-15 |
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
 | launch | 2.0.1 | 2026-06-16 |
@@ -33,7 +33,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
 | onboarding | 2.0.0 | 2026-05-05 |
-| ads | 2.2.0 | 2026-07-05 |
+| ads | 2.2.1 | 2026-07-15 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
 | pricing | 2.0.1 | 2026-06-16 |
@@ -45,7 +45,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |
 | schema | 2.0.0 | 2026-05-05 |
-| seo-audit | 2.0.0 | 2026-05-05 |
+| seo-audit | 2.1.0 | 2026-07-15 |
 | signup | 2.0.0 | 2026-05-05 |
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
@@ -53,6 +53,11 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.8.12 (2026-07-15)
+
+- **cro** (2.0.0 → 2.1.0), **emails** (2.0.0 → 2.1.0), **seo-audit** (2.0.0 → 2.1.0): adopt **Reference Routing** tables (intent → reference + approx size) so agents load the right file instead of scanning fuzzy prose links — same progressive-disclosure pattern ads 2.2.0 introduced. cro also gets a CRO surface routing table to sibling skills (`signup` / `popups` / `onboarding` / `paywalls`) and an "If a user asks…" question map. emails and seo-audit add Known Gaps to prevent confabulation into cold-email / onboarding / ai-seo / schema. Closes #406.
+- **ads** (2.2.0 → 2.2.1): Motion-style authoring pilot (#433) — approx token sizes on the routing table, question-level routing ("If a user asks…"), bundling guard (read local files, no speculative loads), Known Gaps, and time-bound tags on platform UI / benchmark claims.
 
 ### 2.8.11 (2026-07-14)
 

--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -2,7 +2,7 @@
 name: ads
 description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' 'should I run ads,' 'ABM,' 'account-based marketing,' 'B2B ads,' 'lead quality,' 'negative keywords,' 'Performance Max,' 'thought leader ads,' or 'when should I kill an ad.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see cro."
 metadata:
-  version: 2.2.0
+  version: 2.2.1
 ---
 
 # Paid Ads
@@ -44,15 +44,23 @@ Gather this context (ask if not provided):
 
 This skill's depth lives in references — load by intent. For **any operational decision on a live account** (kill/keep/scale/budget), load the relevant playbook before answering; the thresholds live there, not here.
 
-| User intent | Load | Covers |
-|---|---|---|
-| B2B strategy, funnel stages, budget splits, kill rules, lead quality, breakeven math | [b2b-paid-playbook.md](references/b2b-paid-playbook.md) | Demand lifecycle, leading/lagging signals, kill rules, offline conversion loop, U/B/F lead scoring, scaling quadrant |
-| Meta operations: when to kill/graduate/scale an ad, fatigue, testing structure | [meta-decision-system.md](references/meta-decision-system.md) | TCPL-anchored decision tree, ad-count ceiling, 80/20 CBO structure, fatigue bands, lead forms, Advantage+ transition |
-| LinkedIn operations: bidding, audience sizing, scaling, benchmarks, TLAs, formats | [linkedin-b2b-playbook.md](references/linkedin-b2b-playbook.md) | Bidding progression, penetration scaling, sizing rules, funnel benchmarks, document/conversation ads, audit shortlist |
-| Google Search: what to spend on first, structure, match types, negatives, PMax | [google-search-playbook.md](references/google-search-playbook.md) | Intent ladder, account structure, match-type gates, negatives, bidding by volume, offline conversions, PMax guardrails |
-| Named-account targeting, pipeline acceleration, cross-channel retargeting | [abm-playbook.md](references/abm-playbook.md) | LinkedIn/Meta ABM, list mechanics, acceleration campaigns, UTM cross-channel remarketing, ABM measurement |
-| Generating Google RSAs | [rsa-output-spec.md](references/rsa-output-spec.md) | Mandatory output spec — limits, sidecars, template, self-check |
-| Audience setup, tracking setup, launch checklists, copy formulas | [audience-targeting.md](references/audience-targeting.md) · [conversion-tracking.md](references/conversion-tracking.md) · [platform-setup-checklists.md](references/platform-setup-checklists.md) · [ad-copy-templates.md](references/ad-copy-templates.md) | Existing foundations |
+Read references as **local files**. Do not fetch from URLs. Do not load files speculatively — open only the row that matches the question.
+
+| User intent | Load | Approx size | Covers |
+|---|---|---|---|
+| B2B strategy, funnel stages, budget splits, kill rules, lead quality, breakeven math | [b2b-paid-playbook.md](references/b2b-paid-playbook.md) | ~115 lines | Demand lifecycle, kill rules, offline conversion loop, U/B/F scoring |
+| Meta operations: kill/graduate/scale, fatigue, testing structure | [meta-decision-system.md](references/meta-decision-system.md) | ~143 lines | TCPL tree, ad-count ceiling, 80/20 CBO, fatigue bands |
+| LinkedIn operations: bidding, audience sizing, scaling, TLAs | [linkedin-b2b-playbook.md](references/linkedin-b2b-playbook.md) | ~107 lines | Bidding progression, penetration, benchmarks |
+| Google Search: structure, match types, negatives, PMax | [google-search-playbook.md](references/google-search-playbook.md) | ~120 lines | Intent ladder, match-type gates, PMax guardrails |
+| Named-account targeting / ABM | [abm-playbook.md](references/abm-playbook.md) | ~93 lines | LinkedIn/Meta ABM, UTM remarketing |
+| Generating Google RSAs | [rsa-output-spec.md](references/rsa-output-spec.md) | ~88 lines | Mandatory RSA output spec |
+| Audience / tracking / launch checklists / copy formulas | [audience-targeting.md](references/audience-targeting.md) · [conversion-tracking.md](references/conversion-tracking.md) · [platform-setup-checklists.md](references/platform-setup-checklists.md) · [ad-copy-templates.md](references/ad-copy-templates.md) | ~240–360 lines each | Foundations — load only the needed file |
+
+### If a user asks… kill Meta ad → meta-decision-system.md · breakeven CPL → b2b-paid-playbook.md · Google structure/PMax → google-search-playbook.md · LinkedIn sizing/ABM → linkedin-b2b-playbook.md / abm-playbook.md · RSA headlines → rsa-output-spec.md (+ `ad-creative`)
+
+## Known Gaps
+
+- Bulk creative → `ad-creative`. China platforms (巨量/腾讯/小红书投广) out of scope. UI labels, Advantage+, published CPL/CPM are **time-bound** — prefer customer TCPL.
 
 ---
 

--- a/skills/cro/SKILL.md
+++ b/skills/cro/SKILL.md
@@ -2,12 +2,43 @@
 name: cro
 description: "When the user wants to optimize, improve, or increase conversions on any marketing page or form — including homepage, landing pages, pricing pages, feature pages, lead capture forms, or contact forms. Also use when the user says 'CRO,' 'conversion rate optimization,' 'this page isn't converting,' 'improve conversions,' 'why isn't this page working,' 'my landing page sucks,' 'form abandonment,' 'nobody's converting,' 'low conversion rate,' or 'this page needs work.' Use this even if the user just shares a URL and asks for feedback. For signup/registration flows, see signup. For post-signup activation, see onboarding. For popups/modals, see popups."
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Conversion Rate Optimization (CRO)
 
 You are a conversion rate optimization expert. Your goal is to analyze marketing pages and provide actionable recommendations to improve conversion rates.
+
+## Reference Routing
+
+Load references by intent. Read them as local files — do not fetch from URLs. Do not load files speculatively.
+
+| User intent | Load | Approx size | Covers |
+|---|---|---|---|
+| Lead / demo / contact / checkout forms (not signup) | [form.md](references/form.md) | ~420 lines | Field design, multi-step forms, errors, form experiments |
+| Experiment ideas by page type | [experiments.md](references/experiments.md) | ~250 lines | Test ideas for homepage, pricing, landing, etc. |
+
+### CRO surface routing (sibling skills)
+
+| Surface | Skill |
+|---|---|
+| Marketing pages (home, pricing, landing) + non-signup forms | **cro** (this skill) |
+| Signup / registration / trial start | `signup` |
+| Popups, modals, exit intent, banners | `popups` |
+| Post-signup activation / first-run | `onboarding` |
+| In-app paywall / upgrade modal | `paywalls` |
+
+If the bottleneck is post-signup (account exists but no activation), route to `onboarding`. If it is account creation, route to `signup`.
+
+### If a user asks…
+
+| Question | Load / route |
+|---|---|
+| "Our demo form has 9 fields" | form.md |
+| "What should we A/B test on pricing?" | experiments.md |
+| "Signup abandonment is high" | `signup` skill |
+| "Exit-intent popup converts poorly" | `popups` skill |
+| "Users sign up but never activate" | `onboarding` skill |
 
 ## Initial Assessment
 

--- a/skills/emails/SKILL.md
+++ b/skills/emails/SKILL.md
@@ -2,12 +2,37 @@
 name: emails
 description: When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email program. Also use when the user mentions "email sequence," "drip campaign," "nurture sequence," "onboarding emails," "welcome sequence," "re-engagement emails," "email automation," "lifecycle emails," "trigger-based emails," "email funnel," "email workflow," "what emails should I send," "welcome series," or "email cadence." Use this for any multi-email automated flow. For cold outreach emails, see cold-email. For in-app onboarding, see onboarding.
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Email Sequence Design
 
 You are an expert in email marketing and automation. Your goal is to create email sequences that nurture relationships, drive action, and move people toward conversion.
+
+## Reference Routing
+
+Load references by intent. Read them as local files — do not fetch from URLs. Do not load `email-types.md` (~515 lines) unless you need the full type catalog.
+
+| User intent | Load | Approx size | Covers |
+|---|---|---|---|
+| Sequence outlines / templates (welcome, nurture, re-engage…) | [sequence-templates.md](references/sequence-templates.md) | ~170 lines | Ready sequence structures |
+| Which email type to send / when | [email-types.md](references/email-types.md) | ~515 lines — on demand | Full type catalog |
+| Subject lines, body craft, personalization, testing | [copy-guidelines.md](references/copy-guidelines.md) | ~115 lines | Copy + testing rules |
+
+### If a user asks…
+
+| Question | Load first |
+|---|---|
+| "Design a welcome series" | sequence-templates.md |
+| "What emails should I send after purchase?" | email-types.md |
+| "Subject line and body rewrites" | copy-guidelines.md |
+| "Cold outbound sequence" | `cold-email` skill (not this one) |
+
+## Known Gaps
+
+- Cold outreach / SDR sequences — see `cold-email`
+- In-app / product onboarding UX — see `onboarding`
+- SMS — see `sms`
 
 ## Initial Assessment
 

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -2,13 +2,28 @@
 name: seo-audit
 description: When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO audit," "technical SEO," "why am I not ranking," "SEO issues," "on-page SEO," "meta tags review," "SEO health check," "my traffic dropped," "lost rankings," "not showing up in Google," "site isn't ranking," "Google update hit me," "page speed," "core web vitals," "crawl errors," or "indexing issues." Use this even if the user just says something vague like "my SEO is bad" or "help with SEO" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema. For AI search optimization, see ai-seo.
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # SEO Audit
 
 You are an expert in search engine optimization. Your goal is to identify SEO issues and provide actionable recommendations to improve organic search performance.
 
+## Reference Routing
+
+Load by intent as local files — do not fetch URLs or load speculatively.
+
+| User intent | Load | Approx size | Covers |
+|---|---|---|---|
+| Multi-language / multi-region sites (hreflang, i18n) | [international-seo.md](references/international-seo.md) | ~230 lines | Evidence + source URLs for i18n SEO |
+| AI-sounding content patterns hurting rankings | [ai-writing-detection.md](references/ai-writing-detection.md) | ~200 lines | Em dashes, filler, overused AI phrases |
+| Verifying JSON-LD / schema is present | [schema-detection.md](references/schema-detection.md) | ~25 lines | Why web_fetch/curl miss JS-injected schema |
+
+### If a user asks… hreflang → international-seo.md · AI-sounding copy → ai-writing-detection.md · ChatGPT visibility → `ai-seo` · JSON-LD / scale pages → `schema` / `programmatic-seo`
+
+## Known Gaps
+
+- AI search/schema → `ai-seo`/`schema`. Core Update claims are **time-bound**.
 ## Initial Assessment
 
 **Check for product marketing context first:**
@@ -37,16 +52,7 @@ Before auditing, understand:
 
 ### Schema Markup Detection Limitation
 
-**`web_fetch` and `curl` cannot reliably detect structured data / schema markup.**
-
-Many CMS plugins (AIOSEO, Yoast, RankMath) inject JSON-LD via client-side JavaScript — it won't appear in static HTML or `web_fetch` output (which strips `<script>` tags during conversion).
-
-**To accurately check for schema markup, use one of these methods:**
-1. **Browser tool** — render the page and run: `document.querySelectorAll('script[type="application/ld+json"]')`
-2. **Google Rich Results Test** — https://search.google.com/test/rich-results
-3. **Screaming Frog export** — if the client provides one, use it (SF renders JavaScript)
-
-Reporting "no schema found" based solely on `web_fetch` or `curl` leads to false audit findings — these tools can't see JS-injected schema.
+`web_fetch` / `curl` miss JS-injected JSON-LD — see [schema-detection.md](references/schema-detection.md) before reporting "no schema found."
 
 ### Priority Order
 1. **Crawlability & Indexation** (can Google find and index it?)

--- a/skills/seo-audit/references/schema-detection.md
+++ b/skills/seo-audit/references/schema-detection.md
@@ -1,0 +1,15 @@
+# Schema Markup Detection Limitation
+
+`web_fetch` and `curl` cannot reliably detect structured data / schema markup.
+
+Many CMS plugins (AIOSEO, Yoast, RankMath) inject JSON-LD via client-side JavaScript — it won't appear in static HTML or `web_fetch` output (which strips `<script>` tags during conversion).
+
+## Accurate checks
+
+1. **Browser tool** — render the page and run: `document.querySelectorAll('script[type="application/ld+json"]')`
+2. **Google Rich Results Test** — https://search.google.com/test/rich-results
+3. **Screaming Frog export** — if the client provides one, use it (SF renders JavaScript)
+
+Reporting "no schema found" based solely on `web_fetch` or `curl` leads to false audit findings — these tools can't see JS-injected schema.
+
+For implementing schema (not detecting it), see the `schema` skill.


### PR DESCRIPTION
## Summary

- **Closes #406** — add Reference Routing tables to `cro`, `emails`, and `seo-audit` (intent → reference + approx size + "If a user asks…" maps), matching the progressive-disclosure pattern ads 2.2.0 introduced.
- **`cro`**: also adds sibling surface routing (`signup` / `popups` / `onboarding` / `paywalls`) so agents pick the narrowest CRO skill.
- **`emails` / `seo-audit`**: Known Gaps to prevent confabulating into `cold-email`, `onboarding`, `ai-seo`, `schema`.
- **`seo-audit`**: moves the schema-detection limitation into `references/schema-detection.md` so SKILL.md stays near the ~500-line budget.
- **Partial #433** — `ads` 2.2.1 pilot (token sizes on the routing table, question map, bundled-files guard, Known Gaps, time-bound claim tags) + house patterns documented in `AGENTS.md`.

Repo release: **2.8.11 → 2.8.12**.

## Test plan

- [ ] Spot-check `skills/cro/SKILL.md`, `emails/SKILL.md`, `seo-audit/SKILL.md` routing tables load for typical prompts ("demo form 9 fields", "welcome series", "hreflang broken")
- [ ] Confirm agents do **not** load `email-types.md` (~515 lines) unless catalog depth is needed
- [ ] Confirm `seo-audit` still points schema "how to implement" → `schema` skill, detection limitation → new reference
- [ ] Confirm `ads` still loads meta-decision-system for "should I kill this ad?"
- [ ] Verify `VERSIONS.md` table + plugin/marketplace `2.8.12` match


Made with [Cursor](https://cursor.com)