### PR TITLE
feat(tools): add MiniMax (Hailuo) text-to-video integration

### DIFF
--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -302,9 +302,9 @@ Video hosting, creation, and AI generation.
 | **wistia** | Video hosting, marketing analytics | Best for marketing video hosting |
 | **heygen** | AI avatars, talking-head videos | MCP server available |
 | **hyperframes** | Programmatic video from HTML/CSS | Open source, agent-native |
-| **minimax** | AI text-to-video generation (Hailuo) | CLI available; character consistency across shots |
+| **minimax** | AI text-to-video and image-to-video generation | CLI available; current v2 and legacy v1 models |
 
-**Agent recommendation**: HeyGen for AI avatar videos (MCP-enabled). Hyperframes for templated, data-driven video from code. MiniMax (Hailuo) for AI-generated marketing footage from text prompts. Wistia for hosting and analytics.
+**Agent recommendation**: HeyGen for AI avatar videos (MCP-enabled). Hyperframes for templated, data-driven video from code. MiniMax for AI-generated marketing footage from text or image prompts. Wistia for hosting and analytics.
 
 ### Data Enrichment
 

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -94,6 +94,7 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | wistia | Video | ✓ | - | [✓](clis/wistia.js) | - | [wistia.md](integrations/wistia.md) |
 | heygen | Video | ✓ | ✓ | - | ✓ | [heygen.md](integrations/heygen.md) |
 | hyperframes | Video | - | - | ✓ | ✓ | [hyperframes.md](integrations/hyperframes.md) |
+| minimax | Video | ✓ | - | [✓](clis/minimax-video.js) | - | [minimax.md](integrations/minimax.md) |
 | trustpilot | Reviews | ✓ | - | [✓](clis/trustpilot.js) | - | [trustpilot.md](integrations/trustpilot.md) |
 | g2 | Reviews | ✓ | - | [✓](clis/g2.js) | - | [g2.md](integrations/g2.md) |
 | onesignal | Push | ✓ | - | [✓](clis/onesignal.js) | ✓ | [onesignal.md](integrations/onesignal.md) |
@@ -301,8 +302,9 @@ Video hosting, creation, and AI generation.
 | **wistia** | Video hosting, marketing analytics | Best for marketing video hosting |
 | **heygen** | AI avatars, talking-head videos | MCP server available |
 | **hyperframes** | Programmatic video from HTML/CSS | Open source, agent-native |
+| **minimax** | AI text-to-video generation (Hailuo) | CLI available; character consistency across shots |
 
-**Agent recommendation**: HeyGen for AI avatar videos (MCP-enabled). Hyperframes for templated, data-driven video from code. Wistia for hosting and analytics.
+**Agent recommendation**: HeyGen for AI avatar videos (MCP-enabled). Hyperframes for templated, data-driven video from code. MiniMax (Hailuo) for AI-generated marketing footage from text prompts. Wistia for hosting and analytics.
 
 ### Data Enrichment
 

--- a/tools/clis/README.md
+++ b/tools/clis/README.md
@@ -64,6 +64,7 @@ Every CLI reads credentials from environment variables:
 | `livestorm` | `LIVESTORM_API_TOKEN` |
 | `mailchimp` | `MAILCHIMP_API_KEY` |
 | `mention-me` | `MENTIONME_API_KEY` |
+| `minimax-video` | `MINIMAX_API_KEY`, `MINIMAX_REGION` (optional), `MINIMAX_BASE_URL` (optional) |
 | `meta-ads` | `META_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID` |
 | `mixpanel` | `MIXPANEL_TOKEN` (ingestion), `MIXPANEL_API_KEY` + `MIXPANEL_SECRET` (query) |
 | `onesignal` | `ONESIGNAL_REST_API_KEY`, `ONESIGNAL_APP_ID` |
@@ -166,6 +167,7 @@ DOMAINS=$(rewardful affiliates list | jq -r '.data[].email')
 | `livestorm.js` | Webinar | [Livestorm](https://livestorm.co) |
 | `mailchimp.js` | Email | [Mailchimp](https://mailchimp.com) |
 | `mention-me.js` | Referral | [Mention Me](https://www.mention-me.com) |
+| `minimax-video.js` | Video | [MiniMax (Hailuo)](https://www.minimax.io) |
 | `meta-ads.js` | Ads | [Meta Ads](https://www.facebook.com/business/ads) |
 | `mixpanel.js` | Analytics | [Mixpanel](https://mixpanel.com) |
 | `onesignal.js` | Push | [OneSignal](https://onesignal.com) |

--- a/tools/clis/minimax-video.js
+++ b/tools/clis/minimax-video.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
-// MiniMax (Hailuo) text-to-video CLI for marketing footage generation.
-// Text-to-video is an async flow: submit a generation task, poll for status,
-// then retrieve the finished file. This CLI wraps those three steps.
+// MiniMax text-to-video and image-to-video CLI for marketing footage generation.
 
 const API_KEY = process.env.MINIMAX_API_KEY
 
@@ -13,18 +11,18 @@ const REGIONS = {
   cn_zh: 'https://api.minimaxi.com',
 }
 
-// Text-to-video models. Hailuo 2.3 is the current default.
-const T2V_MODELS = [
+const VIDEO_MODELS = [
+  'MiniMax-H3',
   'MiniMax-Hailuo-2.3',
   'MiniMax-Hailuo-2.3-Fast',
   'MiniMax-Hailuo-02',
   'T2V-01-Director',
   'T2V-01',
 ]
-const DEFAULT_MODEL = 'MiniMax-Hailuo-2.3'
+const DEFAULT_MODEL = 'MiniMax-H3'
 
-// Request fields accepted by the text-to-video operation.
-const T2V_FIELDS = ['model', 'prompt', 'prompt_optimizer', 'fast_pretreatment', 'duration', 'resolution', 'callback_url']
+const V2_FIELDS = ['model', 'content', 'resolution', 'duration', 'ratio', 'callback_url']
+const V1_FIELDS = ['model', 'prompt', 'first_frame_image', 'prompt_optimizer', 'fast_pretreatment', 'duration', 'resolution', 'callback_url']
 
 function parseArgs(argv) {
   const result = { _: [] }
@@ -91,6 +89,19 @@ function numeric(value) {
   return Number.isNaN(n) ? value : n
 }
 
+function videoApiVersion(model) {
+  const version = args['api-version'] || (model === 'MiniMax-H3' ? 'v2' : 'v1')
+  if (!['v1', 'v2'].includes(version)) throw new Error('--api-version must be v1 or v2')
+  return version
+}
+
+function v2Content(prompt) {
+  const content = [{ type: 'text', text: prompt }]
+  if (args['first-frame-image']) content.push({ type: 'image_url', image_url: { url: args['first-frame-image'] }, role: 'first_frame' })
+  if (args['last-frame-image']) content.push({ type: 'image_url', image_url: { url: args['last-frame-image'] }, role: 'last_frame' })
+  return content
+}
+
 async function main() {
   let result
 
@@ -100,19 +111,52 @@ async function main() {
         case 'generate': {
           const prompt = args.prompt
           if (!prompt) { result = { error: '--prompt required' }; break }
-          const body = { model: args.model || DEFAULT_MODEL, prompt }
-          if (args['prompt-optimizer'] !== undefined) body.prompt_optimizer = args['prompt-optimizer'] !== 'false'
-          if (args['fast-pretreatment'] !== undefined) body.fast_pretreatment = args['fast-pretreatment'] !== 'false'
-          if (args.duration !== undefined) body.duration = numeric(args.duration)
-          if (args.resolution) body.resolution = args.resolution
-          if (args['callback-url']) body.callback_url = args['callback-url']
-          result = await api('POST', '/v1/video_generation', body)
+          const model = args.model || DEFAULT_MODEL
+          const version = videoApiVersion(model)
+          if (version === 'v2') {
+            const hasFrame = args['first-frame-image'] || args['last-frame-image']
+            const body = {
+              model,
+              content: v2Content(prompt),
+              resolution: args.resolution || '2K',
+              duration: numeric(args.duration || 5),
+              ratio: args.ratio || (hasFrame ? 'adaptive' : '16:9'),
+            }
+            if (args['callback-url']) body.callback_url = args['callback-url']
+            result = await api('POST', '/v2/video_generation', body)
+          } else {
+            const body = { model, prompt }
+            if (args['first-frame-image']) body.first_frame_image = args['first-frame-image']
+            if (args['prompt-optimizer'] !== undefined) body.prompt_optimizer = args['prompt-optimizer'] !== 'false'
+            if (args['fast-pretreatment'] !== undefined) body.fast_pretreatment = args['fast-pretreatment'] !== 'false'
+            if (args.duration !== undefined) body.duration = numeric(args.duration)
+            if (args.resolution) body.resolution = args.resolution
+            if (args['callback-url']) body.callback_url = args['callback-url']
+            result = await api('POST', '/v1/video_generation', body)
+          }
           break
         }
         case 'status': {
           const taskId = args['task-id']
           if (!taskId) { result = { error: '--task-id required' }; break }
-          result = await api('GET', `/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`)
+          const version = videoApiVersion(args.model || DEFAULT_MODEL)
+          const path = version === 'v2'
+            ? `/v2/query/video_generation/${encodeURIComponent(taskId)}`
+            : `/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`
+          result = await api('GET', path)
+          break
+        }
+        case 'list': {
+          const query = new URLSearchParams()
+          if (args['page-num']) query.set('page_num', args['page-num'])
+          if (args['page-size']) query.set('page_size', args['page-size'])
+          result = await api('GET', `/v2/query/video_generation${query.size ? `?${query}` : ''}`)
+          break
+        }
+        case 'delete': {
+          const taskId = args['task-id']
+          if (!taskId) { result = { error: '--task-id required' }; break }
+          result = await api('DELETE', `/v2/video_generation/${encodeURIComponent(taskId)}`)
           break
         }
         case 'download': {
@@ -122,22 +166,22 @@ async function main() {
           break
         }
         default:
-          result = { error: 'Unknown video subcommand. Use: generate, status, download' }
+          result = { error: 'Unknown video subcommand. Use: generate, status, list, delete, download' }
       }
       break
 
     case 'models':
-      result = { default: DEFAULT_MODEL, text_to_video: T2V_MODELS }
+      result = { default: DEFAULT_MODEL, video: VIDEO_MODELS }
       break
 
     default:
       result = {
         error: 'Unknown command',
         usage: {
-          video: 'video [generate --prompt <text> [--model <id>] [--duration <n>] [--resolution <res>] [--prompt-optimizer <bool>] [--fast-pretreatment <bool>] [--callback-url <url>] | status --task-id <id> | download --file-id <id>]',
+          video: 'video [generate --prompt <text> [--model <id>] [--first-frame-image <url>] [--last-frame-image <url>] [--duration <n>] [--resolution <res>] [--ratio <ratio>] [--callback-url <url>] | status --task-id <id> | list | delete --task-id <id> | download --file-id <id>]',
           models: 'models',
-          options: '--region <global_en|cn_zh> --dry-run',
-          fields: T2V_FIELDS,
+          options: '--region <global_en|cn_zh> --api-version <v1|v2> --dry-run',
+          fields: { v2: V2_FIELDS, v1: V1_FIELDS },
         },
       }
   }

--- a/tools/clis/minimax-video.js
+++ b/tools/clis/minimax-video.js
@@ -18,6 +18,9 @@ const VIDEO_MODELS = [
   'MiniMax-Hailuo-02',
   'T2V-01-Director',
   'T2V-01',
+  'I2V-01-Director',
+  'I2V-01-live',
+  'I2V-01',
 ]
 const DEFAULT_MODEL = 'MiniMax-H3'
 
@@ -109,10 +112,14 @@ async function main() {
     case 'video':
       switch (sub) {
         case 'generate': {
-          const prompt = args.prompt
-          if (!prompt) { result = { error: '--prompt required' }; break }
           const model = args.model || DEFAULT_MODEL
           const version = videoApiVersion(model)
+          const prompt = args.prompt
+          if (version === 'v2' && !prompt) { result = { error: '--prompt required' }; break }
+          if (version === 'v1' && !prompt && !args['first-frame-image']) {
+            result = { error: '--prompt or --first-frame-image required' }
+            break
+          }
           if (version === 'v2') {
             const hasFrame = args['first-frame-image'] || args['last-frame-image']
             const body = {
@@ -125,7 +132,8 @@ async function main() {
             if (args['callback-url']) body.callback_url = args['callback-url']
             result = await api('POST', '/v2/video_generation', body)
           } else {
-            const body = { model, prompt }
+            const body = { model }
+            if (prompt) body.prompt = prompt
             if (args['first-frame-image']) body.first_frame_image = args['first-frame-image']
             if (args['prompt-optimizer'] !== undefined) body.prompt_optimizer = args['prompt-optimizer'] !== 'false'
             if (args['fast-pretreatment'] !== undefined) body.fast_pretreatment = args['fast-pretreatment'] !== 'false'

--- a/tools/clis/minimax-video.js
+++ b/tools/clis/minimax-video.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+// MiniMax (Hailuo) text-to-video CLI for marketing footage generation.
+// Text-to-video is an async flow: submit a generation task, poll for status,
+// then retrieve the finished file. This CLI wraps those three steps.
+
+const API_KEY = process.env.MINIMAX_API_KEY
+
+// Regional endpoints. Global (English) is the default; the mainland China
+// region uses a different host. Override the host entirely with MINIMAX_BASE_URL.
+const REGIONS = {
+  global_en: 'https://api.minimax.io',
+  cn_zh: 'https://api.minimaxi.com',
+}
+
+// Text-to-video models. Hailuo 2.3 is the current default.
+const T2V_MODELS = [
+  'MiniMax-Hailuo-2.3',
+  'MiniMax-Hailuo-2.3-Fast',
+  'MiniMax-Hailuo-02',
+  'T2V-01-Director',
+  'T2V-01',
+]
+const DEFAULT_MODEL = 'MiniMax-Hailuo-2.3'
+
+// Request fields accepted by the text-to-video operation.
+const T2V_FIELDS = ['model', 'prompt', 'prompt_optimizer', 'fast_pretreatment', 'duration', 'resolution', 'callback_url']
+
+function parseArgs(argv) {
+  const result = { _: [] }
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2)
+      const next = argv[i + 1]
+      if (next && !next.startsWith('--')) {
+        result[key] = next
+        i++
+      } else {
+        result[key] = true
+      }
+    } else {
+      result._.push(arg)
+    }
+  }
+  return result
+}
+
+const args = parseArgs(process.argv.slice(2))
+const [cmd, sub] = args._
+
+const region = args.region || process.env.MINIMAX_REGION || 'global_en'
+if (!REGIONS[region]) {
+  console.error(JSON.stringify({ error: `Unknown region "${region}". Use: ${Object.keys(REGIONS).join(', ')}` }))
+  process.exit(1)
+}
+const BASE_URL = process.env.MINIMAX_BASE_URL || REGIONS[region]
+
+async function api(method, path, body) {
+  if (args['dry-run']) {
+    return {
+      _dry_run: true,
+      method,
+      url: `${BASE_URL}${path}`,
+      headers: { 'Authorization': 'Bearer ***', 'Content-Type': 'application/json' },
+      body: body || undefined,
+    }
+  }
+  if (!API_KEY) {
+    return { error: 'MINIMAX_API_KEY environment variable required' }
+  }
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Authorization': `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  try {
+    return JSON.parse(text)
+  } catch {
+    return { status: res.status, body: text }
+  }
+}
+
+// Numeric flags stay numeric so the API sees the right JSON types.
+function numeric(value) {
+  const n = Number(value)
+  return Number.isNaN(n) ? value : n
+}
+
+async function main() {
+  let result
+
+  switch (cmd) {
+    case 'video':
+      switch (sub) {
+        case 'generate': {
+          const prompt = args.prompt
+          if (!prompt) { result = { error: '--prompt required' }; break }
+          const body = { model: args.model || DEFAULT_MODEL, prompt }
+          if (args['prompt-optimizer'] !== undefined) body.prompt_optimizer = args['prompt-optimizer'] !== 'false'
+          if (args['fast-pretreatment'] !== undefined) body.fast_pretreatment = args['fast-pretreatment'] !== 'false'
+          if (args.duration !== undefined) body.duration = numeric(args.duration)
+          if (args.resolution) body.resolution = args.resolution
+          if (args['callback-url']) body.callback_url = args['callback-url']
+          result = await api('POST', '/v1/video_generation', body)
+          break
+        }
+        case 'status': {
+          const taskId = args['task-id']
+          if (!taskId) { result = { error: '--task-id required' }; break }
+          result = await api('GET', `/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`)
+          break
+        }
+        case 'download': {
+          const fileId = args['file-id']
+          if (!fileId) { result = { error: '--file-id required' }; break }
+          result = await api('GET', `/v1/files/retrieve?file_id=${encodeURIComponent(fileId)}`)
+          break
+        }
+        default:
+          result = { error: 'Unknown video subcommand. Use: generate, status, download' }
+      }
+      break
+
+    case 'models':
+      result = { default: DEFAULT_MODEL, text_to_video: T2V_MODELS }
+      break
+
+    default:
+      result = {
+        error: 'Unknown command',
+        usage: {
+          video: 'video [generate --prompt <text> [--model <id>] [--duration <n>] [--resolution <res>] [--prompt-optimizer <bool>] [--fast-pretreatment <bool>] [--callback-url <url>] | status --task-id <id> | download --file-id <id>]',
+          models: 'models',
+          options: '--region <global_en|cn_zh> --dry-run',
+          fields: T2V_FIELDS,
+        },
+      }
+  }
+
+  console.log(JSON.stringify(result, null, 2))
+}
+
+main().catch(err => {
+  console.error(JSON.stringify({ error: err.message }))
+  process.exit(1)
+})

--- a/tools/integrations/minimax.md
+++ b/tools/integrations/minimax.md
@@ -1,0 +1,118 @@
+# MiniMax (Hailuo)
+
+AI video generation platform. Generate original marketing footage from text prompts — B-roll, hero shots, and scenes you can't practically film — with strong character consistency across clips. Powered by the Hailuo video models.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | Yes | REST API for text-to-video generation, task polling, and file retrieval |
+| MCP | - | - |
+| CLI | Yes | [minimax-video.js](../clis/minimax-video.js) — zero-dependency, single-file |
+| SDK | - | - |
+
+## Authentication
+
+- **Type**: Bearer token
+- **Header**: `Authorization: Bearer {api_key}`
+- **Environment variable**: `MINIMAX_API_KEY`
+- **Get key**: API key section of the MiniMax platform console
+
+## Regional Endpoints
+
+Pick the region closest to your account. The global (English) region is the default.
+
+| Region | Host | Docs |
+|--------|------|------|
+| `global_en` | `https://api.minimax.io` | [platform.minimax.io/docs](https://platform.minimax.io/docs/api-reference/video-generation-t2v) |
+| `cn_zh` | `https://api.minimaxi.com` | [platform.minimaxi.com/docs](https://platform.minimaxi.com/docs/api-reference/video-generation-t2v) |
+
+Select the region with `--region <global_en|cn_zh>` on the CLI (or the `MINIMAX_REGION` environment variable). Set `MINIMAX_BASE_URL` to override the host entirely.
+
+## Models
+
+Text-to-video is an asynchronous flow: submit a generation task, poll until it completes, then retrieve the finished file.
+
+| Model | Notes |
+|-------|-------|
+| `MiniMax-Hailuo-2.3` | Current default — highest fidelity |
+| `MiniMax-Hailuo-2.3-Fast` | Faster generation, lower cost |
+| `MiniMax-Hailuo-02` | Previous-generation Hailuo |
+| `T2V-01-Director` | Director model with camera-movement control |
+| `T2V-01` | Base text-to-video model |
+
+## CLI Quick Start
+
+```bash
+# Preview any request without sending it (key is masked)
+node tools/clis/minimax-video.js video generate \
+  --prompt "A close-up of hands typing on a laptop, warm office lighting, camera slowly pulls back" \
+  --duration 6 --resolution 1080P --prompt-optimizer true --dry-run
+
+# 1. Submit a generation task → returns task_id
+node tools/clis/minimax-video.js video generate \
+  --prompt "A close-up of hands typing on a laptop, warm office lighting" \
+  --model MiniMax-Hailuo-2.3 --duration 6 --resolution 1080P
+
+# 2. Poll the task until status is complete → returns file_id when done
+node tools/clis/minimax-video.js video status --task-id TASK_ID
+
+# 3. Retrieve the finished video file
+node tools/clis/minimax-video.js video download --file-id FILE_ID
+
+# List available text-to-video models
+node tools/clis/minimax-video.js models
+```
+
+## API Quick Start
+
+### Submit a Text-to-Video Task
+
+```bash
+curl -X POST https://api.minimax.io/v1/video_generation \
+  -H "Authorization: Bearer $MINIMAX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMax-Hailuo-2.3",
+    "prompt": "A close-up of hands typing on a laptop, warm office lighting",
+    "duration": 6,
+    "resolution": "1080P",
+    "prompt_optimizer": true
+  }'
+```
+
+Accepted request fields: `model`, `prompt`, `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, `callback_url`.
+
+### Poll the Task
+
+```bash
+curl "https://api.minimax.io/v1/query/video_generation?task_id=TASK_ID" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY"
+```
+
+Returns `status` and, once finished, a `file_id`.
+
+### Retrieve the File
+
+```bash
+curl "https://api.minimax.io/v1/files/retrieve?file_id=FILE_ID" \
+  -H "Authorization: Bearer $MINIMAX_API_KEY"
+```
+
+Response fields across these operations: `task_id`, `status`, `file_id`, `base_resp.status_code`.
+
+## Common Marketing Use Cases
+
+| Use Case | Approach |
+|----------|----------|
+| Hero visuals | Generate a cinematic hero shot from a scene description |
+| B-roll | Text prompts for background footage you can't easily film |
+| Consistent scenes | Reuse subject/style phrasing across shots for character consistency |
+| Ad concept testing | Rapidly generate short clips to validate a creative direction |
+| Social short-form | Vertical clips for feeds and stories |
+
+## Relevant Skills
+
+- video
+- social
+- ad-creative

--- a/tools/integrations/minimax.md
+++ b/tools/integrations/minimax.md
@@ -41,6 +41,9 @@ Video generation is asynchronous: submit a task, then poll until it completes. T
 | `MiniMax-Hailuo-02` | Previous-generation Hailuo |
 | `T2V-01-Director` | Director model with camera-movement control |
 | `T2V-01` | Base text-to-video model |
+| `I2V-01-Director` | Director image-to-video model with camera-movement control |
+| `I2V-01-live` | Image-to-video model for animated illustrations |
+| `I2V-01` | Base image-to-video model |
 
 ## CLI Quick Start
 
@@ -60,6 +63,10 @@ node tools/clis/minimax-video.js video generate \
   --prompt "The camera slowly pushes toward the product" \
   --first-frame-image https://example.com/product.png --duration 6
 
+# Legacy v1 image-to-video accepts a first frame without a prompt
+node tools/clis/minimax-video.js video generate \
+  --model I2V-01 --first-frame-image https://example.com/product.png
+
 # 2. Poll the v2 task until status is succeeded → returns task.content.url
 node tools/clis/minimax-video.js video status --task-id TASK_ID
 
@@ -67,7 +74,7 @@ node tools/clis/minimax-video.js video status --task-id TASK_ID
 node tools/clis/minimax-video.js video status --task-id TASK_ID --api-version v1
 node tools/clis/minimax-video.js video download --file-id FILE_ID
 
-# List available text-to-video models
+# List available video models
 node tools/clis/minimax-video.js models
 ```
 
@@ -109,7 +116,7 @@ curl "https://api.minimax.io/v1/files/retrieve?file_id=FILE_ID" \
   -H "Authorization: Bearer $MINIMAX_API_KEY"
 ```
 
-The v1 API remains available for Hailuo and T2V models. It returns `task_id`, `status`, and `file_id`; retrieve the file from `/v1/files/retrieve`.
+The v1 API remains available for Hailuo, T2V, and I2V models. It returns `task_id`, `status`, and `file_id`; retrieve the file from `/v1/files/retrieve`.
 
 ## Common Marketing Use Cases
 

--- a/tools/integrations/minimax.md
+++ b/tools/integrations/minimax.md
@@ -1,12 +1,12 @@
 # MiniMax (Hailuo)
 
-AI video generation platform. Generate original marketing footage from text prompts — B-roll, hero shots, and scenes you can't practically film — with strong character consistency across clips. Powered by the Hailuo video models.
+AI video generation platform. Generate original marketing footage from text or image prompts — B-roll, hero shots, and scenes you can't practically film — with strong character consistency across clips.
 
 ## Capabilities
 
 | Integration | Available | Notes |
 |-------------|-----------|-------|
-| API | Yes | REST API for text-to-video generation, task polling, and file retrieval |
+| API | Yes | REST API for text-to-video and image-to-video generation, task management, and file retrieval |
 | MCP | - | - |
 | CLI | Yes | [minimax-video.js](../clis/minimax-video.js) — zero-dependency, single-file |
 | SDK | - | - |
@@ -31,11 +31,12 @@ Select the region with `--region <global_en|cn_zh>` on the CLI (or the `MINIMAX_
 
 ## Models
 
-Text-to-video is an asynchronous flow: submit a generation task, poll until it completes, then retrieve the finished file.
+Video generation is asynchronous: submit a task, then poll until it completes. The v2 response provides the output URL directly; v1 tasks use file retrieval.
 
 | Model | Notes |
 |-------|-------|
-| `MiniMax-Hailuo-2.3` | Current default — highest fidelity |
+| `MiniMax-H3` | Current default — v2 text, image, and reference inputs with 2K output |
+| `MiniMax-Hailuo-2.3` | v1 high-fidelity generation |
 | `MiniMax-Hailuo-2.3-Fast` | Faster generation, lower cost |
 | `MiniMax-Hailuo-02` | Previous-generation Hailuo |
 | `T2V-01-Director` | Director model with camera-movement control |
@@ -47,17 +48,23 @@ Text-to-video is an asynchronous flow: submit a generation task, poll until it c
 # Preview any request without sending it (key is masked)
 node tools/clis/minimax-video.js video generate \
   --prompt "A close-up of hands typing on a laptop, warm office lighting, camera slowly pulls back" \
-  --duration 6 --resolution 1080P --prompt-optimizer true --dry-run
+  --duration 6 --resolution 2K --ratio 16:9 --dry-run
 
 # 1. Submit a generation task → returns task_id
 node tools/clis/minimax-video.js video generate \
   --prompt "A close-up of hands typing on a laptop, warm office lighting" \
-  --model MiniMax-Hailuo-2.3 --duration 6 --resolution 1080P
+  --model MiniMax-H3 --duration 6 --resolution 2K --ratio 16:9
 
-# 2. Poll the task until status is complete → returns file_id when done
+# Use a first-frame image for image-to-video
+node tools/clis/minimax-video.js video generate \
+  --prompt "The camera slowly pushes toward the product" \
+  --first-frame-image https://example.com/product.png --duration 6
+
+# 2. Poll the v2 task until status is succeeded → returns task.content.url
 node tools/clis/minimax-video.js video status --task-id TASK_ID
 
-# 3. Retrieve the finished video file
+# Use --api-version v1 for status and file retrieval with v1 models
+node tools/clis/minimax-video.js video status --task-id TASK_ID --api-version v1
 node tools/clis/minimax-video.js video download --file-id FILE_ID
 
 # List available text-to-video models
@@ -69,37 +76,40 @@ node tools/clis/minimax-video.js models
 ### Submit a Text-to-Video Task
 
 ```bash
-curl -X POST https://api.minimax.io/v1/video_generation \
+curl -X POST https://api.minimax.io/v2/video_generation \
   -H "Authorization: Bearer $MINIMAX_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "MiniMax-Hailuo-2.3",
-    "prompt": "A close-up of hands typing on a laptop, warm office lighting",
+    "model": "MiniMax-H3",
+    "content": [{
+      "type": "text",
+      "text": "A close-up of hands typing on a laptop, warm office lighting"
+    }],
     "duration": 6,
-    "resolution": "1080P",
-    "prompt_optimizer": true
+    "resolution": "2K",
+    "ratio": "16:9"
   }'
 ```
 
-Accepted request fields: `model`, `prompt`, `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, `callback_url`.
+Accepted v2 request fields: `model`, `content`, `resolution`, `duration`, `ratio`, `callback_url`. Add `image_url` content with a `first_frame` or `last_frame` role for image-to-video.
 
 ### Poll the Task
 
 ```bash
-curl "https://api.minimax.io/v1/query/video_generation?task_id=TASK_ID" \
+curl "https://api.minimax.io/v2/query/video_generation/TASK_ID" \
   -H "Authorization: Bearer $MINIMAX_API_KEY"
 ```
 
-Returns `status` and, once finished, a `file_id`.
+Returns `task.status` and, once finished, `task.content.url`.
 
-### Retrieve the File
+### v1 File Retrieval
 
 ```bash
 curl "https://api.minimax.io/v1/files/retrieve?file_id=FILE_ID" \
   -H "Authorization: Bearer $MINIMAX_API_KEY"
 ```
 
-Response fields across these operations: `task_id`, `status`, `file_id`, `base_resp.status_code`.
+The v1 API remains available for Hailuo and T2V models. It returns `task_id`, `status`, and `file_id`; retrieve the file from `/v1/files/retrieve`.
 
 ## Common Marketing Use Cases
 


### PR DESCRIPTION
Reason: The video skill recommends MiniMax (Hailuo) for AI-generated marketing footage, but the tools registry had no MiniMax video integration.

## What this adds

Adds a marketing-scoped MiniMax (Hailuo) text-to-video integration following the repository's existing tool patterns:

- **`tools/clis/minimax-video.js`** — a zero-dependency, single-file Node.js CLI covering the full text-to-video flow:
  - `video generate` — submit a text-to-video task (`model`, `prompt`, `prompt_optimizer`, `fast_pretreatment`, `duration`, `resolution`, `callback_url`)
  - `video status` — poll a task by `task_id`
  - `video download` — retrieve the finished file by `file_id`
  - `models` — list available text-to-video models
  - Regional endpoints via `--region global_en|cn_zh` (or `MINIMAX_REGION`), with `MINIMAX_BASE_URL` override
  - Bearer auth from `MINIMAX_API_KEY`, JSON output, and `--dry-run` (key masked), matching the other CLIs
- **`tools/integrations/minimax.md`** — integration guide: capabilities, auth, regional endpoints, current models, request fields, the async generate → poll → retrieve flow, and marketing use cases
- **`tools/REGISTRY.md`** — registers `minimax` under the Video category (index table and by-category section)
- **`tools/clis/README.md`** — adds the CLI to the authentication and available-CLIs tables

## Checks

- `node --check tools/clis/minimax-video.js` passes
- Exercised every command with `--dry-run` (both regions, default and explicit model, missing-arg and unknown-region error paths) and confirmed the correct endpoints, request fields, and masked auth
