### PR TITLE
fix(readme): correct copywriting typo in skill diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Skills reference each other and build on shared context. The `product-marketing`
 │  SEO &   │ │   CRO    │ │Content & │ │  Paid &    │ │ Growth & │ │  Sales &    │ │ Strategy  │
 │ Content  │ │          │ │   Copy   │ │Measurement │ │Retention │ │    GTM      │ │           │
 ├──────────┤ ├──────────┤ ├──────────┤ ├────────────┤ ├──────────┤ ├─────────────┤ ├───────────┤
-│seo-audit │ │cro       │ │copywritng│ │ads         │ │referrals │ │revops       │ │mktg-ideas │
+│seo-audit │ │cro       │ │copywritin│ │ads         │ │referrals │ │revops       │ │mktg-ideas │
 │ai-seo    │ │signup    │ │copy-edit │ │ad-creative │ │free-tools│ │sales-enable │ │mktg-psych │
 │site-arch │ │onboarding│ │cold-email│ │ab-testing  │ │churn-    │ │launch       │ │customer-  │
 │programm  │ │popups    │ │emails    │ │analytics   │ │ prevent  │ │pricing      │ │ research  │


### PR DESCRIPTION
## Summary
- The Content & Copy column in the skills dependency diagram in README.md truncates "copywriting" to "copywritng" — a middle letter is dropped instead of trimming from the end, unlike every other truncated entry in that box (e.g. copy-edit, lead-magnt).
- Fixed to "copywritin", matching the 10-character column width and the end-trim pattern used elsewhere in the diagram.

## Test plan
- [x] Confirmed the box-drawing alignment still lines up after the change (same character count, no width shift).