### PR TITLE
Add marketing-site skill

### DIFF
--- a/skills/marketing-site/SKILL.md
+++ b/skills/marketing-site/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: marketing-site
+description: "When the user wants to build or scaffold a marketing website, landing page, or content/blog site for a product or app — especially when their main app is a client-rendered SPA (React, Vue, Angular, Svelte) with poor SEO and needs a separate, fast, fully-indexable site to drive organic traffic. Also use when the user mentions 'landing page', 'marketing site', 'build a website for my SaaS', 'my SPA has no SEO', 'app not on Google', 'add a blog for SEO', 'Astro site', 'static site for SEO', 'hreflang', 'og tags / open graph', 'sitemap', 'robots.txt', 'JSON-LD / structured data for pages', 'multilingual marketing site', or 'share links have no preview image'. Produces a static, SEO-complete site (per-page meta + canonical, Open Graph, hreflang i18n, JSON-LD, sitemap, robots.txt, RSS, blog via content collections) fronting an app via a Login/CTA link. For auditing existing SEO use seo-audit; for pages at scale use programmatic-seo; for structured data use schema; for IA planning use site-architecture."
+metadata:
+  version: 1.0.0
+---
+
+# Marketing Site
+
+Build a fast, **static, SEO-complete marketing site** (landing page + blog) that fronts an existing web application. The output is HTML that search engines and social crawlers can read on the first request — no JavaScript execution required — with per-page metadata, structured data, i18n, and a content engine baked in.
+
+Use this when someone has a working app but **no way to get found**. Skip it when the request is purely strategic (keyword research, an audit, or an IA plan) — those are `seo-audit`, `programmatic-seo`, and `site-architecture`.
+
+## The core problem this solves
+
+Most web apps are **client-rendered SPAs**. When Googlebot or a social crawler (Facebook, X, LinkedIn, Telegram, Slack) fetches a SPA URL, it receives an almost-empty shell:
+
+```html
+<body><div id="app"></div><script src="/main.js"></script></body>
+```
+
+- **Social crawlers do not run JavaScript at all** → link previews are blank (no title, description, or image).
+- **Googlebot can render JS, but slowly and unreliably** → indexing is delayed and fragile, and any auth gate, consent wall, or pre-mount handshake can break it entirely.
+
+The fix is **not** to bolt SSR onto the app. It is to put a **separate static site in front**: the marketing site owns the public, indexable surface (home, features, pricing, blog, legal); the app owns everything behind login. A single "Login"/"Open app" link connects them. The app never needs SEO.
+
+## Recommended stack
+
+**Astro** — content-first, ships zero JS by default, outputs pure static HTML, and has first-class content collections (blog), sitemap, and i18n. Islands let you hydrate only the rare interactive widget. Alternatives (Next static export, Eleventy, Hugo) work; this skill's templates are Astro but the SEO principles are framework-agnostic.
+
+Live in the **same repo** as the app, in a sibling folder (e.g. `web/` next to `frontend/`). Deploy the built `dist/` as static files (CDN or nginx). Route `/` → marketing site, `/app` (or an `app.` subdomain) → the SPA.
+
+## Before starting — gather context
+
+Ask only for what you cannot infer:
+
+1. **What is the app / product?** One or two sentences — becomes the meta description and hero copy. Read the app's README/landing view if it exists.
+2. **Domain** (real or placeholder). Needed for `site` config → canonical URLs, sitemap, Open Graph. If unknown, use one `SITE_URL` constant they can change in one place.
+3. **Where does the app live?** The Login/CTA link target: same-domain path (`/app`) or subdomain (`app.example.com`). Affects deploy/proxy notes.
+4. **Languages.** One or many? Multilingual needs hreflang + a locale routing strategy. Match the app's existing languages if it has them.
+5. **Deploy target.** CDN (Cloudflare Pages / Vercel / Netlify) or self-hosted (nginx on a VPS). Affects the adapter/config and the proxy story.
+6. **Brand.** Colors, font, logo, tone. Match the app's existing theme so the two feel like one product — pull its CSS variables / Tailwind config.
+
+## Build order
+
+Work in this sequence; each layer depends on the previous. Template files for the starred items are in `assets/scaffold/`.
+
+1. **Scaffold** — `package.json`, `astro.config.mjs`*, `tsconfig.json`, Tailwind config + `global.css`. Set `site`, `trailingSlash`, i18n locales, and the `sitemap()` integration.
+2. **Central config*** — one `src/config.ts` holding `SITE_URL`, `APP_URL` (Login target), and brand constants. Every hard-to-change value lives here so going to production is a one-file edit.
+3. **SEO infra** — the non-negotiable core:
+   - `BaseHead.astro`* — per-page `<title>`, meta description, canonical, Open Graph, Twitter Card, hreflang alternates, favicon, font preconnect.
+   - `schema.ts`* + `JsonLd.astro` — JSON-LD builders (Organization, WebSite, FAQPage, BlogPosting, BreadcrumbList).
+   - `robots.txt` (dynamic route, references `SITE_URL`, disallows the app path) and `rss.xml` (blog feed).
+   - `@astrojs/sitemap` (auto, with hreflang) is wired in step 1.
+4. **Layout + chrome** — `BaseLayout.astro` (wraps BaseHead + global JSON-LD + header/footer), `Header` (nav + language switcher + Login button `rel="nofollow"`), `Footer`.
+5. **Landing page** — Hero → value pillars (one per core feature, benefit-led not feature-led) → how-it-works → FAQ (also emit FAQPage JSON-LD) → CTA. This is the page most links point at; make its copy real, specific, and skimmable.
+6. **Blog engine** — `content.config.ts`* defines the collection + Zod schema; `[slug].astro` renders posts; an index lists them. The blog is the **primary organic-traffic engine** — one indexable, keyword-targeted URL per post. Seed 1–2 real posts, never lorem ipsum.
+7. **Supporting pages** — about, pricing, privacy, terms, 404. Privacy/terms are required before running OAuth or paid ads. Footer must not link to pages that 404.
+8. **Build & verify** — run the build, then grep the emitted HTML to confirm SEO tags actually render (see the checklist). A page that looks right in dev but ships without canonical/OG is the common failure.
+
+## SEO completeness checklist
+
+Every page must ship these. Full details and copy-paste snippets in `references/seo-checklist.md`.
+
+- **Unique `<title>` and meta description** per page (never a single site-wide title).
+- **Canonical URL** — absolute, self-referencing, one per page.
+- **Open Graph + Twitter Card** — `og:title/description/url/image` + `twitter:card=summary_large_image`. The image must be a **PNG/JPG at 1200×630** — crawlers reject or mishandle SVG OG images.
+- **hreflang** for multilingual — every locale plus `x-default`, on the page and in the sitemap.
+- **JSON-LD** — Organization + WebSite site-wide; FAQPage on pages with a FAQ; BlogPosting + BreadcrumbList on posts. Validate in Google's Rich Results Test.
+- **sitemap.xml** referenced from **robots.txt**; robots disallows the app/API paths.
+- **RSS** feed for the blog.
+- **Performance** — static HTML, no render-blocking JS, responsive images, `font-display: swap`. Core Web Vitals are a ranking factor; static Astro passes them by default.
+- **Semantic HTML** — one `<h1>` per page, logical heading order, descriptive `alt`, real `<a href>` links (crawlable), not JS click handlers.
+
+## Verify the build, do not trust dev
+
+After building, inspect the emitted files — this catches the most common shipped-broken bugs:
+
+```bash
+# canonical, hreflang, OG present in the home page HTML
+grep -oE '<(link rel="canonical"|link rel="alternate"[^>]*|meta property="og:[^"]*")[^>]*>' dist/index.html
+# JSON-LD types emitted
+grep -oE '"@type":"[^"]*"' dist/index.html
+# robots + sitemap generated and self-consistent
+cat dist/robots.txt && cat dist/sitemap-index.xml
+```
+
+Confirm: canonical is absolute and correct, hreflang includes `x-default`, OG image URL resolves, and robots points at the real sitemap.
+
+## Multilingual (hreflang) guidance
+
+- Pick a routing scheme: default locale at root (`/`), others prefixed (`/vi/`, `/de/`). Keep it consistent with the app.
+- **Every** page emits `hreflang` links for all locales **plus `x-default`** (points at the default locale). Missing `x-default` is the most common hreflang mistake.
+- The sitemap must carry the same alternates (`@astrojs/sitemap` does this when its `i18n` option is set).
+- Translate real content, not just chrome. A half-translated page is worse than a clean single-language one.
+
+## Deploy
+
+Static output → serve `dist/` from a CDN or nginx. Two ways to attach the app:
+
+- **Subdomain** (`app.example.com`) — cleanest separation; independent deploys; no path juggling. Recommended.
+- **Path** (`example.com/app`) — one domain; requires a reverse proxy and setting the SPA's base path (`base: '/app/'` in its build + router). More moving parts.
+
+Point the marketing site's `robots.txt` `Disallow` at the app path so the app never competes for indexing. Include an nginx snippet in the project README if self-hosting.
+
+## Common mistakes
+
+1. **SVG Open Graph image** — looks fine locally, blank in every social preview. Export a 1200×630 **PNG**.
+2. **Site-wide title/description** — one `<title>` for all routes wastes the single strongest on-page signal.
+3. **Indexing the app** — letting Googlebot crawl the SPA behind login creates thin/duplicate pages. Disallow it in robots and keep it off the sitemap.
+4. **Missing `x-default`** — multilingual sites without it confuse locale selection in search results.
+5. **Canonical pointing at the wrong host/protocol** — always build it from a single `SITE_URL`, absolute, https.
+6. **Trailing-slash inconsistency** — pick one policy (`trailingSlash`) so canonical, sitemap, and internal links agree; mismatches create duplicate URLs.
+7. **`noindex` left in a template** — a stray `noindex` on the base layout silently deindexes the whole site. Only 404/thank-you pages get it.
+8. **Lorem ipsum shipped** — placeholder copy gets indexed and read by real users. Write real, specific copy from the start.
+9. **Blog as an afterthought** — the blog is the traffic engine, not decoration. Ship the content pipeline and seed real posts.
+10. **Bolting SSR onto the SPA instead** — heavier, slower to build, and drags auth complexity into rendering. A separate static front is simpler and faster.
+
+## Task-specific questions to consider
+
+- Is the app's audience local (one language) or international (multilingual + hreflang)?
+- What are the 3–5 highest-intent keywords the landing + first blog posts should target?
+- Does the product have a free tier / signup bonus worth featuring in the hero and pricing?
+- Are there legal/compliance pages required before launch (privacy for OAuth, terms for payments)?
+- What is the single primary conversion action (signup, book demo, open app)? Every CTA should point at it.
+
+## Related skills
+
+- **seo-audit** — audit an existing site's technical/on-page SEO before or after building.
+- **programmatic-seo** — generate many keyword-targeted pages from a dataset at scale.
+- **schema** — deep structured-data implementation beyond the core types here.
+- **site-architecture** — plan the URL/IA structure and internal linking.
+- **copywriting** / **cro** — sharpen the landing and CTA copy for conversion.

--- a/skills/marketing-site/assets/scaffold/BaseHead.astro
+++ b/skills/marketing-site/assets/scaffold/BaseHead.astro
@@ -1,0 +1,66 @@
+---
+/**
+ * SEO head — every page renders through this (via BaseLayout).
+ * Handles: title/description, canonical, Open Graph, Twitter Card,
+ * hreflang alternates (+ x-default), favicon, font preconnect.
+ *
+ * Depends on: src/config.ts and i18n helpers (localizedPath, stripLangPrefix).
+ * For a single-language site, delete the hreflang block.
+ */
+import { SITE_URL, BRAND, LANGS, type Lang } from '../config'
+import { stripLangPrefix, localizedPath } from '../i18n/utils'
+
+interface Props {
+  title: string
+  description: string
+  lang: Lang
+  image?: string
+  type?: 'website' | 'article'
+  noindex?: boolean
+  publishedTime?: string
+}
+const {
+  title, description, lang,
+  image = BRAND.ogImage, type = 'website', noindex = false, publishedTime,
+} = Astro.props
+
+const strip = (u: string) => u.replace(/(.+)\/$/, '$1') // drop trailing slash (except root)
+const canonical = strip(new URL(Astro.url.pathname, SITE_URL).href)
+const ogImage = new URL(image, SITE_URL).href
+const fullTitle = title.includes(BRAND.name) ? title : `${title} · ${BRAND.name}`
+
+const basePath = stripLangPrefix(Astro.url.pathname)
+const alternates = LANGS.map((l) => ({ lang: l, href: strip(new URL(localizedPath(basePath, l), SITE_URL).href) }))
+const xDefault = strip(new URL(localizedPath(basePath, LANGS[0]), SITE_URL).href)
+---
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="generator" content={Astro.generator} />
+
+<title>{fullTitle}</title>
+<meta name="description" content={description} />
+<link rel="canonical" href={canonical} />
+{noindex && <meta name="robots" content="noindex, nofollow" />}
+
+{alternates.map((a) => <link rel="alternate" hreflang={a.lang} href={a.href} />)}
+<link rel="alternate" hreflang="x-default" href={xDefault} />
+
+<meta property="og:type" content={type} />
+<meta property="og:site_name" content={BRAND.name} />
+<meta property="og:title" content={fullTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={canonical} />
+<meta property="og:image" content={ogImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:locale" content={lang === 'en' ? 'en_US' : lang} />
+{type === 'article' && publishedTime && <meta property="article:published_time" content={publishedTime} />}
+
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content={BRAND.twitter} />
+<meta name="twitter:title" content={fullTitle} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImage} />
+
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="alternate" type="application/rss+xml" title={`${BRAND.name} Blog`} href={new URL('/rss.xml', SITE_URL).href} />

--- a/skills/marketing-site/assets/scaffold/README.md
+++ b/skills/marketing-site/assets/scaffold/README.md
@@ -1,0 +1,18 @@
+# scaffold/ — copy-and-adapt templates
+
+Drop-in starting points for an Astro SEO marketing site. Copy into a new `web/` (or standalone) Astro project and edit `config.ts` first — everything else reads from it.
+
+| File | Goes to | Purpose |
+|------|---------|---------|
+| `config.ts` | `src/config.ts` | The one file to edit for production: `SITE_URL`, `APP_URL`, brand, locales. |
+| `astro.config.mjs` | project root | `site`, i18n locales, sitemap (with hreflang), Tailwind. |
+| `BaseHead.astro` | `src/components/BaseHead.astro` | Per-page title/desc, canonical, OG, Twitter, hreflang. |
+| `schema.ts` | `src/lib/schema.ts` | JSON-LD builders (Organization, WebSite, FAQ, Article, Breadcrumb). |
+| `i18n-utils.ts` | `src/i18n/utils.ts` | Locale routing + hreflang path helpers. |
+| `content.config.ts` | `src/content.config.ts` | Blog collection schema (content collections). |
+
+**Order:** edit `config.ts` → wire `astro.config.mjs` → render `BaseHead` inside a `BaseLayout` → add pages → add blog. Then build and grep `dist/` to verify tags render (see `../../references/seo-checklist.md`).
+
+**Single-language site:** delete the `i18n` block in `astro.config.mjs`, set `LANGS = ['en']` in `config.ts`, and the hreflang loop collapses to a single self-reference (harmless) — or trim it.
+
+**Not included** (write per project): `BaseLayout.astro`, `Header`/`Footer`, landing sections, `robots.txt.ts`, `rss.xml.ts`, blog pages. The SKILL.md build order covers these; they are short and project-specific.

--- a/skills/marketing-site/assets/scaffold/astro.config.mjs
+++ b/skills/marketing-site/assets/scaffold/astro.config.mjs
@@ -1,0 +1,29 @@
+// @ts-check
+import { defineConfig } from 'astro/config'
+import sitemap from '@astrojs/sitemap'
+import tailwind from '@astrojs/tailwind'
+import { SITE_URL } from './src/config.ts'
+
+// Static SEO marketing site. `astro build` → dist/ served by CDN or nginx.
+export default defineConfig({
+  site: SITE_URL,          // drives canonical + sitemap + OG absolute URLs
+  trailingSlash: 'ignore', // pick ONE policy and keep it consistent
+
+  // Multilingual: default locale at root, others prefixed (/vi, /de …).
+  // Single-language: delete this whole `i18n` block.
+  i18n: {
+    locales: ['en', 'vi'],
+    defaultLocale: 'en',
+    routing: { prefixDefaultLocale: false },
+  },
+
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    sitemap({
+      // Emits hreflang alternates in the sitemap. Match your locales.
+      i18n: { defaultLocale: 'en', locales: { en: 'en', vi: 'vi' } },
+      changefreq: 'weekly',
+      priority: 0.7,
+    }),
+  ],
+})

--- a/skills/marketing-site/assets/scaffold/config.ts
+++ b/skills/marketing-site/assets/scaffold/config.ts
@@ -1,0 +1,26 @@
+/**
+ * Central site config — the ONE file to edit when going to production.
+ * SITE_URL drives canonical URLs, sitemap, and Open Graph.
+ * APP_URL is the target of the "Login" / "Open app" button (the SPA behind login).
+ */
+
+// ⬇️ Production domain. No trailing slash.
+export const SITE_URL = 'https://example.com'
+
+// Login/CTA target. Same-domain path ('/app') or subdomain ('https://app.example.com').
+export const APP_URL = '/app'
+
+export const BRAND = {
+  name: 'YourProduct',
+  legalName: 'YourProduct, Inc.',
+  tagline: 'One-line value proposition used as the default meta description.',
+  // OG image MUST be PNG/JPG 1200×630 (crawlers reject SVG). Put it in public/.
+  ogImage: '/og-default.png',
+  twitter: '@yourproduct',
+  email: 'hello@example.com',
+} as const
+
+// Locales: default first. Single-language sites: keep just ['en'].
+export const LANGS = ['en'] as const
+export type Lang = (typeof LANGS)[number]
+export const DEFAULT_LANG: Lang = 'en'

--- a/skills/marketing-site/assets/scaffold/content.config.ts
+++ b/skills/marketing-site/assets/scaffold/content.config.ts
@@ -1,0 +1,24 @@
+import { defineCollection, z } from 'astro:content'
+import { glob } from 'astro/loaders'
+
+/**
+ * Blog collection = the organic-traffic engine (one indexable URL per post).
+ * Multilingual layout: src/content/blog/<lang>/<slug>.md → post.id = "<lang>/<slug>".
+ * Single-language: drop the <lang> folder; post.id = "<slug>".
+ */
+const blog = defineCollection({
+  loader: glob({ pattern: '**/[^_]*.md', base: './src/content/blog' }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(), // used for meta description + OG on the post page
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      author: z.string().default('Team'),
+      tags: z.array(z.string()).default([]),
+      heroImage: image().optional(),
+      draft: z.boolean().default(false), // true = excluded from build
+    }),
+})
+
+export const collections = { blog }

--- a/skills/marketing-site/assets/scaffold/i18n-utils.ts
+++ b/skills/marketing-site/assets/scaffold/i18n-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * i18n helpers for hreflang + locale-prefixed routing.
+ * Scheme: default locale at root ('/'), others prefixed ('/vi/...').
+ * Single-language site: you can delete this and hardcode lang in BaseHead.
+ */
+import { DEFAULT_LANG, LANGS, type Lang } from '../config'
+
+/** Locale from URL: /vi/... → 'vi', otherwise the default. */
+export function getLangFromUrl(url: URL): Lang {
+  const seg = url.pathname.split('/')[1]
+  return (LANGS as readonly string[]).includes(seg) && seg !== DEFAULT_LANG ? (seg as Lang) : DEFAULT_LANG
+}
+
+/** Build a locale-prefixed path. localizedPath('/blog','vi') → '/vi/blog'; default → '/blog'. */
+export function localizedPath(path: string, lang: Lang): string {
+  const clean = '/' + path.replace(/^\/+/, '')
+  if (lang === DEFAULT_LANG) return clean === '/' ? '/' : clean.replace(/\/$/, '')
+  return (`/${lang}${clean === '/' ? '' : clean}`).replace(/\/$/, '') || `/${lang}`
+}
+
+/** Strip a locale prefix so a page can map itself to every locale for hreflang. */
+export function stripLangPrefix(pathname: string): string {
+  const others = LANGS.filter((l) => l !== DEFAULT_LANG)
+  const re = new RegExp(`^/(${others.join('|')})(?=/|$)`)
+  const out = pathname.replace(re, '')
+  return out === '' ? '/' : out
+}

--- a/skills/marketing-site/assets/scaffold/schema.ts
+++ b/skills/marketing-site/assets/scaffold/schema.ts
@@ -1,0 +1,64 @@
+/**
+ * JSON-LD builders (schema.org). Import in a page and pass to a <JsonLd> component
+ * that renders <script type="application/ld+json" set:html={JSON.stringify(x)} />.
+ */
+import { SITE_URL, BRAND } from '../config'
+
+const abs = (path: string) => new URL(path, SITE_URL).href
+
+export const organizationSchema = () => ({
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  '@id': `${SITE_URL}/#organization`,
+  name: BRAND.legalName,
+  url: SITE_URL,
+  logo: abs('/favicon.svg'),
+  email: BRAND.email,
+  sameAs: [`https://twitter.com/${BRAND.twitter.replace('@', '')}`],
+})
+
+export const websiteSchema = () => ({
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  '@id': `${SITE_URL}/#website`,
+  name: BRAND.name,
+  url: SITE_URL,
+  publisher: { '@id': `${SITE_URL}/#organization` },
+})
+
+export const faqSchema = (items: { q: string; a: string }[]) => ({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: items.map((it) => ({
+    '@type': 'Question',
+    name: it.q,
+    acceptedAnswer: { '@type': 'Answer', text: it.a },
+  })),
+})
+
+export const breadcrumbSchema = (crumbs: { name: string; path: string }[]) => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: crumbs.map((c, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: c.name,
+    item: abs(c.path),
+  })),
+})
+
+export const articleSchema = (o: {
+  title: string; description: string; path: string; image?: string
+  datePublished: string; dateModified?: string; authorName: string
+}) => ({
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: o.title,
+  description: o.description,
+  image: abs(o.image ?? BRAND.ogImage),
+  datePublished: o.datePublished,
+  dateModified: o.dateModified ?? o.datePublished,
+  author: { '@type': 'Organization', name: o.authorName },
+  publisher: { '@id': `${SITE_URL}/#organization` },
+  mainEntityOfPage: { '@type': 'WebPage', '@id': abs(o.path) },
+})

--- a/skills/marketing-site/references/seo-checklist.md
+++ b/skills/marketing-site/references/seo-checklist.md
@@ -1,0 +1,116 @@
+# SEO completeness checklist + snippets
+
+Copy-paste reference for the tags every page of a marketing site must ship. Snippets are Astro but map 1:1 to any templating layer. Build all URLs from a single absolute `SITE_URL` so canonical, OG, sitemap, and hreflang always agree.
+
+## 1. Title + description (per page, unique)
+
+```astro
+<title>{pageTitle} · {BRAND}</title>
+<meta name="description" content={pageDescription} />
+```
+
+- 50–60 chars for title, 140–160 for description.
+- Never reuse one site-wide title. The `<title>` is the strongest on-page signal.
+
+## 2. Canonical (absolute, self-referencing)
+
+```astro
+---
+const canonical = new URL(Astro.url.pathname, SITE_URL).href.replace(/(.+)\/$/, '$1')
+---
+<link rel="canonical" href={canonical} />
+```
+
+## 3. Open Graph + Twitter Card
+
+```astro
+<meta property="og:type" content="website" />          <!-- "article" for posts -->
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={canonical} />
+<meta property="og:image" content={new URL('/og.png', SITE_URL).href} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={new URL('/og.png', SITE_URL).href} />
+```
+
+- **OG image MUST be PNG or JPG, 1200×630.** SVG is rejected/mishandled by Facebook, X, LinkedIn.
+- Test with the Facebook Sharing Debugger and X Card Validator before launch.
+
+## 4. hreflang (multilingual)
+
+```astro
+<link rel="alternate" hreflang="en" href={`${SITE_URL}/`} />
+<link rel="alternate" hreflang="vi" href={`${SITE_URL}/vi`} />
+<link rel="alternate" hreflang="x-default" href={`${SITE_URL}/`} />
+```
+
+- Include **every locale + `x-default`**. Missing `x-default` is the #1 hreflang error.
+- Emit the same alternates in the sitemap (`@astrojs/sitemap` `i18n` option).
+
+## 5. JSON-LD structured data
+
+Site-wide (in the base layout): **Organization** + **WebSite**.
+Per page type: **FAQPage** (pages with a FAQ), **BlogPosting** + **BreadcrumbList** (posts).
+
+```json
+{ "@context": "https://schema.org", "@type": "FAQPage",
+  "mainEntity": [{ "@type": "Question", "name": "…",
+    "acceptedAnswer": { "@type": "Answer", "text": "…" } }] }
+```
+
+- The visible page must contain the same FAQ text as the JSON-LD, or Google may flag it.
+- Validate every type in Google's Rich Results Test.
+
+## 6. robots.txt (dynamic)
+
+```
+User-agent: *
+Allow: /
+Disallow: /app       # the SPA behind login — do not index
+Disallow: /api/
+
+Sitemap: {SITE_URL}/sitemap-index.xml
+```
+
+## 7. RSS
+
+Generate `/rss.xml` from the blog collection (title, description, pubDate, link, categories). Link it from `<head>`:
+
+```astro
+<link rel="alternate" type="application/rss+xml" title="Blog" href={`${SITE_URL}/rss.xml`} />
+```
+
+## 8. Performance / Core Web Vitals
+
+- Static HTML, zero render-blocking JS (Astro default).
+- Responsive images with width/height set (no layout shift); modern formats (WebP/AVIF).
+- `font-display: swap`; preconnect to font hosts.
+- Target LCP < 2.5s, CLS < 0.1, INP < 200ms — static sites pass these by default.
+
+## 9. Semantic HTML / crawlability
+
+- Exactly one `<h1>` per page; heading levels in order.
+- Real `<a href>` links (crawlable) — not `<div onclick>`.
+- Descriptive `alt` on meaningful images; empty `alt=""` on decorative ones.
+- Language declared: `<html lang="…">` matching the page locale.
+
+## Post-build verification
+
+```bash
+grep -oE '<link rel="canonical"[^>]*>' dist/index.html          # exactly one, absolute
+grep -oE '<meta property="og:[^"]*"[^>]*>' dist/index.html       # og:title/description/url/image
+grep -oE 'hreflang="[^"]*"' dist/index.html                      # all locales + x-default
+grep -oE '"@type":"[^"]*"' dist/index.html                       # expected JSON-LD types
+cat dist/robots.txt dist/sitemap-index.xml                       # present + consistent
+```
+
+## Launch tasks (outside the build)
+
+- Submit the sitemap in Google Search Console + Bing Webmaster Tools.
+- Verify the OG preview in the Facebook Sharing Debugger and X Card Validator.
+- Confirm the app path is excluded from indexing (robots + not in sitemap).
+- Set up analytics (privacy-friendly options: Plausible, Umami) and Search Console performance monitoring.


### PR DESCRIPTION
Scaffold a static, SEO-complete marketing site (landing + blog) that fronts a client-rendered SPA with poor SEO, to drive organic traffic.

Covers: per-page meta + canonical, Open Graph/Twitter, hreflang i18n, JSON-LD (Organization/WebSite/FAQPage/BlogPosting/BreadcrumbList), sitemap, robots.txt, RSS, and a blog via Astro content collections. Includes a references/ SEO checklist and assets/scaffold/ copy-and-adapt templates.