### PR TITLE
release: v2.8.12 — product-marketing context version history

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.8.11",
+    "version": "2.8.12",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.8.11",
+  "version": "2.8.12",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -37,7 +37,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
 | pricing | 2.0.1 | 2026-06-16 |
-| product-marketing | 2.0.0 | 2026-05-05 |
+| product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
 | public-relations | 1.0.0 | 2026-06-10 |
@@ -53,6 +53,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.8.12 (2026-07-16)
+
+- **product-marketing** (2.0.0 → 2.1.0): the context document now carries its own **version history**. `.agents/product-marketing.md` gets a `Document version:` header (v1, v2 …) and a `## Changelog` section at the bottom — a newest-first, dated, one-line-per-revision paper trail of *what changed and why*. The update flow now reads the current version and recent changelog on open, and on save bumps the version, updates `Last updated`, and prepends a new changelog entry naming the sections touched and the reason (never rewriting past entries; skipped only for pure typo fixes). Since this doc is the shared context every other marketing skill reads, the changelog makes positioning/ICP changes traceable across a project — you can see how the positioning evolved and what a downstream skill was generating against. New eval (id 7) covers the version-bump + prepend-changelog behavior on a repositioning update.
 
 ### 2.8.11 (2026-07-14)
 

--- a/skills/product-marketing/SKILL.md
+++ b/skills/product-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: product-marketing
 description: "When the user wants to create or update their product marketing context document. Also use when the user mentions 'product context,' 'marketing context,' 'set up context,' 'positioning,' 'who is my target audience,' 'describe my product,' 'ICP,' 'ideal customer profile,' or wants to avoid repeating foundational information across marketing tasks. Use this at the start of any new project before using other marketing skills — it creates `.agents/product-marketing.md` that all other skills reference for product, audience, and positioning context."
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Product Marketing Context
@@ -18,9 +18,10 @@ The document is stored at `.agents/product-marketing.md`.
 First, check if `.agents/product-marketing.md` already exists. Also check `.claude/product-marketing.md` and the legacy filename `product-marketing-context.md` (in either `.agents/` or `.claude/`) for older setups — if found anywhere other than `.agents/product-marketing.md`, offer to move it to the canonical location.
 
 **If it exists:**
-- Read it and summarize what's captured
+- Read it and summarize what's captured — note its current **Document version** and the last few **Changelog** entries so the user sees where the doc stands and what's changed recently
 - Ask which sections they want to update
 - Only gather info for those sections
+- On any substantive save, bump the version and add a changelog entry (see Step 4). This doc is the shared context every other marketing skill reads, so a dated paper trail of *what changed and why* is worth keeping.
 
 **If it doesn't exist, offer two options:**
 
@@ -133,7 +134,8 @@ After gathering information, create `.agents/product-marketing.md` with this str
 ```markdown
 # Product Marketing Context
 
-*Last updated: [date]*
+**Document version:** v1
+**Last updated:** [date]
 
 ## Product Overview
 **One-liner:**
@@ -219,16 +221,28 @@ After gathering information, create `.agents/product-marketing.md` with this str
 **Business goal:**
 **Conversion action:**
 **Current metrics:**
+
+## Changelog
+*Newest first. One line per revision: what changed and why.*
+- v1 ([date]) — Initial context.
 ```
 
 ---
 
-## Step 4: Confirm and Save
+## Step 4: Confirm, Version, and Save
 
 - Show the completed document
 - Ask if anything needs adjustment
+- **Set the version and changelog** — this is the paper trail for a doc every other skill reads:
+  - **New document:** set `Document version: v1` and a single Changelog entry — `- v1 ([today]) — Initial context.`
+  - **Updating an existing document:** increment the version (v2 → v3 …), update `Last updated` to today, and **prepend a new Changelog entry** at the top of the list (newest first) summarizing *what changed and why* in one line. Never rewrite or reorder past entries.
+  - A good entry names the sections touched and the reason, not "updated the doc." Examples:
+    - `- v3 (2026-07-16) — Repositioned from "email tool" to "deliverability platform"; added RevOps to the ICP.`
+    - `- v2 (2026-06-02) — Rewrote value prop and objections after 5 customer interviews; added competitor Acme.`
+  - Use today's date in ISO form (YYYY-MM-DD) for the entry and `Last updated`.
+  - **Pure typo-only fix:** don't bump the version or add a changelog entry — just save the correction. Every other change bumps the version and gets an entry. When the change is a real repositioning, say so plainly — downstream skills will now generate against the new context.
 - Save to `.agents/product-marketing.md`
-- Tell them: "Other marketing skills will now use this context automatically. Run `/product-marketing` anytime to update it."
+- Tell them: "Other marketing skills will now use this context automatically. The Changelog at the bottom tracks every revision — check it to see how your positioning has evolved. Run `/product-marketing` anytime to update it."
 
 ---
 

--- a/skills/product-marketing/evals/evals.json
+++ b/skills/product-marketing/evals/evals.json
@@ -80,6 +80,19 @@
         "Does not attempt to write homepage copy using context creation patterns"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We just repositioned — we're no longer an 'email tool,' we're a 'deliverability platform,' and our ICP now includes RevOps teams. Update our product marketing context.",
+      "expected_output": "Should recognize an existing .agents/product-marketing.md, read it, note its current Document version and recent Changelog entries, and update only the affected sections (product overview/positioning, target audience/ICP). On save, should bump the Document version (e.g. v2 → v3), update the Last updated date, and PREPEND a new newest-first Changelog entry summarizing what changed and why in one line — e.g. 'Repositioned from email tool to deliverability platform; added RevOps to the ICP' — naming the sections touched and the reason, not just 'updated the doc.' Should not rewrite or reorder past changelog entries. Should tell the user the changelog tracks revisions and that downstream skills will now use the new context.",
+      "assertions": [
+        "Reads the existing doc and surfaces its current version + recent changelog",
+        "Updates only the affected sections (positioning + ICP)",
+        "Bumps the Document version and updates Last updated",
+        "Prepends a newest-first changelog entry naming what changed and why",
+        "Preserves prior changelog entries unchanged"
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
## Release v2.8.12

One z-release since v2.8.11:

- **2.8.12 — product-marketing 2.1.0** (#466): version history for the shared context document. `.agents/product-marketing.md` now carries a `Document version:` header + a newest-first `## Changelog` section; the update flow reads the version/recent changelog on open and, on any substantive save, bumps the version and prepends an entry naming what changed and why (typo fixes skip both, never rewrites past entries). Makes positioning/ICP changes traceable across a project since every skill reads this doc. New eval. Codex-reviewed.

plugin.json / marketplace.json at 2.8.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
