### PR TITLE
Refresh MiniMax-H3 v2 video guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -52,9 +52,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
 | social | 2.2.0 | 2026-07-09 |
-| video | 2.1.0 | 2026-07-14 |
+| video | 2.2.0 | 2026-08-01 |
 
 ## Recent Changes
+
+### 2.10.1 (2026-08-01)
+
+- **video** (2.1.0 → 2.2.0): refreshed MiniMax-H3 guidance for the v2 create, query, list, and delete lifecycle; both regional endpoints; required create fields; 2K-only output; integer 4-15 second duration; supported ratios; and first/last-frame plus reference image, video, and audio role constraints. Added eval coverage for the regional API flow and task lifecycle.
 
 ### 2.10.0 (2026-07-22)
 

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -2,7 +2,7 @@
 name: video
 description: "When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use when the user mentions 'video production,' 'AI video,' 'Remotion,' 'Hyperframes,' 'HeyGen,' 'Synthesia,' 'Veo,' 'Sora,' 'Runway,' 'Kling,' 'Seedance,' 'Hailuo,' 'MiniMax,' 'Pika,' 'Hunyuan,' 'Wan,' 'video generation,' 'AI avatar,' 'talking head video,' 'programmatic video,' 'video template,' 'explainer video,' 'product demo video,' 'video pipeline,' 'copy this edit,' 'match this video style,' 'reverse-engineer this video,' 'edit like this reference,' or 'make me a video.' Use this for video creation, generation, and production workflows. For video content strategy and what to post, see social. For paid video ad creative, see ad-creative."
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Video
@@ -135,17 +135,46 @@ Generate original footage from text or image prompts. Use for B-roll, hero visua
 | **Runway Gen-4** | Up to 4K | ~10 sec/gen | Motion control, temporal consistency, edit-style workflows | $12-76/mo |
 | **Kling 2.5/3.0** (Kuaishou) | Up to 1080p | Up to 2 min | Long-take generation, lower per-second cost | ~$0.03/sec |
 | **Seedance** (ByteDance) | Up to 1080p | Short clips | Fast generation, strong motion fidelity at low cost, batch-friendly | Per-credit |
-| **Hailuo / MiniMax** | Up to 1080p | Short clips | Character consistency across shots | Per-credit |
+| **MiniMax-H3** | 2K | 4-15 sec | First/last-frame and reference-guided clips | Per-second |
 | **Pika 2.x** | 1080p | Short clips | Quick effects, image-to-video, lower bar to entry | Per-credit |
 | **Hunyuan Video / Wan 2** | 720p–1080p | Variable | Open-source self-hosted; full control, no API fees | Free (GPU) |
 
 **Quick picks**:
 - **Highest quality + audio**: Veo 3 or Sora 2
 - **Batch / volume / cost**: Kling, Seedance
-- **Character consistency across multiple shots**: Hailuo
+- **2K clips with first/last-frame or reference control**: MiniMax-H3
 - **Self-hosted, brand-controlled**: Hunyuan Video or Wan 2 (open weights)
 - **Storyboard → video workflow**: Runway, LTX Studio
 - **Image-to-video from a still you already have**: Kling, Pika, Runway
+
+### MiniMax-H3 v2 API
+
+Use MiniMax-H3 for 2K clips with text, first/last-frame, or reference-media control. Create requests require `model`, `content`, `resolution`, and `duration`; set `model` to `MiniMax-H3`, `resolution` to `2K`, and `duration` to an integer from 4 through 15 seconds. Optional fields are `ratio` and `callback_url`. The China endpoint also accepts `aigc_watermark`.
+
+| Region | Create Endpoint |
+|--------|-----------------|
+| Global | `https://api.minimax.io/v2/video_generation` |
+| China | `https://api.minimaxi.com/v2/video_generation` |
+
+The v2 task lifecycle uses Bearer authorization:
+
+| Action | Method | Path |
+|--------|--------|------|
+| Create | `POST` | `/v2/video_generation` |
+| Query one task | `GET` | `/v2/query/video_generation/{task_id}` |
+| List tasks | `GET` | `/v2/query/video_generation` |
+| Delete | `DELETE` | `/v2/video_generation/{task_id}` |
+
+Build `content` from these supported types and roles:
+
+- Include required `text` content, up to 7,000 characters.
+- Use `image_url` with `first_frame`, `last_frame`, or `reference_image`.
+- Use `video_url` with `reference_video`, and `audio_url` with `reference_audio`.
+- A `reference_audio` item requires an image or video reference.
+- Do not combine first/last-frame roles with reference-media roles in one request.
+- Keep the complete request body at or below 64 MB.
+
+Supported ratios are `adaptive`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, and `9:16`.
 
 ### Prompting for Video Models
 

--- a/skills/video/evals/evals.json
+++ b/skills/video/evals/evals.json
@@ -98,6 +98,21 @@
         "Applies the originality guardrail — copies editing grammar applied to the user's own footage, never the reference's footage/script/music"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Use MiniMax-H3 to turn a product opening frame and closing frame into an 8-second 2K 16:9 video. Show the API flow and constraints for both global and China accounts, including how to monitor and delete the task.",
+      "expected_output": "Should use the MiniMax-H3 v2 API rather than a legacy generation flow. Should identify the global create endpoint as https://api.minimax.io/v2/video_generation and the China create endpoint as https://api.minimaxi.com/v2/video_generation, with Bearer authorization. Should explain that POST /v2/video_generation requires model, content, resolution, and duration; model is MiniMax-H3, resolution is 2K only, and duration must be an integer from 4 through 15 seconds. Should represent the opening and closing images with image_url content using first_frame and last_frame roles, include required text content, and note that first/last-frame roles cannot be mixed with reference-media roles. Should list GET /v2/query/video_generation/{task_id} for one task, GET /v2/query/video_generation for task listing, and DELETE /v2/video_generation/{task_id} for deletion. Should use ratio 16:9 and note that aigc_watermark is China-only.",
+      "assertions": [
+        "Uses the MiniMax-H3 v2 create endpoint for the correct region",
+        "Includes all required create fields and Bearer authorization",
+        "Enforces 2K output and an integer duration from 4 through 15 seconds",
+        "Uses first_frame and last_frame content roles with required text content",
+        "Does not mix frame roles with reference-media roles",
+        "Explains query, list, and delete task operations",
+        "Treats aigc_watermark as China-only"
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
Reason: Refresh MiniMax-H3 video guidance for the v2 API surface and current constraints.

## Skill Update

**Skill:** `skills/video`

## Summary

- Document the global and China v2 create endpoints and task lifecycle.
- Add the 2K output, integer 4-15 second duration, ratio, and reference-media constraints.
- Add eval coverage and update the video skill and plugin version metadata.

## Type of update

- [ ] Bug fix
- [x] Improved instructions
- [ ] Added references/scripts
- [ ] Other

## Checks

- `git diff --check origin/main...HEAD`
- Secret scan of the committed upstream diff

## Checklist

- [x] Changes are focused and minimal
- [x] `SKILL.md` is still under 500 lines
- [x] No sensitive data or credentials
- [x] Tested locally with AI agent
