### PR TITLE
docs: fix broken PR template links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,10 +71,10 @@ skills/your-skill-name/
 2. Create a feature branch (`git checkout -b feature/new-skill-name`)
 3. Make your changes
 4. Test locally with an AI agent
-5. Submit a pull request using the appropriate template:
-   - [New Skill](?template=new-skill.md)
-   - [Skill Update](?template=skill-update.md)
-   - [Documentation](?template=documentation.md)
+5. Submit a pull request using the appropriate template (append `?template=<name>.md` to the PR URL to pre-fill it):
+   - [New Skill](.github/PULL_REQUEST_TEMPLATE/new-skill.md) — `?template=new-skill.md`
+   - [Skill Update](.github/PULL_REQUEST_TEMPLATE/skill-update.md) — `?template=skill-update.md`
+   - [Documentation](.github/PULL_REQUEST_TEMPLATE/documentation.md) — `?template=documentation.md`
 
 ## Skill Quality Checklist
 


### PR DESCRIPTION
## Documentation

## Summary

The three pull-request template links in CONTRIBUTING.md were written as bare `(?template=new-skill.md)` hrefs. When viewed on GitHub, clicking them just reloads CONTRIBUTING.md with a query string appended — they don't lead anywhere.

This PR points each link at the actual template file in `.github/PULL_REQUEST_TEMPLATE/` and adds a short note explaining that appending `?template=<name>.md` to a pull request URL pre-fills it with that template (the originally intended usage).

## Files changed

- `CONTRIBUTING.md` — fixed the three PR template links in the "Submitting Your Contribution" section

## Checklist

- [x] Links are valid
- [x] Formatting is consistent with existing docs
- [x] No sensitive data or credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)