### PR TITLE
Fix garbled typo in SaaS prospecting guide

### DIFF
--- a/skills/prospecting/references/saas-prospecting.md
+++ b/skills/prospecting/references/saas-prospecting.md
@@ -119,5 +119,5 @@ Each top target gets a one-sentence outreach rationale that names the specific s
 1. **Buying lists from Apollo wholesale** without re-verifying email and re-checking firmographics. Stale data is the norm.
 2. **Treating tech stack data as 100% accurate**. BuiltWith and Wappalyzer miss things; Clay's waterfalls miss things. Cross-check.
 3. **Targeting Series C+ for early-stage SaaS sellers**. The buyer profile is wrong — too many procurement hoops, too much red tape.
-4. **Targeting Series Pre-Seed seed** for products requiring meaningful budget. They have neither budget nor evaluator bandwidth.
+4. **Targeting Pre-Seed/Seed** for products requiring meaningful budget. They have neither budget nor evaluator bandwidth.
 5. **Ignoring intent data when it exists** (ZoomInfo Intent, 6sense, etc.) — pre-warm signals beat cold every time.


### PR DESCRIPTION
## Summary
- Item 4 in the "Common Mistakes (SaaS)" list read **"Targeting Series Pre-Seed seed"**, a garbled duplicate. Fixed to **"Targeting Pre-Seed/Seed"**, consistent with item 3's contrasting mistake (targeting too-late-stage Series C+ companies).

## Test plan
- Docs-only change, no code/tests affected.