### PR TITLE
feat: adapt marketing skills for ChatGPT and Codex

### DIFF
--- a/OPENAI.md
+++ b/OPENAI.md
@@ -1,0 +1,172 @@
+# Uso con ChatGPT y OpenAI Codex
+
+Este fork está preparado para usar las habilidades de marketing en superficies distintas de OpenAI sin depender de Claude Code.
+
+## Diferencia entre ChatGPT y Codex
+
+| Producto | Para qué sirve | Cómo usa las habilidades |
+|---|---|---|
+| ChatGPT | Trabajo conversacional, análisis, creación de contenido y flujos de negocio | Instala Skills desde la interfaz o usa archivos en un Proyecto/GPT personalizado |
+| Codex | Trabajo sobre repositorios, archivos, terminal y código | Descubre Skills instaladas en rutas compatibles y sigue `AGENTS.md` |
+
+Los dos productos pueden usar el estándar `SKILL.md`, pero la instalación y el acceso a herramientas son diferentes.
+
+## 1. ChatGPT con Personal Skills
+
+Cuando tu cuenta o workspace tenga habilitada la función:
+
+1. Abre **Plugins** en la barra lateral.
+2. Entra a **Skills**.
+3. Selecciona **Create**.
+4. Selecciona **Upload from your computer**.
+5. Sube el ZIP de una habilidad.
+6. Revisa el resultado del análisis de seguridad.
+7. Instala la habilidad.
+
+Después, ChatGPT puede activarla automáticamente o puedes seleccionarla explícitamente mediante `@`.
+
+### Crear paquetes subibles
+
+Desde la raíz del repositorio:
+
+```bash
+python tools/package_chatgpt_skills.py --skill emails
+python tools/package_chatgpt_skills.py --skill revops analytics cro
+python tools/package_chatgpt_skills.py --all
+```
+
+La salida se guarda en:
+
+```text
+dist/chatgpt/
+```
+
+Cada ZIP contiene una sola habilidad y coloca `SKILL.md` en la raíz del paquete.
+
+## 2. ChatGPT sin Personal Skills
+
+Cuando no aparezca **Plugins → Skills**, usa un **Proyecto** o un **GPT personalizado**.
+
+### Archivos recomendados
+
+Carga solamente las habilidades necesarias:
+
+```text
+skills/product-marketing/SKILL.md
+skills/revops/SKILL.md
+skills/emails/SKILL.md
+skills/analytics/SKILL.md
+skills/cro/SKILL.md
+skills/copywriting/SKILL.md
+skills/copy-editing/SKILL.md
+skills/customer-research/SKILL.md
+skills/social/SKILL.md
+skills/ads/SKILL.md
+chatgpt/INSTRUCTIONS.md
+```
+
+Añade también tu documento de contexto:
+
+```text
+product-marketing.md
+```
+
+### Configuración del Proyecto o GPT
+
+Usa `chatgpt/INSTRUCTIONS.md` como instrucciones principales. Ese archivo hace que ChatGPT:
+
+- Identifique la habilidad adecuada.
+- Revise el contexto del producto.
+- Combine habilidades cuando la tarea lo requiera.
+- Distinga estrategia de ejecución.
+- Verifique información actual cuando sea necesario.
+- Entregue resultados listos para usar.
+
+### Evita cargar todo sin necesidad
+
+Subir decenas de habilidades a un solo GPT puede reducir la precisión de selección y consumir contexto innecesariamente. Crea conjuntos por uso:
+
+- **CRM y automatización:** `product-marketing`, `revops`, `emails`, `analytics`
+- **Contenido:** `product-marketing`, `copywriting`, `copy-editing`, `social`
+- **Conversión:** `product-marketing`, `cro`, `signup`, `onboarding`, `ab-testing`
+- **Paid media:** `product-marketing`, `ads`, `ad-creative`, `analytics`
+- **Investigación:** `customer-research`, `competitor-profiling`, `competitors`
+
+## 3. OpenAI Codex
+
+### Instalación por proyecto
+
+Ejecuta dentro de la carpeta del proyecto:
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex
+```
+
+### Instalación global
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex -g
+```
+
+### Habilidades específicas
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex \
+  --skill product-marketing revops emails analytics cro
+```
+
+### Uso en Codex
+
+Puedes solicitar:
+
+```text
+Usa las skills product-marketing, revops y analytics para diseñar un modelo de scoring de leads y el plan de medición.
+```
+
+Codex también debe leer el `AGENTS.md` del repositorio antes de modificar archivos.
+
+## 4. `AGENTS.md`, `SKILL.md` e instrucciones de ChatGPT
+
+- `AGENTS.md`: reglas para trabajar dentro del repositorio. Codex lo utiliza como contexto operativo.
+- `skills/<nombre>/SKILL.md`: flujo reutilizable de una especialidad.
+- `chatgpt/INSTRUCTIONS.md`: enrutador para Proyectos y GPTs personalizados.
+- `.agents/product-marketing.md`: contexto reutilizable de marca y producto en proyectos locales.
+- `product-marketing.md`: equivalente recomendado como archivo de conocimiento en ChatGPT.
+
+## 5. Contexto mínimo de producto
+
+El documento de contexto debe incluir:
+
+1. Marca y empresa.
+2. Productos y servicios.
+3. Mercado y ubicación.
+4. Segmentos y perfiles.
+5. Problemas, motivaciones y objeciones.
+6. Propuesta de valor.
+7. Diferenciadores.
+8. Voz y tono.
+9. Canales.
+10. Restricciones.
+11. Métricas objetivo.
+12. Herramientas disponibles.
+
+## 6. Compatibilidad y seguridad
+
+- Mantén las instrucciones compartidas libres de sintaxis exclusiva de un proveedor.
+- No incluyas claves API, contraseñas, tokens ni datos personales en las habilidades.
+- Revisa scripts y archivos antes de subirlos a ChatGPT.
+- Una habilidad no concede acceso automático a Gmail, HubSpot, Google Drive u otras herramientas.
+- El acceso real depende de las apps, conectores y permisos disponibles en la cuenta.
+- No afirmes que una acción fue ejecutada si solo se produjo una recomendación o un borrador.
+
+## 7. Actualizaciones
+
+Para actualizar tu fork desde el proyecto original:
+
+```bash
+git remote add upstream https://github.com/coreyhaines31/marketingskills.git
+git fetch upstream
+git merge upstream/main
+```
+
+Después de actualizar, vuelve a generar los paquetes de ChatGPT.

--- a/README.md
+++ b/README.md
@@ -1,332 +1,301 @@
-# Marketing Skills for AI Agents
+# Marketing Skills for ChatGPT, Codex & AI Agents
 
-A collection of AI agent skills focused on marketing tasks. Built for technical marketers and founders who want AI coding agents to help with conversion optimization, copywriting, SEO, analytics, and growth engineering. Works with Claude Code, OpenAI Codex, Cursor, Windsurf, and any agent that supports the [Agent Skills spec](https://agentskills.io).
+A collection of reusable marketing workflows based on the open Agent Skills standard. This fork is organized **OpenAI-first** for ChatGPT and Codex while preserving compatibility with Claude Code, Cursor, Windsurf, and other compatible agents.
 
-Built by [Corey Haines](https://corey.co?ref=marketingskills). Need hands-on help? Check out [Conversion Factory](https://conversionfactory.co?ref=marketingskills) — Corey's agency for conversion optimization, landing pages, and growth strategy. Want to learn more about marketing? Subscribe to [Swipe Files](https://swipefiles.com?ref=marketingskills). Want to get dangerously good at using AI for marketing? Check out [AI Marketing Training](https://conversionfactory.co/offers/ai-marketing-training?ref=marketingskills). Want an autonomous AI agent that uses these skills to be your CMO? Try [Magister](https://magistermarketing.com?ref=marketingskills).
+Original project by [Corey Haines](https://github.com/coreyhaines31/marketingskills). This fork keeps the original MIT license and attribution.
 
-New to the terminal and coding agents? Check out the companion guide [Coding for Marketers](https://codingformarketers.com?ref=marketingskills).
+## OpenAI quick start
 
-**Contributions welcome!** Found a way to improve a skill or have a new one to add? [Open a PR](#contributing).
+| Surface | Recommended setup |
+|---|---|
+| ChatGPT with Personal Skills | Upload individual skill packages from **Plugins → Skills → Create → Upload from your computer** |
+| ChatGPT without Personal Skills | Use a Project or Custom GPT with selected `SKILL.md` files plus `chatgpt/INSTRUCTIONS.md` |
+| Codex, current project | `npx skills add THEGACCI/marketingskills -a codex` |
+| Codex, all projects | `npx skills add THEGACCI/marketingskills -a codex -g` |
+| Other compatible agents | Install to `.agents/skills/` or use the agent-specific path supported by the Skills CLI |
 
-Run into a problem or have a question? [Open an issue](https://github.com/coreyhaines31/marketingskills/issues) — we're happy to help.
+See [OPENAI.md](OPENAI.md) for the detailed ChatGPT and Codex guide.
+
+## Recommended starter pack for CRM and marketing operations
+
+Install these first instead of loading the entire repository:
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex \
+  --skill product-marketing revops emails analytics cro \
+  copywriting copy-editing customer-research social ads
+```
+
+This set covers:
+
+- Product and audience context
+- CRM lifecycle, lead scoring, routing, and handoff
+- Email and lifecycle automation
+- Analytics and experimentation
+- Conversion optimization
+- Marketing copy and editing
+- Customer research
+- Social content and paid media
 
 ## What are Skills?
 
-Skills are markdown files that give AI agents specialized knowledge and workflows for specific tasks. When you add these to your project, your agent can recognize when you're working on a marketing task and apply the right frameworks and best practices.
+Skills are folders containing a `SKILL.md` file and, optionally, references, scripts, templates, or assets. They teach an AI agent how to execute a repeatable workflow consistently.
 
-## How Skills Work Together
+The repository uses the open Agent Skills structure:
 
-Skills reference each other and build on shared context. The `product-marketing` skill is the foundation — every other skill checks it first to understand your product, audience, and positioning before doing anything.
-
-```
-                            ┌──────────────────────────────────────┐
-                            │          product-marketing           │
-                            │    (read by all other skills first)  │
-                            └──────────────────┬───────────────────┘
-                                               │
-    ┌──────────────┬─────────────┬─────────────┼─────────────┬──────────────┬──────────────┐
-    ▼              ▼             ▼             ▼             ▼              ▼              ▼
-┌──────────┐ ┌──────────┐ ┌──────────┐ ┌────────────┐ ┌──────────┐ ┌─────────────┐ ┌───────────┐
-│  SEO &   │ │   CRO    │ │Content & │ │  Paid &    │ │ Growth & │ │  Sales &    │ │ Strategy  │
-│ Content  │ │          │ │   Copy   │ │Measurement │ │Retention │ │    GTM      │ │           │
-├──────────┤ ├──────────┤ ├──────────┤ ├────────────┤ ├──────────┤ ├─────────────┤ ├───────────┤
-│seo-audit │ │cro       │ │copywritng│ │ads         │ │referrals │ │revops       │ │mktg-ideas │
-│ai-seo    │ │signup    │ │copy-edit │ │ad-creative │ │free-tools│ │sales-enable │ │mktg-psych │
-│site-arch │ │onboarding│ │cold-email│ │ab-testing  │ │churn-    │ │launch       │ │customer-  │
-│programm  │ │popups    │ │emails    │ │analytics   │ │ prevent  │ │pricing      │ │ research  │
-│schema    │ │paywalls  │ │social    │ │            │ │community │ │competitors  │ │           │
-│content   │ │          │ │video     │ │            │ │lead-magnt│ │comp-profile │ │           │
-│aso       │ │          │ │image     │ │            │ │co-mktg   │ │directory    │ │           │
-│          │ │          │ │sms       │ │            │ │          │ │prospecting  │ │           │
-└────┬─────┘ └────┬─────┘ └────┬─────┘ └─────┬──────┘ └────┬─────┘ └──────┬──────┘ └─────┬─────┘
-     │            │            │              │             │              │              │
-     └────────────┴─────┬──────┴──────────────┴─────────────┴──────────────┴──────────────┘
-                        │
-         Skills cross-reference each other:
-           copywriting ↔ cro ↔ ab-testing
-           revops ↔ sales-enablement ↔ cold-email
-           seo-audit ↔ schema ↔ ai-seo
-           customer-research → copywriting, cro, competitors
+```text
+skills/
+└── skill-name/
+    ├── SKILL.md
+    ├── references/
+    ├── scripts/
+    └── assets/
 ```
 
-See each skill's **Related Skills** section for the full dependency map.
+The `product-marketing` skill is the foundation. Other skills should use the product, audience, positioning, and messaging context before producing recommendations or deliverables.
 
-## Available Skills
+## Available skills
 
-<!-- SKILLS:START -->
-| Skill | Description |
-|-------|-------------|
-| [ab-testing](skills/ab-testing/) | When the user wants to plan, design, or implement an A/B test or experiment, or build a growth experimentation program.... |
-| [ad-creative](skills/ad-creative/) | When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad... |
-| [ads](skills/ads/) | When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X,... |
-| [ai-seo](skills/ai-seo/) | When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers.... |
-| [analytics](skills/analytics/) | When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions... |
-| [aso](skills/aso/) | When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO... |
-| [churn-prevention](skills/churn-prevention/) | When the user wants to reduce churn, build cancellation flows, set up save offers, recover failed payments, or... |
-| [co-marketing](skills/co-marketing/) | When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use... |
-| [cold-email](skills/cold-email/) | Write B2B cold emails and follow-up sequences that get replies. Use when the user wants to write cold outreach emails,... |
-| [community-marketing](skills/community-marketing/) | Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a... |
-| [competitor-profiling](skills/competitor-profiling/) | When the user wants to research, profile, or analyze competitors from their URLs. Also use when the user mentions... |
-| [competitors](skills/competitors/) | When the user wants to create competitor comparison or alternative pages for SEO and sales enablement. Also use when... |
-| [content-strategy](skills/content-strategy/) | When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also... |
-| [copy-editing](skills/copy-editing/) | When the user wants to edit, review, or improve existing marketing copy, or refresh outdated content. Also use when the... |
-| [copywriting](skills/copywriting/) | When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages,... |
-| [cro](skills/cro/) | When the user wants to optimize, improve, or increase conversions on any marketing page or form — including homepage,... |
-| [customer-research](skills/customer-research/) | When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer... |
-| [directory-submissions](skills/directory-submissions/) | When the user wants to submit their product to startup, SaaS, AI, agent, MCP, no-code, or review directories for... |
-| [emails](skills/emails/) | When the user wants to create or optimize an email sequence, drip campaign, automated email flow, or lifecycle email... |
-| [free-tools](skills/free-tools/) | When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or... |
-| [image](skills/image/) | When the user wants to create, generate, edit, or optimize images for marketing — blog heroes, social graphics, product... |
-| [launch](skills/launch/) | When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user... |
-| [lead-magnets](skills/lead-magnets/) | When the user wants to create, plan, or optimize a lead magnet for email capture or lead generation. Also use when the... |
-| [marketing-council](skills/marketing-council/) | When the user wants multiple expert perspectives on a marketing question — a simulated board of advisors staffed by... |
-| [marketing-ideas](skills/marketing-ideas/) | When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the... |
-| [marketing-loops](skills/marketing-loops/) | When the user wants to set up a recurring, self-running marketing workflow — a repeatable loop an AI agent runs on a... |
-| [marketing-plan](skills/marketing-plan/) | When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use... |
-| [marketing-psychology](skills/marketing-psychology/) | When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when... |
-| [offers](skills/offers/) | When the user wants to design, construct, or improve an offer — the thing they actually sell — including value framing,... |
-| [onboarding](skills/onboarding/) | When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also... |
-| [paywalls](skills/paywalls/) | When the user wants to create or optimize in-app paywalls, upgrade screens, upsell modals, or feature gates. Also use... |
-| [popups](skills/popups/) | When the user wants to create or optimize popups, modals, overlays, slide-ins, or banners for conversion purposes. Also... |
-| [pricing](skills/pricing/) | When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions... |
-| [product-marketing](skills/product-marketing/) | When the user wants to create or update their product marketing context document. Also use when the user mentions... |
-| [programmatic-seo](skills/programmatic-seo/) | When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions... |
-| [prospecting](skills/prospecting/) | When the user wants to find, qualify, and build a list of prospects to reach out to — across B2B SaaS, general B2B, or... |
-| [public-relations](skills/public-relations/) | When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy... |
-| [referrals](skills/referrals/) | When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy.... |
-| [revops](skills/revops/) | When the user wants help with revenue operations, lead lifecycle management, or marketing-to-sales handoff processes.... |
-| [sales-enablement](skills/sales-enablement/) | When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also... |
-| [schema](skills/schema/) | When the user wants to add, fix, or optimize schema markup and structured data on their site. Also use when the user... |
-| [seo-audit](skills/seo-audit/) | When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO... |
-| [signup](skills/signup/) | When the user wants to optimize signup, registration, account creation, or trial activation flows. Also use when the... |
-| [site-architecture](skills/site-architecture/) | When the user wants to plan, map, or restructure their website's page hierarchy, navigation, URL structure, or internal... |
-| [sms](skills/sms/) | When the user wants to plan, build, or optimize SMS or MMS marketing — including welcome flows, abandoned cart texts,... |
-| [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
-| [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
-<!-- SKILLS:END -->
+### Conversion optimization
+
+- `cro`
+- `signup`
+- `onboarding`
+- `popups`
+- `paywalls`
+- `ab-testing`
+
+### Content and copy
+
+- `copywriting`
+- `copy-editing`
+- `cold-email`
+- `emails`
+- `social`
+- `sms`
+- `video`
+- `image`
+- `content-strategy`
+
+### SEO and discovery
+
+- `seo-audit`
+- `ai-seo`
+- `programmatic-seo`
+- `site-architecture`
+- `competitors`
+- `competitor-profiling`
+- `schema`
+- `aso`
+- `directory-submissions`
+
+### Paid media and measurement
+
+- `ads`
+- `ad-creative`
+- `analytics`
+
+### Growth and retention
+
+- `churn-prevention`
+- `co-marketing`
+- `community-marketing`
+- `free-tools`
+- `lead-magnets`
+- `marketing-loops`
+- `referrals`
+
+### Strategy and monetization
+
+- `product-marketing`
+- `marketing-plan`
+- `marketing-council`
+- `marketing-ideas`
+- `marketing-psychology`
+- `customer-research`
+- `offers`
+- `launch`
+- `pricing`
+
+### Sales and revenue operations
+
+- `revops`
+- `sales-enablement`
+- `prospecting`
+- `public-relations`
 
 ## Installation
 
-### Option 1: CLI Install (Recommended)
+### ChatGPT Web/Desktop
 
-Use [npx skills](https://github.com/vercel-labs/skills) to install skills directly:
+When Personal Skills are enabled for your account or workspace:
+
+1. Open **Plugins** in ChatGPT.
+2. Open the **Skills** tab.
+3. Select **Create**.
+4. Select **Upload from your computer**.
+5. Upload one packaged skill at a time.
+
+Generate ChatGPT-ready ZIP packages:
 
 ```bash
-# Install all skills
-npx skills add coreyhaines31/marketingskills
-
-# Install specific skills
-npx skills add coreyhaines31/marketingskills --skill cro copywriting
-
-# List available skills
-npx skills add coreyhaines31/marketingskills --list
+python tools/package_chatgpt_skills.py --skill emails
+python tools/package_chatgpt_skills.py --skill revops analytics cro
+python tools/package_chatgpt_skills.py --all
 ```
 
-The CLI detects which agents you have installed and asks where to install. For Claude Code it installs into `.claude/skills/`; universal agents share `.agents/skills/`.
+Packages are created in:
 
-> [!TIP]
-> If you run the command from **inside** an agent session (e.g., asking Claude Code to install the skills for you), the CLI runs non-interactively and may only install to the universal `.agents/skills/` directory, which Claude Code does not read. Pass the agent explicitly:
->
-> ```bash
-> npx skills add coreyhaines31/marketingskills -a claude-code
-> ```
-
-### Option 2: Claude Code Plugin
-
-Install via Claude Code's built-in plugin system:
-
-```bash
-# Add the marketplace
-/plugin marketplace add coreyhaines31/marketingskills
-
-# Install all marketing skills
-/plugin install marketing-skills
+```text
+dist/chatgpt/
 ```
 
-### Option 3: Clone and Copy
+When Personal Skills are not available, follow the Project or Custom GPT setup in [OPENAI.md](OPENAI.md).
 
-Clone the entire repo and copy the skills folder:
+### OpenAI Codex
+
+Install all skills in the current project:
 
 ```bash
-git clone https://github.com/coreyhaines31/marketingskills.git
+npx skills add THEGACCI/marketingskills -a codex
+```
+
+Install selected skills:
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex \
+  --skill product-marketing revops emails analytics cro
+```
+
+Install globally:
+
+```bash
+npx skills add THEGACCI/marketingskills -a codex -g
+```
+
+List available skills:
+
+```bash
+npx skills add THEGACCI/marketingskills --list
+```
+
+### Clone and copy
+
+macOS, Linux, or Git Bash:
+
+```bash
+git clone https://github.com/THEGACCI/marketingskills.git
+mkdir -p .agents/skills
 cp -r marketingskills/skills/* .agents/skills/
 ```
 
-### Option 4: Git Submodule
+Windows PowerShell:
 
-Add as a submodule for easy updates:
-
-```bash
-git submodule add https://github.com/coreyhaines31/marketingskills.git .agents/marketingskills
+```powershell
+git clone https://github.com/THEGACCI/marketingskills.git
+New-Item -ItemType Directory -Force ".agents\skills" | Out-Null
+Copy-Item ".\marketingskills\skills\*" ".\.agents\skills\" -Recurse -Force
 ```
 
-Then reference skills from `.agents/marketingskills/skills/`.
+### Claude Code compatibility
 
-### Option 5: Fork and Customize
-
-1. Fork this repository
-2. Customize skills for your specific needs
-3. Clone your fork into your projects
-
-### Option 6: SkillKit (Multi-Agent)
-
-Use [SkillKit](https://github.com/rohitg00/skillkit) to install skills across multiple AI agents (Claude Code, Cursor, Copilot, etc.):
+The original Claude Code plugin files remain available in `.claude-plugin/`.
 
 ```bash
-# Install all skills
-npx skillkit install coreyhaines31/marketingskills
-
-# Install specific skills
-npx skillkit install coreyhaines31/marketingskills --skill cro copywriting
-
-# List available skills
-npx skillkit install coreyhaines31/marketingskills --list
+/plugin marketplace add THEGACCI/marketingskills
+/plugin install marketing-skills
 ```
 
-## Upgrading from v1.x to v2.0
-
-v2.0 renames 17 skills and consolidates `page-cro` + `form-cro` into a single `cro` skill. If you installed the v1.x skills, you'll have **stale old-name folders** in your install directory after upgrading — the new skills install alongside the old ones, so you'll see both `skills/page-cro/` and `skills/cro/`, etc. Clean them up:
-
-```bash
-# From the directory where you installed the skills (e.g., .agents/skills/ or .claude/skills/)
-rm -rf page-cro form-cro \
-       ab-test-setup analytics-tracking aso-audit competitor-alternatives \
-       email-sequence free-tool-strategy launch-strategy onboarding-cro \
-       paid-ads paywall-upgrade-cro popup-cro pricing-strategy \
-       product-marketing-context referral-program schema-markup \
-       signup-flow-cro social-content
-```
-
-Then reinstall the v2.0 skills via your usual method (e.g., `npx skills add coreyhaines31/marketingskills`).
-
-### Migrate the product marketing context file
-
-In v2.0 the context file moved from `.claude/` to `.agents/` and was renamed from `product-marketing-context.md` to `product-marketing.md`. Move your existing context file:
-
-```bash
-mkdir -p .agents
-# v2.0 file (or pre-v2.0 file with new name)
-mv .claude/product-marketing.md .agents/product-marketing.md 2>/dev/null
-# pre-v2.0 file with legacy name
-mv .claude/product-marketing-context.md .agents/product-marketing.md 2>/dev/null
-```
-
-Skills will still check `.claude/` and the legacy `product-marketing-context.md` filename as fallbacks, so nothing breaks if you don't migrate.
-
-### Full rename map
-
-| Old | New |
-|-----|-----|
-| `ab-test-setup` | `ab-testing` |
-| `analytics-tracking` | `analytics` |
-| `aso-audit` | `aso` |
-| `competitor-alternatives` | `competitors` |
-| `email-sequence` | `emails` |
-| `form-cro` | merged into `cro` |
-| `free-tool-strategy` | `free-tools` |
-| `launch-strategy` | `launch` |
-| `onboarding-cro` | `onboarding` |
-| `page-cro` | `cro` |
-| `paid-ads` | `ads` |
-| `paywall-upgrade-cro` | `paywalls` |
-| `popup-cro` | `popups` |
-| `pricing-strategy` | `pricing` |
-| `product-marketing-context` | `product-marketing` |
-| `referral-program` | `referrals` |
-| `schema-markup` | `schema` |
-| `signup-flow-cro` | `signup` |
-| `social-content` | `social` |
+Claude-specific syntax must remain outside the shared `skills/` files so the same skills continue to work with ChatGPT, Codex, and other compatible agents.
 
 ## Usage
 
-Once installed, just ask your agent to help with marketing tasks:
+Ask naturally:
 
-```
-"Help me optimize this landing page for conversions"
-→ Uses cro skill
+```text
+Use the revops skill to design a lead lifecycle and scoring model.
 
-"Write homepage copy for my SaaS"
-→ Uses copywriting skill
+Use the emails skill to create a five-email reactivation flow.
 
-"Set up GA4 tracking for signups"
-→ Uses analytics skill
-
-"Create a 5-email welcome sequence"
-→ Uses emails skill
+Use the cro and analytics skills to audit this landing page and define the events to track.
 ```
 
-You can also invoke skills directly:
+In ChatGPT, installed Skills may activate automatically or can be selected explicitly. In Codex, mention the skill name when you need deterministic routing.
 
+## Product marketing context
+
+Create a reusable product context document before running complex marketing tasks:
+
+```text
+.agents/product-marketing.md
 ```
-/cro
-/emails
-/seo-audit
+
+For ChatGPT Projects or Custom GPTs, upload the same document as knowledge. Include:
+
+- Company and brand
+- Products or services
+- Priority audiences and segments
+- Problems, motivations, and objections
+- Value proposition and positioning
+- Differentiators
+- Voice and tone
+- Available channels
+- Legal, commercial, and brand restrictions
+- Metrics and business goals
+
+## Repository structure
+
+```text
+marketingskills/
+├── .claude-plugin/              # Optional Claude Code compatibility
+├── chatgpt/
+│   └── INSTRUCTIONS.md          # Orchestrator for Projects and Custom GPTs
+├── skills/                      # Portable Agent Skills
+├── tools/
+│   └── package_chatgpt_skills.py
+├── AGENTS.md                    # Codex/repository operating instructions
+├── OPENAI.md                    # ChatGPT and Codex setup guide
+├── CONTRIBUTING.md
+└── README.md
 ```
 
-## Skill Categories
+## Validation
 
-### Conversion Optimization
-- `cro` - Pages and forms
-- `signup` - Registration flows
-- `onboarding` - Post-signup activation
-- `popups` - Modals and overlays
-- `paywalls` - In-app upgrade moments
+Validate and package one skill:
 
-### Content & Copy
-- `copywriting` - Marketing page copy
-- `copy-editing` - Edit and polish existing copy
-- `cold-email` - B2B cold outreach emails and sequences
-- `emails` - Automated email flows
-- `social` - Social media content
-- `image` - AI image generation, design tools, and optimization
+```bash
+python tools/package_chatgpt_skills.py --skill emails
+```
 
-### SEO & Discovery
-- `seo-audit` - Technical and on-page SEO
-- `ai-seo` - AI search optimization (AEO, GEO, LLMO)
-- `programmatic-seo` - Scaled page generation
-- `site-architecture` - Page hierarchy, navigation, URL structure
-- `competitors` - Comparison and alternative pages
-- `schema` - Structured data
+The script verifies:
 
-### Paid & Distribution
-- `ads` - Google, Meta, LinkedIn ad campaigns
-- `ad-creative` - Bulk ad creative generation and iteration
-- `social` - Social media scheduling and strategy
+- `SKILL.md` exists
+- YAML frontmatter is present
+- `name` exists and matches the directory
+- `description` exists
+- The archive contains `SKILL.md` at its root
 
-### Measurement & Testing
-- `analytics` - Event tracking setup
-- `ab-testing` - Experiment design
+## Syncing with the original repository
 
-### Retention
-- `churn-prevention` - Cancel flows, save offers, dunning, payment recovery
+Add the original repository as an upstream remote:
 
-### Growth Engineering
-- `co-marketing` - Partner identification and joint campaigns
-- `free-tools` - Marketing tools and calculators
-- `referrals` - Referral and affiliate programs
+```bash
+git remote add upstream https://github.com/coreyhaines31/marketingskills.git
+git fetch upstream
+git merge upstream/main
+```
 
-### Strategy & Monetization
-- `marketing-ideas` - 140 SaaS marketing ideas
-- `marketing-psychology` - Mental models and psychology
-- `launch` - Product launches and announcements
-- `pricing` - Pricing, packaging, and monetization
-
-### Sales & RevOps
-- `revops` - Lead lifecycle, scoring, routing, pipeline management
-- `sales-enablement` - Sales decks, one-pagers, objection docs, demo scripts
+Review conflicts carefully in `README.md`, `OPENAI.md`, `chatgpt/`, and `tools/package_chatgpt_skills.py`.
 
 ## Contributing
 
-Found a way to improve a skill? Have a new skill to suggest? PRs and issues welcome!
+Keep shared skills portable:
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on adding or improving skills.
+- Do not add vendor-specific command syntax to `skills/*/SKILL.md`.
+- Keep tool-specific integration instructions in dedicated platform documentation.
+- Use `.agents/` as the cross-agent project context location.
+- Preserve the original license and attribution.
 
 ## License
 
-[MIT](LICENSE) - Use these however you want.
-
-<br />
-<br />
-<a href="https://vercel.com/open-source-program">
-  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
-</a>
+[MIT](LICENSE)

--- a/chatgpt/INSTRUCTIONS.md
+++ b/chatgpt/INSTRUCTIONS.md
@@ -1,0 +1,136 @@
+# Instrucciones para ChatGPT: Marketing Skills Orchestrator
+
+## Objetivo
+
+Actúa como un orquestador de habilidades de marketing. Selecciona y aplica los archivos `SKILL.md` relevantes para resolver la solicitud del usuario con precisión, consistencia y resultados utilizables.
+
+## Selección de habilidades
+
+1. Identifica el resultado que el usuario necesita.
+2. Localiza la habilidad cuyo `name` y `description` coincidan mejor.
+3. Usa `product-marketing` primero cuando la tarea dependa de producto, audiencia, posicionamiento, marca o propuesta de valor.
+4. Combina habilidades solamente cuando cada una aporte una función distinta.
+5. No menciones una habilidad que no hayas aplicado realmente.
+6. Cuando dos habilidades se superpongan, usa la más específica como principal.
+
+Ejemplos:
+
+- Lifecycle, scoring, routing o handoff: `revops`
+- Secuencias y automatizaciones de email: `emails`
+- Copy de landing page: `copywriting`
+- Revisión de copy existente: `copy-editing`
+- Conversión de páginas o formularios: `cro`
+- Eventos, UTMs, GA4 o medición: `analytics`
+- Campañas pagadas: `ads`
+- Variaciones masivas de anuncios: `ad-creative`
+- Investigación de usuarios: `customer-research`
+- Comparación estratégica de competidores: `competitor-profiling`
+- Páginas de comparación SEO: `competitors`
+
+## Contexto
+
+Antes de producir una estrategia o pieza importante:
+
+1. Revisa `product-marketing.md` cuando esté disponible.
+2. Reutiliza hechos confirmados del contexto.
+3. No inventes productos, precios, métricas, capacidades, audiencias ni resultados.
+4. Marca claramente cualquier supuesto.
+5. Haz una sola pregunta de alto impacto únicamente cuando falte información indispensable. En los demás casos, avanza con supuestos explícitos.
+
+## Información actual
+
+Cuando la respuesta dependa de información que pueda cambiar:
+
+1. Investiga fuentes actuales.
+2. Prioriza documentación oficial y fuentes primarias.
+3. Compara la fecha de publicación con la fecha real del evento o cambio.
+4. Cita las afirmaciones relevantes.
+5. No presentes datos antiguos como actuales.
+6. Si no tienes acceso a navegación o herramientas, dilo y limita la conclusión.
+
+## Uso de herramientas y conectores
+
+1. Usa herramientas conectadas solamente cuando estén disponibles y sean necesarias.
+2. No afirmes acceso a una cuenta o sistema que no esté conectado.
+3. Antes de ejecutar una acción externa, verifica destinatarios, alcance y datos críticos.
+4. Distingue claramente entre:
+   - Estrategia propuesta
+   - Configuración recomendada
+   - Borrador generado
+   - Acción realmente ejecutada
+5. No expongas claves, tokens ni secretos.
+
+## Proceso general
+
+1. Define el objetivo de negocio.
+2. Identifica la audiencia o segmento.
+3. Revisa el contexto disponible.
+4. Selecciona la habilidad o combinación mínima.
+5. Ejecuta el flujo indicado en cada `SKILL.md`.
+6. Adapta el resultado al canal solicitado.
+7. Incluye medición, riesgos o próximos pasos cuando sean parte natural del trabajo.
+8. Ejecuta una revisión final antes de responder.
+
+## Reglas para CRM y automatización
+
+Cuando la solicitud sea sobre CRM, lifecycle o automatización, separa la respuesta en:
+
+1. Objetivo
+2. Segmento o criterio de entrada
+3. Datos y propiedades necesarias
+4. Disparador
+5. Condiciones y exclusiones
+6. Acciones
+7. Frecuencia o ventanas de espera
+8. Salidas y sincronización
+9. Métricas
+10. Riesgos, consentimiento y control de presión comercial
+
+No propongas automatizaciones sin definir cómo evitar duplicados, reingresos incorrectos, mensajes excesivos o conflictos de propiedad.
+
+## Reglas para copy
+
+Cuando el usuario pida una pieza terminada:
+
+1. Respeta el canal: email, WhatsApp, SMS, landing page, anuncio o red social.
+2. Mantén datos, fechas, ubicaciones, enlaces y condiciones sin alterarlos.
+3. Ajusta longitud y formato al canal.
+4. Evita lenguaje genérico, exagerado o no demostrable.
+5. Entrega primero la versión lista para usar.
+6. Añade explicación solo cuando aporte valor.
+
+## Reglas para análisis y auditorías
+
+1. Separa hechos observados de hipótesis.
+2. Prioriza problemas por impacto y esfuerzo.
+3. Incluye evidencia.
+4. Propón acciones concretas.
+5. Define cómo medir el cambio.
+6. No declares causalidad sin datos suficientes.
+
+## Formato de salida
+
+Usa la estructura más útil para la tarea. Evita plantillas rígidas cuando no aporten valor.
+
+Para planes complejos, incluye:
+
+- Recomendación
+- Fundamento
+- Implementación
+- Medición
+- Riesgos o dependencias
+
+Para piezas de comunicación, entrega texto listo para copiar.
+
+## Control de calidad
+
+Antes de finalizar, verifica:
+
+- ¿Se aplicó la habilidad correcta?
+- ¿Se usó el contexto de producto?
+- ¿Los datos están confirmados?
+- ¿Los supuestos están marcados?
+- ¿El resultado cumple el canal y formato?
+- ¿Las acciones son ejecutables?
+- ¿Las métricas corresponden al objetivo?
+- ¿Se evitó afirmar que algo fue ejecutado sin evidencia?

--- a/tools/package_chatgpt_skills.py
+++ b/tools/package_chatgpt_skills.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate and package Agent Skills for ChatGPT upload.
+
+Each generated ZIP contains one skill and places SKILL.md at the archive root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Iterable
+
+
+IGNORED_NAMES = {
+    ".DS_Store",
+    "Thumbs.db",
+}
+
+IGNORED_PARTS = {
+    "__pycache__",
+    ".git",
+}
+
+
+class SkillValidationError(ValueError):
+    """Raised when a skill does not satisfy the minimum package rules."""
+
+
+def parse_frontmatter(skill_md: Path) -> dict[str, str]:
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise SkillValidationError(f"{skill_md}: missing YAML frontmatter")
+
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise SkillValidationError(f"{skill_md}: incomplete YAML frontmatter")
+
+    values: dict[str, str] = {}
+    for raw_line in parts[1].splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+
+    return values
+
+
+def validate_skill(skill_dir: Path) -> None:
+    if not skill_dir.is_dir():
+        raise SkillValidationError(f"Skill directory not found: {skill_dir}")
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        raise SkillValidationError(f"{skill_dir.name}: SKILL.md not found")
+
+    frontmatter = parse_frontmatter(skill_md)
+    name = frontmatter.get("name", "")
+    description = frontmatter.get("description", "")
+
+    if not name:
+        raise SkillValidationError(f"{skill_dir.name}: frontmatter name is required")
+    if name != skill_dir.name:
+        raise SkillValidationError(
+            f"{skill_dir.name}: frontmatter name must match the directory; found {name!r}"
+        )
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", name):
+        raise SkillValidationError(
+            f"{skill_dir.name}: name must use lowercase letters, numbers, and hyphens"
+        )
+    if not description:
+        raise SkillValidationError(
+            f"{skill_dir.name}: frontmatter description is required"
+        )
+    if len(description) > 1024:
+        raise SkillValidationError(
+            f"{skill_dir.name}: description exceeds 1024 characters"
+        )
+
+
+def should_include(path: Path) -> bool:
+    if path.name in IGNORED_NAMES:
+        return False
+    if any(part in IGNORED_PARTS for part in path.parts):
+        return False
+    return not path.is_symlink()
+
+
+def iter_skill_files(skill_dir: Path) -> Iterable[Path]:
+    for path in sorted(skill_dir.rglob("*")):
+        if path.is_file() and should_include(path.relative_to(skill_dir)):
+            yield path
+
+
+def package_skill(skill_dir: Path, output_dir: Path) -> Path:
+    validate_skill(skill_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / f"{skill_dir.name}.zip"
+
+    files = list(iter_skill_files(skill_dir))
+    if not files:
+        raise SkillValidationError(f"{skill_dir.name}: no packageable files found")
+
+    with zipfile.ZipFile(
+        destination,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+    ) as archive:
+        for source in files:
+            archive.write(source, arcname=source.relative_to(skill_dir).as_posix())
+
+    with zipfile.ZipFile(destination, mode="r") as archive:
+        names = set(archive.namelist())
+        if "SKILL.md" not in names:
+            raise SkillValidationError(
+                f"{skill_dir.name}: generated archive is missing root SKILL.md"
+            )
+
+    return destination
+
+
+def discover_skills(skills_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in skills_dir.iterdir()
+        if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate and package Agent Skills for ChatGPT upload."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--skill",
+        nargs="+",
+        metavar="NAME",
+        help="One or more skill directory names to package.",
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Package every valid skill in the repository.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output directory. Default: dist/chatgpt",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    skills_dir = repo_root / "skills"
+    output_dir = args.output or (repo_root / "dist" / "chatgpt")
+
+    if not skills_dir.is_dir():
+        print(f"error: skills directory not found: {skills_dir}", file=sys.stderr)
+        return 2
+
+    if args.all:
+        targets = discover_skills(skills_dir)
+    else:
+        targets = [skills_dir / name for name in args.skill]
+
+    if not targets:
+        print("error: no skills found", file=sys.stderr)
+        return 2
+
+    created: list[Path] = []
+    errors: list[str] = []
+
+    for skill_dir in targets:
+        try:
+            destination = package_skill(skill_dir, output_dir)
+            created.append(destination)
+            print(f"created: {destination.relative_to(repo_root)}")
+        except (OSError, SkillValidationError, zipfile.BadZipFile) as exc:
+            errors.append(str(exc))
+            print(f"error: {exc}", file=sys.stderr)
+
+    print(f"\nPackaged {len(created)} skill(s).")
+    if errors:
+        print(f"Failed {len(errors)} skill(s).", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Cambios

- Adapta la documentación para ChatGPT y OpenAI Codex.
- Añade una guía específica de instalación y uso con OpenAI.
- Añade instrucciones para Proyectos y GPTs personalizados.
- Añade un script para validar y empaquetar cada skill como ZIP.
- Conserva la compatibilidad con Claude Code y otros agentes.