### PR TITLE
Release: pricing-page teardown (2.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -37,7 +37,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | ads | 2.2.0 | 2026-07-05 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
-| pricing | 2.0.1 | 2026-06-16 |
+| pricing | 2.1.0 | 2026-07-27 |
 | product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
@@ -54,6 +54,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.9.1 (2026-07-27)
+
+- **pricing** (2.0.1 → 2.1.0): added a **Pricing Page Teardown** — a two-axis audit of a live pricing page. Axis 1 is the classic human buyer experience (value-prop clarity, plan differentiation, cognitive load, trust signals, psychology, transparency); Axis 2 is the novel **AI-agent readiness** lens: whether the LLMs/agents that increasingly shortlist and compare tools can actually read and quote your pricing — machine-readable prices (not locked in an image or behind "Contact us"), extractable FAQ/objection coverage, per-tier depth in text, and structured data. Includes the memorable **"paste test"** (give the URL to a browsing-capable AI and ask for the plans and prices — if it can't answer, an AI shopping for your buyer can't either), a full 10-dimension rubric + scoring/report template in `references/pricing-page-teardown.md`, and hand-offs to `schema` (Product/Offer JSON-LD) and `ai-seo` (extractability, AI search-bot access, llms.txt). New eval (id 7). AI-agent-readiness lens adapted from Kyle Poyar / Growth Unhinged (learn-from-only, credited).
 
 ### 2.9.0 (2026-07-15)
 

--- a/skills/pricing/SKILL.md
+++ b/skills/pricing/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pricing
-description: "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' or 'should I offer a free plan.' Use this whenever someone is figuring out what to charge or how to structure their plans. For in-app upgrade screens, see paywalls. For offer construction (bonuses, guarantees, value framing, naming) on services/courses/coaching/high-ticket B2B, see offers."
+description: "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' 'should I offer a free plan,' 'pricing page teardown,' 'pricing page audit,' 'is my pricing page AI-readable,' or 'can AI read my pricing.' Use this whenever someone is figuring out what to charge, how to structure their plans, or wants to audit a pricing page (for humans and for the AI agents that shortlist tools). For in-app upgrade screens, see paywalls. For offer construction (bonuses, guarantees, value framing, naming) on services/courses/coaching/high-ticket B2B, see offers."
 metadata:
-  version: 2.0.1
+  version: 2.1.0
 ---
 
 # Pricing Strategy
@@ -191,6 +191,21 @@ Identifies which features customers value most:
 
 ---
 
+## Pricing Page Teardown
+
+When someone wants to audit an existing pricing *page* for **clarity, transparency, and AI-readability** (not the pricing strategy itself, and not conversion-rate optimization — that's `cro`), run a **teardown** that scores it across two axes and returns prioritized fixes:
+
+- **Human buyer experience** — value-prop clarity, plan differentiation, cognitive load, trust signals, pricing psychology, and price transparency.
+- **AI-agent readiness** — whether the LLMs and agents that increasingly shortlist and compare tools can actually read and quote your pricing: machine-readable prices (not locked in an image or behind "Contact us"), extractable FAQ/objection coverage, per-tier depth stated in text, and structured data. Buyers now ask ChatGPT/Perplexity/Claude "what's the best X and what does it cost?" *before* visiting — a pricing page an agent can't parse loses deals you never see.
+
+**Fast check — the "paste test":** give the pricing URL to a browsing-capable AI (Perplexity, ChatGPT with search, Claude with web) — or paste the rendered page text — and ask "what are the plans and prices?" A clean miss means agents fetching your page will struggle too (a heuristic, not proof every agent fails).
+
+The AI-readiness fixes are usually high-impact, low-effort (put prices in text, add `Offer` schema). Hand implementation to **schema** (Product/Offer JSON-LD) and **ai-seo** (extractability, AI-bot access, `llms.txt`).
+
+**For the full 10-dimension rubric, scoring, and report template:** See [references/pricing-page-teardown.md](references/pricing-page-teardown.md). *(AI-agent-readiness lens adapted from Kyle Poyar / Growth Unhinged.)*
+
+---
+
 ## Pricing Checklist
 
 ### Before Setting Prices
@@ -224,6 +239,8 @@ Identifies which features customers value most:
 
 - **churn-prevention**: For cancel flows, save offers, and reducing revenue churn
 - **cro**: For optimizing pricing page conversion
+- **ai-seo**: For making the pricing page extractable/citable by AI (the teardown's AI-agent-readiness axis)
+- **schema**: For Product/Offer structured data so machines can read your tiers and prices
 - **copywriting**: For pricing page copy
 - **marketing-psychology**: For pricing psychology principles
 - **ab-testing**: For testing pricing changes

--- a/skills/pricing/evals/evals.json
+++ b/skills/pricing/evals/evals.json
@@ -85,6 +85,20 @@
         "Does not attempt full page CRO audit"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "Can you tear down our pricing page? I want to know if it is clear for buyers, and also whether AI tools like ChatGPT or Perplexity can actually read our prices when someone asks them to compare tools in our category.",
+      "expected_output": "Should run the two-axis pricing page teardown (references/pricing-page-teardown.md), not a generic CRO audit. Axis 1 (human buyer experience): value-prop clarity, plan differentiation, cognitive load, trust signals, pricing psychology, price transparency. Axis 2 (AI-agent readiness): machine-readable pricing (real numbers in HTML/text, not locked in an image, JS-only render, or behind Contact us), extractable FAQ/objection coverage, per-tier depth stated in text, and structured data (Product/Offer schema) + AI-bot crawlability. Should recommend the paste test (paste the URL into an LLM and ask for plans and prices; if it cannot answer, an AI shopping for the buyer cannot either). Should prioritize fixes by impact x effort and note AI-readiness fixes are often high-impact/low-effort. Should hand implementation to schema (Product/Offer JSON-LD) and ai-seo (extractability, AI-bot access, llms.txt). May credit the AI-agent-readiness lens to Kyle Poyar.",
+      "assertions": [
+        "Runs the two-axis teardown (human buyer experience AND AI-agent readiness)",
+        "Checks machine-readable pricing (not locked in an image / JS-only / behind Contact us)",
+        "Recommends the paste test (an LLM can correctly quote plans and prices)",
+        "Hands off to schema (Product/Offer structured data) and ai-seo (extractability / AI-bot access / llms.txt)",
+        "Prioritizes fixes by impact x effort; flags AI-readiness fixes as often high-impact low-effort",
+        "Does not treat this as pure conversion-rate CRO"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/pricing/references/pricing-page-teardown.md
+++ b/skills/pricing/references/pricing-page-teardown.md
@@ -1,0 +1,85 @@
+# Pricing Page Teardown
+
+A structured way to score a live pricing page and return prioritized fixes. It grades **two axes**: the classic **human buyer experience**, and — the newer, higher-leverage lens — **AI-agent readiness**: whether the LLMs and agents that increasingly shortlist and compare tools can actually read, quote, and recommend your pricing.
+
+> **Framework credit:** the two-axis structure and especially the AI-agent-readiness lens are adapted from **Kyle Poyar's** (Growth Unhinged) pricing-page teardown. Learn-from-only — this rubric is authored independently; credit the framing to Poyar.
+
+## Why the second axis matters now
+
+Buyers increasingly ask ChatGPT, Perplexity, and Claude *"what's the best [category] tool and what does it cost?"* before they ever hit your site. If your price is trapped in an image, rendered only by JavaScript, or missing from the page's text, a text-fetching agent often can't read it — some agents render JS or fall back to vision/OCR, but many don't, so don't count on it. And a "Contact us" tier gives an agent no public number to quote at all. When the agent can't read your price, it recommends and quotes the competitor whose pricing it *can*. This axis is the pricing-page complement to `ai-seo` and `schema` — neither *guarantees* a citation, but a page a fetcher can't parse makes one much less likely.
+
+**The 30-second test — the "paste test":** give the pricing URL to a **browsing-capable** AI (Perplexity, ChatGPT with search, or Claude with web) — or paste the page's *rendered* text — and ask *"What are the plans and prices?"* If it can't answer correctly and completely, agents fetching your page the same way will struggle too. It's a heuristic, not proof every agent fails (some render JS or use vision), but a clean miss is a real finding worth fixing.
+
+## The rubric
+
+Score each dimension **Pass / Partial / Gap** (or 1–5 if you want a number). Two sub-scores (one per axis) plus a prioritized fix list is the deliverable — not a single vanity number.
+
+### Axis 1 — Human buyer experience
+
+| # | Dimension | Passing looks like | Common gaps |
+|---|---|---|---|
+| 1 | **Value-prop clarity** | Above the fold: what you get + why it's worth it, in the buyer's words | Feature list with no outcome; "flexible plans for every team" |
+| 2 | **Plan clarity / differentiation** | Obvious which plan is for whom and exactly how they differ | Feature-soup tables; tiers that blur together; no "who it's for" |
+| 3 | **Cognitive load** | A buyer can decide in <30s | Too many tiers (5+), unexplained jargon, decision paralysis |
+| 4 | **Trust signals** | Logos, testimonials, security/compliance, a guarantee near the CTA | No proof; trust content buried below the fold |
+| 5 | **Pricing psychology** | A recommended/anchor tier, sensible anchoring, coherent charm vs. round pricing | No recommended tier; highest price hidden last; random price endings |
+| 6 | **Transparency** | The actual price is shown; what's in/out is clear; no surprise fees | "Contact us" on every tier; hidden overages; usage limits omitted |
+
+### Axis 2 — AI-agent readiness (the novel lens)
+
+| # | Dimension | Passing looks like | Common gaps |
+|---|---|---|---|
+| 7 | **Machine-readable pricing** | The real numbers are in the page's HTML/text | Price in an image/SVG, JS-only render, or a PDF — text-fetching crawlers get nothing reliable; "Contact sales" leaves no public number to quote |
+| 8 | **FAQ / objection coverage** | Extractable answers to "does it do X," "what's the limit," "can I cancel," "is there a free trial" | No FAQ, or answers only in a support portal an agent won't reach |
+| 9 | **Per-tier depth in text** | Each plan's inclusions, limits, and quotas stated in words | Differences shown only as checkmark columns in an image; limits unnamed |
+| 10 | **Structured data & extractability** | `Product`/`Offer` schema markup, clean semantic HTML, AI search/agent bots allowed to crawl (`llms.txt` is a nice-to-have, not yet a standard) | No schema; pricing behind auth/interaction; AI *search* bots blocked in robots.txt |
+
+Dimensions 7 and 10 hand off to **`schema`** (Product/Offer JSON-LD) and **`ai-seo`** (extractability, AI-bot access, `llms.txt`) for implementation.
+
+## How to run it
+
+1. **Load context** — read `.agents/product-marketing.md` (ICP, positioning) so "clarity" is judged against the *right* buyer.
+2. **Fetch the page as an agent would** — get the rendered text/HTML, not a screenshot. Note immediately whether prices appear in the text (that's dimension 7).
+3. **Run the paste test** — ask an LLM for the plans and prices from the URL; record what it gets wrong or misses.
+4. **Score all 10 dimensions** Pass/Partial/Gap with a one-line reason each.
+5. **Prioritize fixes** by impact × effort. AI-readiness gaps are often *high impact, low effort* (add text prices, add Offer schema) — surface those first.
+
+## Output template
+
+```markdown
+# Pricing Page Teardown — [url] — [date]
+
+## Scores
+- Human buyer experience: [X/6 passing]
+- AI-agent readiness:      [X/4 passing]
+
+## Paste test
+[What an LLM returned for "plans and prices" — and what it got wrong/missed]
+
+## Dimension-by-dimension
+| # | Dimension | Verdict | Note |
+|---|-----------|---------|------|
+| 1 | Value-prop clarity | Pass/Partial/Gap | ... |
+| … | … | … | … |
+
+## Prioritized fixes (impact × effort)
+1. [High/low] — [fix] — [why it matters] — [→ schema / ai-seo / cro if handing off]
+2. ...
+
+## The one thing
+[The single highest-leverage fix — often "put your actual prices in text + add Offer schema so AI can quote you."]
+```
+
+## Common failure patterns
+
+- **The image-price** — a beautiful pricing graphic with the numbers baked in. Humans love it; text-fetching agents (and screen readers) usually can't read it. Put prices in text; the image can stay as decoration.
+- **"Contact us" everywhere** — sometimes right for true enterprise, but if *all* tiers hide price, both humans and agents bounce to a competitor with numbers. Show at least a starting price or a representative range.
+- **Checkmark-only tables** — feature differences shown only as ✓/✗ columns in an image or icon font. State the actual limits and inclusions in words.
+- **JS-only render / auth wall** — if the price only appears after interaction or login, most fetchers won't see it (only JS-rendering agents might).
+- **Blocked AI *search* bots** — the crawlers that feed AI *answers* are the search agents, not the training crawlers: OpenAI's `OAI-SearchBot`, Anthropic's `Claude-SearchBot` / `Claude-User`, Perplexity's `PerplexityBot`. Blocking `GPTBot` only opts out of model *training*, not ChatGPT Search — so check which bots your robots.txt actually blocks. (Bot access is `ai-seo`'s domain — hand it off there.)
+
+## Related
+- `schema` — Product/Offer JSON-LD so machines read your tiers and prices.
+- `ai-seo` — extractability, AI-bot access, `llms.txt`, getting cited by AI answers.
+- `cro` — converting the human once the page is clear.
+- `copywriting` — the value-prop and tier copy the teardown flags.


### PR DESCRIPTION
## Release 2.9.1 — pricing-page teardown

Promotes the **pricing** skill's new Pricing Page Teardown straight to `main` as a focused **2.9.1** patch, ahead of the staged 2.10.0 attribution release (#478) — so the teardown reaches users without waiting on that launch. Release order stays contiguous: **2.9.0 → 2.9.1 → 2.10.0**.

### What's included
- **`pricing`** (2.0.1 → **2.1.0**) — a two-axis **Pricing Page Teardown**:
  - **Axis 1 — human buyer experience:** value-prop clarity, plan differentiation, cognitive load, trust signals, pricing psychology, price transparency.
  - **Axis 2 — AI-agent readiness (novel):** whether the LLMs/agents that shortlist and compare tools can read and quote your pricing — machine-readable prices (not locked in an image or behind "Contact us"), extractable FAQ/objection coverage, per-tier depth in text, structured data + AI search-bot crawlability.
  - The **"paste test"**, a full 10-dimension rubric + report template (`references/pricing-page-teardown.md`), and hand-offs to `schema` + `ai-seo`. New eval id 7.

Repo release **2.9.0 → 2.9.1** (z: existing-skill update): `plugin.json`, `marketplace.json`, `VERSIONS.md`.

### Notes
- **Framework credit:** AI-agent-readiness lens adapted from **Kyle Poyar / Growth Unhinged** (learn-from-only).
- **Codex-reviewed twice** — corrected over-claims (agents can render JS/use vision; browsing-capable paste test; llms.txt = nice-to-have; correct AI *search*-bot names vs GPTBot=training). Boundary kept clean vs `cro`.
- Direct feature→main release (hotfix pattern) because `development` is staging the unrelated 2.10.0 attribution work; main→development sync will follow so development carries this too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
