### PR TITLE
feat: influencer-marketing skill (expanded from PR #417 contribution, standalone)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.11",
+    "version": "2.9.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.11",
+  "version": "2.9.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [emails](skills/emails/) | When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email... |
 | [free-tools](skills/free-tools/) | When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or... |
 | [image](skills/image/) | When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product... |
+| [influencer-marketing](skills/influencer-marketing/) | When the user wants to run influencer, creator, or ambassador partnerships to promote their product — finding and vetting partners, structuring deals, briefing creators, disclosure... |
 | [launch](skills/launch/) | When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user... |
 | [lead-magnets](skills/lead-magnets/) | When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the... |
 | [marketing-council](skills/marketing-council/) | When the user wants multiple expert perspectives on a marketing question — a simulated board of advisors staffed by... |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -24,6 +24,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
+| influencer-marketing | 1.0.0 | 2026-07-15 |
 | launch | 2.0.1 | 2026-06-16 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
@@ -53,6 +54,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.9.0 (2026-07-15)
+
+- Added **`influencer-marketing`** skill — influencer, creator, and ambassador partnerships end to end. Foundation contributed by @Adi29102000-s (PR #417), expanded to the repo's standard and shipped standalone (the PR's other proposed skills were not included). Covers the **influencer ↔ ambassador spectrum** (paid influencer → affiliate creator → gifting → long-term ambassador program → organic advocate, each with when-to-use and skill handoffs), finding & vetting (audience-alignment test, creator tiers incl. B2B thought leaders, engagement/fake-follower/brand-safety checks), 1:1 outreach (→ cold-email), deal structuring (flat / CPA / hybrid / gifting compensation, rate-as-a-range reality, and the high-ROI content-usage-rights/whitelisting clause → ad-creative), a full **FTC disclosure & compliance section** (material-connection disclosure, clear-and-conspicuous placement, gifting-still-needs-disclosure, platform labels, brand liability, no fabricated claims — a gap in the original contribution), the creative brief (don't script; grounded talking points), measurement & ROI (unique promo codes, UTMs, vanity URLs, post-purchase survey for the branded-search/direct attribution blind spot, whitelisting performance, cost-per-qualified-outcome over EMV/reach), and a structured **ambassador program design** (ask → benefits ladder → recruit-from-evidence → equip → activate → track, cross-referencing community-marketing for community-led advocacy and referrals for payout rails). Six-eval suite covering compensation/whitelisting, podcast attribution, the gifting-disclosure misconception, ambassador-program design, creator vetting, and the no-word-for-word-scripting brief. New skill = repo y release. Total skills: 48.
 
 ### 2.8.11 (2026-07-14)
 

--- a/skills/influencer-marketing/SKILL.md
+++ b/skills/influencer-marketing/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: influencer-marketing
+description: "When the user wants to run influencer, creator, or ambassador partnerships to promote their product — finding and vetting partners, structuring deals, briefing creators, disclosure compliance, and measuring ROI. Also use when the user mentions 'influencer marketing,' 'creator partnerships,' 'sponsorships,' 'YouTube sponsorships,' 'podcast sponsorships,' 'brand ambassador,' 'ambassador program,' 'creator program,' 'UGC creators,' 'B2B influencers,' 'thought leader ads,' 'gifting,' 'product seeding,' 'whitelisting creator content,' 'how much to pay an influencer,' or 'FTC disclosure.' For affiliate/referral payout mechanics, see referrals. For community-led advocacy, see community-marketing. For turning creator content into paid ads, see ad-creative."
+metadata:
+  version: 1.0.0
+---
+
+# Influencer & Creator Marketing
+
+You are an expert in influencer, creator, and ambassador marketing across B2C (Instagram, TikTok, YouTube) and B2B (LinkedIn, X, newsletters, niche podcasts). Your goal is to help the user pick the right partners, structure fair deals, keep the program compliant, and measure real ROI — not vanity reach.
+
+> Foundation contributed by @Adi29102000-s; expanded to the repo's standard.
+
+## Before Starting
+
+**Check for product marketing context first.** If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or legacy `product-marketing-context.md`), read it before asking questions — the ICP, positioning, and offer anchor every partner-fit decision. Then gather what's missing: goal (awareness / conversions / content / trust), budget and whether it's cash or product, target platform(s), and any brand-safety redlines.
+
+## The Influencer ↔ Ambassador Spectrum
+
+"Influencer marketing" and "ambassador programs" are points on one spectrum — from a one-off paid post to an unpaid long-term advocate. Pick the model that fits the goal and stage, not the buzzword:
+
+| Model | What it is | Pay | Best for | Home |
+|---|---|---|---|---|
+| **Paid influencer** | A creator posts sponsored content for a fee | Cash (flat / hybrid) | Reach + a credibility borrow, fast | This skill |
+| **Affiliate creator** | A creator promotes for commission on sales | Performance (CPA/rev-share) | Conversion at scale, low upfront risk | This skill + **referrals** (payout mechanics) |
+| **Gifted / seeding** | Free product, no obligation to post | Product only | Physical DTC, nano/micro, volume | This skill |
+| **Brand ambassador program** | A cohort of ongoing advocates (paid, gifted, or perks) posting over months | Mixed / perks | Sustained presence, community depth | This skill (design below) + **community-marketing** |
+| **Organic advocate** | A customer who already recommends you unprompted | None | Authenticity, cheapest trust | **community-marketing** |
+
+The further right you go, the more it's about *relationship* than *transaction* — and the cheaper and more durable the trust, but the slower to scale. Most programs blend several (a few paid macro placements for reach + a gifted micro cohort + an affiliate tier for conversion).
+
+## 1. Finding & Vetting Partners
+
+Influence is trust and relevance, not follower count.
+
+**The audience-alignment test.** Don't ask "Are they famous?" Ask "Does their *audience* match our ICP?" A 12k-follower creator whose audience is exactly your buyer beats a 500k generalist. Where you can, look at *their* audience (comments, who engages, any media-kit demographics), not just the creator.
+
+**Creator tiers** (reach vs. trust trade-off):
+
+| Tier | Followers | Character |
+|---|---|---|
+| **Nano** | 1k–10k | Highest engagement, hyper-niche, often works for gifting. High ROI, low reach. |
+| **Micro** | 10k–50k | Best balance of reach and trust; usually paid; strong conversion. |
+| **Mid** | 50k–500k | Broader reach, more awareness than conversion, pricier. |
+| **Macro / celebrity** | 500k+ | Top-of-funnel awareness; lowest conversion rate per follower; expensive. |
+| **B2B thought leader** | Any size | LinkedIn creators, newsletter writers, niche podcasters — small audiences, extreme purchasing power. Judge by *who* follows, not how many. |
+
+For most brands, a portfolio of **micro + nano** partners out-converts one macro placement at the same total spend — and produces more content to repurpose.
+
+**Vetting checklist:**
+- **Engagement rate**, not follower count (a rough floor: ~1–3% is healthy on IG/TikTok at scale; higher for nano). Suspiciously round numbers, comment pods, or comments that don't match the audience are red flags.
+- **Fake-follower / bot check** — a sudden follower spike, generic comments, or engagement wildly out of line with reach. Tools like SparkToro (audience intelligence) help; media kits overstate.
+- **Sponsored-content track record** — do their *ads* still get engagement, or does their audience tune out promos? Ask for past campaign results.
+- **Brand safety** — scroll their last ~3 months. Controversy, competitor conflicts, or off-brand content that would attach to you.
+- **Authenticity of fit** — have they mentioned your category unprompted? A genuine user is worth several cold partners.
+
+## 2. Outreach
+
+Reach out **1:1 and personally** — reference specific content, why *them*, and what's in it for their audience. A generic form blast to 200 creators converts worse than 20 tailored notes. For writing the outreach itself, use **cold-email** (personalization, deliverability, follow-up cadence). Lead with the offer and the fit; don't bury the ask.
+
+## 3. Structuring the Deal
+
+Move beyond "pay for a post."
+
+**Compensation models:**
+- **Flat fee** — standard for awareness; you pay for the placement regardless of result.
+- **Performance / CPA** — pay per click or conversion. Hard to get larger creators to accept without a baseline; best with affiliate-minded creators (see **referrals** for tracking + payout).
+- **Hybrid (flat + CPA)** — usually the best deal: a lower baseline to cover their production time, plus commission for upside. Aligns incentives.
+- **Gifting / seeding** — free product, no obligation. Works for physical DTC with nano/micro at volume; expect a low but authentic post rate.
+
+**Rate reality:** published "rates" are wildly variable by niche, geography, and platform, and creators quote high. Treat any benchmark as a *range to negotiate from*, not a price — and anchor on **cost per qualified outcome** (CPA, cost per qualified follower/lead), not cost per post. A cheap post to the wrong audience is the expensive one.
+
+**Deliverables to negotiate:**
+- **Content usage rights (crucial)** — the right to repurpose their content as **paid ads** (whitelisting / dark posting / "creator ads") for a defined window (commonly 3–6 months). This is often the highest-ROI clause: their content becomes your best-performing ad. Then run it through **ad-creative** (and present variations for sign-off with the creative review page).
+- **Exclusivity** — competitor lockout for a set period; costs more, worth it in tight categories.
+- **Format & specifics** — dedicated video vs. a 60-second integration; number of posts; stories vs. feed; posting window; approval rights; how long it stays up.
+- **Approvals & revisions** — one review round is normal; scripting word-for-word is not (below).
+
+Put it in a simple written agreement: deliverables, timing, usage rights, exclusivity, disclosure obligation (below), payment terms, and a kill/rework clause.
+
+## 4. Disclosure & Compliance (non-negotiable)
+
+Influencer marketing has hard legal requirements — this is the part most brands under-do, and the brand is liable, not just the creator.
+
+- **Any material connection must be disclosed** — payment, free product, commission, a family/employee relationship, even a free trial. Gifting is *not* a loophole; a gifted post still needs disclosure.
+- **The disclosure must be clear and hard to miss** — "#ad" or "#sponsored" placed where viewers actually see it (not buried in a wall of hashtags, not below the "more" fold, and spoken aloud in video/audio, not just in the description). "#sp," "#collab," "#ambassador," and "thanks to [brand]" are considered insufficient on their own by the FTC.
+- **Use the platform's own tool** — Instagram/TikTok/YouTube "paid partnership" labels *in addition to* the written disclosure, not instead of it.
+- **You're responsible for your creators.** Build the disclosure requirement into the brief and the agreement, and check that they actually did it. Non-disclosure is a brand risk (FTC actions target advertisers).
+- **No fabricated claims.** Creators can't say things about the product that aren't true, can't fake results, and can't imply they're a customer if they aren't. Give them what's true and let them speak it in their voice.
+- **International + platform rules vary** (e.g., stricter regimes in the UK/EU, category rules for health/finance/alcohol). When the campaign is regulated or cross-border, route to legal.
+
+Disclosure done well doesn't hurt performance — audiences expect it, and the FTC has never found "#ad" to tank a genuinely good integration.
+
+## 5. The Creative Brief
+
+Do **not** script the creator word-for-word — they know their audience better than you, and scripted reads convert worst. Provide:
+
+- **The "why"** — the core problem your product solves (the one sentence).
+- **Key talking points (2–3 max)** — the most important benefits; more than three and none land.
+- **The CTA** — exactly what to tell the audience to do (a specific vanity link, a unique promo code).
+- **Guardrails** — what *not* to say (don't promise features that don't exist), the disclosure requirement, and any brand redlines.
+- **Creative freedom** — explicitly grant it. The integration should live inside their normal content style.
+
+Ground the talking points in real proof (reviews, results) — same grounding discipline as **ad-creative**'s inputs. Never hand a creator a claim you can't back.
+
+## 6. Measurement & ROI
+
+Influencer marketing suffers from attribution gaps — fix them upfront, before the campaign runs:
+
+- **Unique promo codes** (e.g., `CREATOR20`) — the easiest direct-conversion tracker, and essential for podcasts/video where links aren't clickable.
+- **UTM tracking links** — mandatory on every digital placement; one per creator per placement.
+- **Vanity / dedicated landing pages** — `yourdomain.com/creatorname` with a personalized welcome; lifts conversion *and* attributes cleanly.
+- **Post-purchase survey** — "How did you hear about us?" catches the halo/branded-search effect that promo codes and last-click miss (much of influencer impact shows up later as branded search and direct — see the attribution blind spot in **ai-seo**'s citations-vs-recommendations).
+- **Whitelisting performance** — when you repurpose creator content as ads, that ad's own metrics are a clean read on the creative's real pull.
+
+Judge the program on **cost per qualified outcome and repeat/retained value**, not reach, likes, or "EMV" (earned media value is a vanity number). One nano creator driving 40 real buyers beats a macro placement with a million muted views.
+
+## Ambassador Program Design
+
+When you want *sustained* presence rather than one-off posts, design a program (this is the structured, paid/perks version of community-marketing's advocate program):
+
+1. **Define the tier(s) and the ask** — e.g., 2 posts/month + 1 event; keep it light enough to sustain.
+2. **Build the benefits ladder** — perks that scale with contribution: early access, free/ongoing product, commission (via **referrals**), exclusive swag, revenue share, public recognition, a private channel. Meaningful beats "early access to features."
+3. **Recruit from evidence** — start with people already advocating unprompted (reviews, mentions, community — mine via **customer-research**); a personal 1:1 ask, never a form.
+4. **Equip them** — referral/affiliate links, shareable assets, 2–3 talking points, the disclosure requirement, a private Slack/Discord.
+5. **Activate on a cadence** — give them something to post about monthly (launches, milestones, challenges); a program with nothing to do dies.
+6. **Track and iterate** — attributed traffic/signups per ambassador (codes + links), and double down on the top decile; graduate strong ambassadors to paid partnerships.
+
+For the community-led, unpaid advocate end of this (badges, recognition, community support), hand off to **community-marketing**; for the affiliate payout rails, **referrals**.
+
+## Common Mistakes
+
+- **Chasing follower count over audience fit** — reach to the wrong people is the most expensive spend there is.
+- **Skipping disclosure** — a brand-liability risk, and audiences trust disclosed content more than they distrust it.
+- **Scripting the creator** — kills the authenticity you're paying for; brief, don't dictate.
+- **Not securing usage rights** — you lose the biggest ROI lever (whitelisting their content into paid ads).
+- **No attribution plan** — codes, UTMs, vanity URLs, and the post-purchase survey must exist *before* launch, not after.
+- **One-and-done** — the second post from the same creator usually outperforms the first (their audience has seen you before); build relationships, not transactions.
+- **Judging on EMV / reach** — measure cost per qualified outcome.
+- **Ignoring nano/micro** — a portfolio of small, aligned creators usually beats one big name at the same budget.
+
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md).
+
+| Tool | Best for | Guide |
+|------|----------|-------|
+| **SparkToro** | Audience intelligence — where your ICP actually pays attention, and vetting a creator's real audience | [sparktoro.md](../../tools/integrations/sparktoro.md) |
+
+Dedicated creator-discovery/CRM platforms (e.g., Modash, GRIN, Aspire, Upfluence) and creator-sponsorship marketplaces (e.g., Passionfroot) are the category to reach for at scale; add the specific one to the registry when the user adopts it. For pulling a specific creator's recent posts to vet them, use `social-fetch`; for analyzing their content style, `watch-video`.
+
+## Related Skills
+
+- **referrals** — affiliate/commission tracking and payout rails (the performance side of creator deals)
+- **community-marketing** — community-led advocacy and the unpaid advocate program
+- **ad-creative** — repurpose creator content into paid ads (whitelisting); creative review page for sign-off
+- **cold-email** — the creator outreach itself (personalization, deliverability, follow-up)
+- **customer-research** — find existing advocates and ground the talking points
+- **ai-seo** — the branded-search/direct attribution blind spot that hides influencer impact
+- **social** — organic content strategy the partnerships plug into

--- a/skills/influencer-marketing/SKILL.md
+++ b/skills/influencer-marketing/SKILL.md
@@ -80,12 +80,12 @@ Put it in a simple written agreement: deliverables, timing, usage rights, exclus
 
 ## 4. Disclosure & Compliance (non-negotiable)
 
-Influencer marketing has hard legal requirements — this is the part most brands under-do, and the brand is liable, not just the creator.
+Influencer marketing has hard legal requirements — this is the part most brands under-do, and the brand — not just the creator — can be held liable.
 
 - **Any material connection must be disclosed** — payment, free product, commission, a family/employee relationship, even a free trial. Gifting is *not* a loophole; a gifted post still needs disclosure.
 - **The disclosure must be clear and hard to miss** — "#ad" or "#sponsored" placed where viewers actually see it (not buried in a wall of hashtags, not below the "more" fold, and spoken aloud in video/audio, not just in the description). "#sp," "#collab," "#ambassador," and "thanks to [brand]" are considered insufficient on their own by the FTC.
 - **Use the platform's own tool** — Instagram/TikTok/YouTube "paid partnership" labels *in addition to* the written disclosure, not instead of it.
-- **You're responsible for your creators.** Build the disclosure requirement into the brief and the agreement, and check that they actually did it. Non-disclosure is a brand risk (FTC actions target advertisers).
+- **You're responsible for your creators.** Build the disclosure requirement into the brief and the agreement, and check that they actually did it. Non-disclosure exposes the brand to liability, not just the creator — the FTC expects advertisers to have a program to guide, monitor, and remediate disclosure (FTC actions target advertisers).
 - **No fabricated claims.** Creators can't say things about the product that aren't true, can't fake results, and can't imply they're a customer if they aren't. Give them what's true and let them speak it in their voice.
 - **International + platform rules vary** (e.g., stricter regimes in the UK/EU, category rules for health/finance/alcohol). When the campaign is regulated or cross-border, route to legal.
 

--- a/skills/influencer-marketing/SKILL.md
+++ b/skills/influencer-marketing/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 You are an expert in influencer, creator, and ambassador marketing across B2C (Instagram, TikTok, YouTube) and B2B (LinkedIn, X, newsletters, niche podcasts). Your goal is to help the user pick the right partners, structure fair deals, keep the program compliant, and measure real ROI — not vanity reach.
 
-> Foundation contributed by @Adi29102000-s; expanded to the repo's standard.
+> Foundation contributed by @Adi29102000-s; compensation benchmarks and run-of-show checklist adapted from @SamSon75's PR; expanded to the repo's standard.
 
 ## Before Starting
 
@@ -69,6 +69,19 @@ Move beyond "pay for a post."
 - **Gifting / seeding** — free product, no obligation. Works for physical DTC with nano/micro at volume; expect a low but authentic post rate.
 
 **Rate reality:** published "rates" are wildly variable by niche, geography, and platform, and creators quote high. Treat any benchmark as a *range to negotiate from*, not a price — and anchor on **cost per qualified outcome** (CPA, cost per qualified follower/lead), not cost per post. A cheap post to the wrong audience is the expensive one.
+
+**Starting ranges for a single post** (negotiation anchors, *not* fixed prices — aligned to the tiers above):
+
+| Tier | Single post (rough range) | Notes |
+|---|---|---|
+| **Nano** (1k–10k) | Free product – $100 | Often product-only |
+| **Micro** (10k–50k) | $100 – $1,500 | Widest range; negotiate on engagement, not follower count |
+| **Mid** (50k–500k) | $1,500 – $10,000 | Rate cards common at this tier |
+| **Macro / celebrity** (500k+) | $10,000 – $30,000+ | Usually has an agent/manager |
+| **Video / long-form** (YouTube) | Higher than short-form at the same follower count | More production effort |
+| **B2B thought leader** | Priced on audience quality, not size | A 5k-follower niche voice can command more than a 200k generalist |
+
+Ask for their **rate card first** — it sets an anchor you respond to rather than naming a number blind.
 
 **Deliverables to negotiate:**
 - **Content usage rights (crucial)** — the right to repurpose their content as **paid ads** (whitelisting / dark posting / "creator ads") for a defined window (commonly 3–6 months). This is often the highest-ROI clause: their content becomes your best-performing ad. Then run it through **ad-creative** (and present variations for sign-off with the creative review page).
@@ -138,6 +151,30 @@ For the community-led, unpaid advocate end of this (badges, recognition, communi
 - **One-and-done** — the second post from the same creator usually outperforms the first (their audience has seen you before); build relationships, not transactions.
 - **Judging on EMV / reach** — measure cost per qualified outcome.
 - **Ignoring nano/micro** — a portfolio of small, aligned creators usually beats one big name at the same budget.
+
+## Run-of-Show Checklist
+
+### Sourcing
+- [ ] Define the ICP overlap you're looking for, not just follower count
+- [ ] Shortlist 10–20 creators across at least two tiers (weight toward micro + nano)
+- [ ] Check engagement rate and comment quality for each; run the fake-follower check
+
+### Outreach & Deal
+- [ ] Personalize outreach with a specific reference to their content
+- [ ] Agree deliverables, timeline, and compensation type in writing
+- [ ] Lock **usage rights** (paid-ad whitelisting window) and exclusivity terms
+- [ ] Put the disclosure requirement in the agreement
+
+### Execution
+- [ ] Send a brief with the "why," 2–3 talking points, the CTA, and what to avoid
+- [ ] Set up tracking (unique code, UTM, or vanity URL) *before* content goes live
+- [ ] Review the draft if you have approval rights — without over-scripting
+- [ ] Confirm the disclosure actually shipped where viewers can see it
+
+### Post-Campaign
+- [ ] Pull performance against the goal set upfront (cost per qualified outcome)
+- [ ] Share results with the creator — it builds the relationship
+- [ ] Decide: one-off, repeat, or move to a retainer / ambassador program
 
 ## Tool Integrations
 

--- a/skills/influencer-marketing/evals/evals.json
+++ b/skills/influencer-marketing/evals/evals.json
@@ -1,0 +1,76 @@
+{
+  "skill_name": "influencer-marketing",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want to sponsor a big YouTuber with 1M subs. Should we just pay their flat rate?",
+      "expected_output": "Should advise against just paying a flat rate without negotiation. Should recommend the hybrid compensation model (lower flat fee + performance upside). Should explicitly recommend negotiating content usage rights (whitelisting/dark posting) so the video can be repurposed as a paid ad. Should warn that macro-influencers have lower conversion rates per follower and suggest that a portfolio of micro/nano creators may out-convert one macro placement at the same budget. Should require FTC disclosure in the deal.",
+      "assertions": [
+        "Recommends hybrid compensation model over a bare flat fee",
+        "Highlights securing content usage rights / whitelisting",
+        "Warns about macro-influencer conversion rates and suggests micro/nano portfolio",
+        "Requires clear FTC disclosure"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "How do we make sure we can track ROI from podcast sponsorships?",
+      "expected_output": "Should recommend multiple attribution methods set up before launch. Must mention unique promo codes (critical for audio where links aren't clickable). Should suggest dedicated vanity URLs / landing pages and UTM links. Should recommend a post-purchase 'how did you hear about us?' survey to catch the halo/branded-search effect that direct attribution misses. Should steer judging on cost per qualified outcome rather than reach or EMV.",
+      "assertions": [
+        "Recommends unique promo codes",
+        "Recommends vanity URLs / dedicated landing pages and UTMs",
+        "Recommends a post-purchase survey for the attribution blind spot",
+        "Judges ROI on cost per qualified outcome, not reach/EMV"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We're just gifting free product to creators — no payment — so we don't need them to say #ad, right?",
+      "expected_output": "Should correct the misconception firmly: gifting is a material connection and a gifted post STILL requires clear disclosure. Should explain the disclosure must be clear and conspicuous (visible placement, spoken in video/audio, not buried in hashtags), that platform 'paid partnership' labels are in addition to not instead of it, and that the brand — not just the creator — is liable for non-disclosure. Should recommend building the disclosure requirement into the brief and agreement and verifying it happened.",
+      "assertions": [
+        "States gifting still requires disclosure (not a loophole)",
+        "Describes clear-and-conspicuous placement (not buried in hashtags; spoken in video)",
+        "Notes brand liability for creator non-disclosure",
+        "Recommends putting disclosure in the brief/agreement and verifying it"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "I want to build a long-term brand ambassador program for our DTC skincare brand, not just one-off posts.",
+      "expected_output": "Should apply the ambassador-program design (the sustained end of the spectrum): define a light, sustainable ask; build a benefits ladder that scales with contribution (early access, product, commission, recognition); recruit from evidence (existing unprompted advocates found via reviews/community) with a personal 1:1 ask rather than a form; equip ambassadors with links, assets, talking points, disclosure requirement, and a private channel; activate on a monthly cadence; and track attributed results per ambassador (codes + links), doubling down on top performers. Should cross-reference referrals for affiliate payout rails and community-marketing for the community-led/unpaid end, and require disclosure.",
+      "assertions": [
+        "Applies structured ambassador-program design (ask, benefits ladder, recruit, equip, activate, track)",
+        "Recruits from existing advocates with a personal ask, not a mass form",
+        "Sets up per-ambassador attribution and iterates on top performers",
+        "Cross-references referrals (payout) and/or community-marketing (community advocacy)"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "This creator has 500k followers but I'm worried some are fake. How do I vet them before we pay?",
+      "expected_output": "Should focus vetting on audience quality and fit over follower count: check engagement rate relative to followers (flagging suspiciously low or padded engagement, comment pods, generic comments, sudden follower spikes), assess whether their audience matches the ICP (not just size), review sponsored-content track record (do their ads still get engagement), and scroll recent content for brand safety. Should note media kits overstate and suggest audience-intelligence tooling (e.g., SparkToro) and pulling their recent posts (social-fetch) to inspect real engagement. Should frame audience alignment as more important than reach.",
+      "assertions": [
+        "Prioritizes engagement quality + audience fit over follower count",
+        "Flags fake-follower / engagement-pod signals to check",
+        "Checks sponsored-content track record and brand safety",
+        "Suggests audience-intelligence tooling / inspecting real recent posts"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Write me a word-for-word script for the influencer to read.",
+      "expected_output": "Should push back on word-for-word scripting (it kills the authenticity being paid for and converts worst) and instead provide a creative brief: the one-sentence 'why,' 2-3 key talking points max, the exact CTA (vanity link / promo code), guardrails (what not to say, disclosure requirement, brand redlines), and explicit creative freedom to integrate it in their own style. Talking points must be grounded in real proof, not invented claims.",
+      "assertions": [
+        "Declines to script word-for-word and explains why",
+        "Provides a brief structure (why, 2-3 talking points, CTA, guardrails, creative freedom)",
+        "Includes the disclosure requirement and grounded (non-fabricated) talking points"
+      ],
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New **`influencer-marketing`** skill — influencer, creator, and ambassador partnerships end to end. Closes #462. Repo release **2.9.0** (new skill = y-bump; total skills 48).

**Provenance:** the foundation was contributed by **@Adi29102000-s** in PR #417 (a bundle of four skills targeting `main`). Per direction, we took *only* the influencer-marketing skill, expanded it to house standard, and ship it standalone through the normal workflow — the other three proposed skills are not included, and #417 is not merged.

**What's covered:**
- **The influencer ↔ ambassador spectrum** — paid influencer → affiliate creator → gifting → long-term ambassador program → organic advocate, each with when-to-use and skill handoffs
- Finding & vetting (audience-alignment test, creator tiers incl. B2B thought leaders, engagement/fake-follower/brand-safety checks)
- 1:1 outreach (→ cold-email), deal structuring (flat/CPA/hybrid/gifting, rate-as-a-range, and the high-ROI content-usage-rights/whitelisting clause → ad-creative)
- **A full FTC disclosure & compliance section** — material-connection disclosure, clear-and-conspicuous placement, gifting-still-needs-disclosure, platform labels, brand liability, no fabricated claims (this was absent from the original contribution)
- The creative brief (don't script; grounded talking points), measurement & ROI (promo codes, UTMs, vanity URLs, post-purchase survey for the attribution blind spot, cost-per-qualified-outcome over EMV/reach)
- **Structured ambassador-program design** (ask → benefits ladder → recruit-from-evidence → equip → activate → track), cross-referencing community-marketing and referrals
- Six-eval suite

## Review

Codex review: **SHIP.** FTC accuracy verified against 16 CFR Part 255 + FTC guidance (gifting-needs-disclosure, clear-and-conspicuous placement, insufficient tags, platform-labels-not-alone all confirmed correct); all relative links resolve; frontmatter valid (name matches dir, desc 758 chars); the ambassador/affiliate boundaries with community-marketing and referrals are clean. One low-severity precision nit applied — "the brand is liable" → the more exact "can be held liable / expected to monitor."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
