### PR TITLE
feat: add geo-dual-frontier skill (rank on Google + get cited by AI with one asset)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [ad-creative](skills/ad-creative/) | When the user wants to generate, iterate, or scale ad creative — headlines, descriptions, primary text, or full ad... |
 | [ads](skills/ads/) | When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X,... |
 | [ai-seo](skills/ai-seo/) | When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers.... |
+| [geo-dual-frontier](skills/geo-dual-frontier/) | When the user wants one piece of content to rank on Google AND get cited by AI assistants (ChatGPT, Perplexity, AI Overviews) at the same time — the dual-frontier operating workflow.... |
 | [analytics](skills/analytics/) | When the user wants to set up, improve, or audit analytics tracking and measurement. Also use when the user mentions... |
 | [aso](skills/aso/) | When the user wants to audit or optimize an App Store or Google Play listing. Also use when the user mentions 'ASO... |
 | [attribution](skills/attribution/) | When the user wants to figure out which marketing actually drives conversions and revenue, choose or interpret an... |
@@ -285,6 +286,7 @@ You can also invoke skills directly:
 ### SEO & Discovery
 - `seo-audit` - Technical and on-page SEO
 - `ai-seo` - AI search optimization (AEO, GEO, LLMO)
+- `geo-dual-frontier` - Make one asset rank on Google AND get cited by AI (dual-frontier workflow)
 - `programmatic-seo` - Scaled page generation
 - `site-architecture` - Page hierarchy, navigation, URL structure
 - `competitors` - Comparison and alternative pages

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -24,6 +24,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
+| geo-dual-frontier | 1.0.0 | 2026-08-04 |
 | image | 2.0.1 | 2026-05-18 |
 | influencer-marketing | 1.0.0 | 2026-07-15 |
 | launch | 2.0.1 | 2026-06-16 |

--- a/skills/geo-dual-frontier/SKILL.md
+++ b/skills/geo-dual-frontier/SKILL.md
@@ -42,6 +42,8 @@ Google and AI engines diverge in *selection*, but converge in *what they reward*
 
 **Implication:** write one document with (a) a tight answer block up top (snippet + extraction bait) and (b) comprehensive, sourced depth below (ranks + gives AI confident context). Do **not** write a separate "AI version" — that risks Google's scaled-content-abuse spam policy.
 
+> **Evidence base (validated by 2026 research):** Google's March 2026 core update rewarded the *same* signals AI engines prefer to cite — original research (+22% visibility), penalized thin AI-spin content, and doubled down on E-E-A-T — effectively confirming the "one playbook, two channels" convergence. Princeton GEO research (Aggarwal et al., KDD 2024) measured concrete lifts: statistics **+32–41%**, cited sources **+30%**, expert quotations **+41%** in AI citation rates. **Honest nuance:** Google's June 2026 official guide states you do *not* need `llms.txt`, AI-specific markup, or AI-only rewrites — "optimizing for generative AI search is still SEO." So the durable core is good SEO + structured, citable, source-backed content; machine-readable files (Step 3, Layer 2) are a bonus, not a requirement.
+
 ---
 
 ## Workflow
@@ -96,22 +98,20 @@ The same prose serves both fronts — no AI-only rewrite.
 
 > Full template with annotated examples: [references/dual-frontier-content-template.md](references/dual-frontier-content-template.md)
 
-### Step 3 — Three-Layer Schema (三层Schema)
+### Step 3 — Make Content Machine-Readable (三层, 核心在前)
 
-Make the content machine-readable on three layers so both Google and AI can parse it:
+The durable core that *both* Google and AI reward is **structured, citable, source-backed content** — not special AI files. Prioritize in this order:
 
-**Layer 1 — On-page JSON-LD (for Google rich results):**
-`Article`/`BlogPosting`, `FAQPage`, `HowTo`, `Product`. Content with proper schema shows 30–40% higher AI visibility on non-Google engines. For implementation, use the **schema** skill.
+**Layer 1 — On-page JSON-LD (standard SEO, do this first):**
+`Article`/`BlogPosting`, `FAQPage`, `HowTo`, `Product`. Proper schema + clean HTML is the price of entry for both Google rich results *and* AI retrieval — AI Overviews pull from the same indexed web Google already ranks. For implementation, use the **schema** skill.
 
-**Layer 2 — Machine-readable files (for AI engines & buying agents):**
-- `/llms.txt` — concise context file pointing AI to key pages (see llmstxt.org).
-- `/pricing.md` or `/pricing.txt` — structured facts/pricing parseable without JS or login walls. Agents increasingly compare products before a human visits; opaque pricing gets filtered out.
-- `/okf/` — Open Knowledge Format bundle (Google-backed, v0.1) for agent-readable site content.
+**Layer 2 — Optional machine-readable files (nice-to-have, NOT required):**
+- `/llms.txt` (llmstxt.org) and `/pricing.md` can help buying agents and power users, but **Google's June 2026 official guide explicitly states these are not needed** for AI visibility — good SEO + crawlability already covers it. Treat as a bonus, not core; don't over-invest before Layer 1 and Layer 3 are solid.
 
 **Layer 3 — Entity & third-party presence (drives AI *recommendations*, not just citations):**
-Google Business Profile, accurate Wikipedia/entity data, review platforms (G2, Trustpilot), authentic community participation. Citation ≠ recommendation — recommendations are governed by web-wide consensus (reviews, forums, press). See `ai-seo` → citations-vs-recommendations.
+Google Business Profile, consistent entity naming, review platforms (G2, Trustpilot), authentic community participation. Citation ≠ recommendation — recommendations are governed by web-wide consensus (reviews, forums, press). See `ai-seo` → citations-vs-recommendations.
 
-> Implementation paths for each layer: [references/three-layer-schema.md](references/three-layer-schema.md)
+> Evidence: Google March 2026 core update rewarded the same signals AI cites (original research +22%, E-E-A-T emphasis); Princeton GEO research (KDD 2024) measured stats +32–41%, sources +30%, quotes +41%. Google June 2026: "optimizing for generative AI search is still SEO" — no special markup required. Implementation paths: [references/three-layer-schema.md](references/three-layer-schema.md)
 
 ### Step 4 — Dual-Line Validation (双线验证)
 

--- a/skills/geo-dual-frontier/SKILL.md
+++ b/skills/geo-dual-frontier/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: geo-dual-frontier
+description: "When the user wants to make a single piece of content rank on Google AND get cited by AI assistants (ChatGPT, Perplexity, Gemini, Google AI Overviews) at the same time — the 'dual-frontier' operating workflow. Use when the user mentions 'GEO,' 'generative engine optimization,' 'dual-frontier SEO,' 'content that ranks and gets cited,' 'AI citations plus SEO,' 'answer engine and search together,' or 'write once for Google and AI.' For deep generative-engine theory, platform ranking factors, and the AI-visibility audit, see ai-seo. For implementing JSON-LD structured data, see schema. For planning the content calendar, see content-strategy."
+metadata:
+  author: Delonix AI
+  version: 1.0.0
+---
+
+# GEO Dual-Frontier
+
+You run the **dual-frontier** operating method: produce one content asset that wins **both** battlefields at once —
+
+1. **Search-frontier (SEO):** rank on Google / Bing for high-intent queries.
+2. **Answer-frontier (GEO):** get extracted and cited by AI assistants (ChatGPT, Perplexity, Gemini, AI Overviews) when users ask in natural language.
+
+Most teams run these as two separate teams and two separate content calendars. That doubles cost and produces conflicting copy. The dual-frontier method plans, writes, and validates content **once** so it ranks *and* gets cited — because the overlap between what Google rewards and what AI cites is large (clear, factual, structured, authoritative, well-sourced content).
+
+> This skill is the **operational companion** to `ai-seo`. `ai-seo` covers the theory, platform factors, and the full AI-visibility audit. This skill covers the *workflow* for shipping one asset that serves both fronts. Read `ai-seo` first if you need the deep background.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or the legacy `product-marketing-context.md`), read it before asking questions. Use that context and only ask for what's missing or task-specific.
+
+Gather (ask if not provided):
+- What queries matter most — and do they have *both* search demand and AI-ask demand?
+- Current Google ranking position and current AI citation status for those queries.
+- Existing structured data, `llms.txt`, machine-readable pricing/facts files.
+- Brand's authority signals (reviews, entity presence, original data).
+
+---
+
+## The Dual-Frontier Principle
+
+Google and AI engines diverge in *selection*, but converge in *what they reward*:
+
+| | Search-frontier (Google) | Answer-frontier (AI) |
+|---|--------------------------|----------------------|
+| **Wants** | E-E-A-T, links, relevance, freshness | Extractable passages, citations, stats, clear structure |
+| **Punishes** | Thin/thin-spin content, no expertise | Keyword stuffing (−10%), fabricated claims |
+| **Overlap (exploit this)** | Clear definitions, real data w/ sources, FAQ structure, expert attribution, freshness | Same — directly answers, 40–60 word blocks, comparison tables |
+
+**Implication:** write one document with (a) a tight answer block up top (snippet + extraction bait) and (b) comprehensive, sourced depth below (ranks + gives AI confident context). Do **not** write a separate "AI version" — that risks Google's scaled-content-abuse spam policy.
+
+---
+
+## Workflow
+
+### Step 1 — Dual-Frontier Keyword Selection (双栖筛词)
+
+Score every candidate query on **two axes**. Only pursue queries that score well on **both** — a keyword that only ranks or only gets asked to AI is half-wasted.
+
+| Axis | What to measure | Tool / signal |
+|------|-----------------|---------------|
+| **Demand (SEO)** | Search volume, ranking difficulty, business value | GSC, Semrush/Ahrefs, keyword planner |
+| **AI-Query-Fit (GEO)** | Phrased as a natural-language question? Comparison / definition / how-to / pricing intent? | Manually ask ChatGPT/Perplexity; check AI Overview presence |
+
+Build a matrix and tag each query:
+
+```
+Query                  | Demand (1–5) | AI-Fit (1–5) | Dual score | Action
+-----------------------|--------------|--------------|------------|----------------------------------
+"天津婚宴 多少钱一桌"    | 4            | 5            | 20         | ✅ Build (both fronts)
+"best CRM software"    | 5            | 3            | 15         | ⚠️ Build for SEO; add answer block
+"our brand story"      | 1            | 2            | 2          | ❌ Skip (no demand, no AI-ask)
+```
+
+**Rules:**
+- ✅ **Dual score ≥ 16** → primary target: full dual-frontier treatment.
+- ⚠️ **One axis strong, one weak** → build for the strong axis, then add the *minimum* structure to also serve the weak axis (e.g., a 40–60 word answer block on an SEO page).
+- ❌ **Both weak** → skip or fold into a broader cluster page.
+
+For the topical cluster / fan-out planning, see `ai-seo` (Query Fan-Out) and `content-strategy`.
+
+### Step 2 — Dual-Frontier Content Structure (双栖文)
+
+One document, two layers:
+
+**Layer A — Answer Block (40–60 words, first):**
+Lead with a direct answer to the exact query. Self-contained, no surrounding context needed. This is both featured-snippet bait (Google) and the passage AI extracts (GEO).
+
+```markdown
+**Q: 天津办婚宴 450㎡ 无柱宴会厅多少钱一桌？**
+瑞湾开元名都婚宴 2199 元/桌起（第三方婚嫁平台观测起步价），主力档 2599 元含五楼开元厅 450㎡ 无柱大厅+专属布置。同档滨海酒店普遍 3500+，瑞湾性价比突出。正式报价以酒店销售口径为准。
+```
+
+**Layer B — Depth (long-form below the answer block):**
+- Cover the fan-out variants (related questions) so you're retrievable for them too.
+- Add real statistics **with dated sources and links** (+37–40% citation boost per Princeton GEO research).
+- Add expert quotes with name + title (+25–30%).
+- Use comparison tables for "[X] vs [Y]" queries, numbered lists for how-to.
+- Show "Last updated: [date]" — freshness is weighted heavily by both fronts.
+- One idea per paragraph; H2/H3 headings that match how people phrase the query.
+
+The same prose serves both fronts — no AI-only rewrite.
+
+> Full template with annotated examples: [references/dual-frontier-content-template.md](references/dual-frontier-content-template.md)
+
+### Step 3 — Three-Layer Schema (三层Schema)
+
+Make the content machine-readable on three layers so both Google and AI can parse it:
+
+**Layer 1 — On-page JSON-LD (for Google rich results):**
+`Article`/`BlogPosting`, `FAQPage`, `HowTo`, `Product`. Content with proper schema shows 30–40% higher AI visibility on non-Google engines. For implementation, use the **schema** skill.
+
+**Layer 2 — Machine-readable files (for AI engines & buying agents):**
+- `/llms.txt` — concise context file pointing AI to key pages (see llmstxt.org).
+- `/pricing.md` or `/pricing.txt` — structured facts/pricing parseable without JS or login walls. Agents increasingly compare products before a human visits; opaque pricing gets filtered out.
+- `/okf/` — Open Knowledge Format bundle (Google-backed, v0.1) for agent-readable site content.
+
+**Layer 3 — Entity & third-party presence (drives AI *recommendations*, not just citations):**
+Google Business Profile, accurate Wikipedia/entity data, review platforms (G2, Trustpilot), authentic community participation. Citation ≠ recommendation — recommendations are governed by web-wide consensus (reviews, forums, press). See `ai-seo` → citations-vs-recommendations.
+
+> Implementation paths for each layer: [references/three-layer-schema.md](references/three-layer-schema.md)
+
+### Step 4 — Dual-Line Validation (双线验证)
+
+Report both fronts together; optimize the weaker line.
+
+| Line | What to measure | How |
+|------|-----------------|-----|
+| **SEO line** | Ranking position, GSC impressions/clicks, featured-snippet wins | GSC, Semrush/Ahrefs |
+| **GEO line** | Are you cited by AI? Which page? Share of voice | Manual: ChatGPT/Perplexity/AI Overviews for your queries; tools: Peec AI, Otterly, ZipTie |
+
+**Monthly cadence:**
+1. Pick top 20 dual-frontier queries.
+2. Run each through Google, ChatGPT, Perplexity; record rank + cite + which page.
+3. Log month-over-month; intervene where one line lags.
+
+> Detailed checklist + scoring sheet: [references/dual-line-validation.md](references/dual-line-validation.md)
+
+---
+
+## Ethics Guardrails (both fronts enforce these)
+
+1. **No fabricated stats or sources.** Breaks Google E-E-A-T *and* AI trust simultaneously. Every number gets a dated, linked source.
+2. **No separate "AI-only" content.** Writing a variant just for AI risks Google's scaled-content-abuse policy. One document, both audiences.
+3. **Real scarcity / limits only.** "Only 3 weekends left" must be true.
+4. **Don't block AI crawlers if you want citations.** Allow GPTBot, PerplexityBot, ClaudeBot, Google-Extended in robots.txt (block training-only CCBot if needed).
+5. **No keyword stuffing.** Actively reduces AI visibility by ~10%.
+
+---
+
+## Common Mistakes
+
+- **Running SEO and GEO as separate teams** — duplicated cost, conflicting copy. Plan once, dual-frontier.
+- **Skipping the answer block** — loses both snippet and extraction upside.
+- **Fabricating "AI-friendly" numbers** — backfires on both fronts the moment a source is checked.
+- **Publishing AI-only spin** — Google spam risk; one document is safer and cheaper.
+- **Measuring only rankings** — you can rank #1 and still be invisible in AI answers. Validate both lines.
+- **Ignoring third-party presence** — citations don't equal recommendations; offsite consensus is the recommendation lever.
+
+---
+
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md).
+
+| Tool | Use For |
+|------|---------|
+| `semrush` / `ahrefs` | Demand scoring, ranking, content-gap (SEO line) |
+| `gsc` | Search Console performance, query tracking (SEO line) |
+| `ga4` | Referral traffic from AI sources (GEO line) |
+| Peec AI / Otterly / ZipTie | Cross-platform AI citation & share-of-voice (GEO line) |
+
+---
+
+## Task-Specific Questions
+
+1. Which queries have *both* search demand and AI-ask demand for you?
+2. Do you currently rank AND get cited for them, or only one?
+3. Is your content structured with an answer block + depth, or just long-form?
+4. Do you have Layer 1/2/3 schema in place (JSON-LD, llms.txt, entity presence)?
+5. Are you validating both the SEO line and the GEO line monthly?
+
+---
+
+## Related Skills
+
+- **ai-seo** — Deep generative-engine theory, platform ranking factors, full AI-visibility audit (read this first for background)
+- **schema** — Implementing JSON-LD structured data (Layer 1)
+- **content-strategy** — Planning the topical cluster and content calendar
+- **seo-audit** — Traditional technical/on-page SEO health
+- **ab-testing** — Measuring which dual-frontier variant wins (title, answer block, structure)
+- **copywriting** — Writing content that's human-readable and AI-extractable

--- a/skills/geo-dual-frontier/evals/evals.json
+++ b/skills/geo-dual-frontier/evals/evals.json
@@ -1,0 +1,84 @@
+{
+  "skill_name": "geo-dual-frontier",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We keep hearing about GEO and SEO as separate things. Can you give me an operating method to make one piece of content rank on Google AND get cited by ChatGPT and Perplexity at the same time? We're a hotel with a wedding banquet hall.",
+      "expected_output": "Should introduce the dual-frontier method: one asset serving both the search-frontier (Google ranking) and the answer-frontier (AI citation). Should explain the overlap (clear, factual, structured, sourced content rewards both) and the divergence (Google wants E-E-A-T/links; AI wants extractable passages). Should present the 4-step workflow: (1) dual-frontier keyword selection scoring Demand × AI-Query-Fit, (2) dual-frontier content structure with a 40-60 word answer block + depth, (3) three-layer schema, (4) dual-line validation. Should reference ai-seo for deep theory. Should not recommend writing a separate AI-only version (Google spam risk).",
+      "assertions": [
+        "Frames it as one asset for two fronts (SEO + GEO), not two separate efforts",
+        "Explains the overlap and divergence between Google and AI selection",
+        "Presents the 4-step workflow (keyword selection, content structure, schema, validation)",
+        "Recommends a 40-60 word answer block plus long-form depth",
+        "Warns against a separate AI-only version (scaled-content-abuse risk)",
+        "References ai-seo for background theory"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "How do I decide which keywords are worth the dual-frontier treatment versus just normal SEO?",
+      "expected_output": "Should describe the dual-frontier keyword selection matrix: score each query on Demand (search volume, difficulty, business value) and AI-Query-Fit (natural-language question, comparison/definition/how-to/pricing intent, confirmed by asking the AI directly). Multiply for a Dual score. Should give decision rules: Dual ≥ 16 = full treatment; one axis strong = build for strong axis and add minimum structure for the weak one; both weak = skip or fold into a cluster page. Should mention fan-out / topical cluster coverage.",
+      "assertions": [
+        "Uses a two-axis scoring (Demand × AI-Query-Fit)",
+        "Explains how to measure each axis",
+        "Gives concrete decision rules based on the Dual score",
+        "Recommends validating AI-Query-Fit by asking the AI directly",
+        "Mentions fan-out / topical cluster coverage"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I wrote a long blog post about our wedding banquet pricing. It ranks okay but AI assistants never cite us. What should I change?",
+      "expected_output": "Should diagnose the missing answer block and extraction structure. Should recommend adding a 40-60 word direct answer block at the top answering the exact query (snippet + extraction bait), keeping the long-form depth below for ranking and AI context. Should add FAQ schema, comparison tables, and real statistics with dated sources. Should NOT suggest rewriting a separate AI-only version. Should point to the three-layer schema (JSON-LD, llms.txt/pricing.md, entity presence) and dual-line validation to confirm the fix worked.",
+      "assertions": [
+        "Identifies the missing answer block as the core issue",
+        "Recommends a 40-60 word answer block at the top + keep depth below",
+        "Adds FAQ schema / tables / sourced statistics",
+        "Does not recommend a separate AI-only rewrite",
+        "Points to three-layer schema and dual-line validation"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "What's this 'three-layer schema' you mention for making content machine-readable for AI? Do I need llms.txt and OKF?",
+      "expected_output": "Should explain the three layers: Layer 1 on-page JSON-LD (Article/FAQPage/HowTo/Product) for Google rich results; Layer 2 machine-readable files (llms.txt, /pricing.md, OKF bundle) for non-Google AI engines and buying agents; Layer 3 entity & third-party presence (Google Business Profile, Wikipedia, reviews) that drives AI recommendations not just citations. Should clarify Google does not require llms.txt/OKF for AI Overviews but they help other engines without harming Google. Should give a rollout order: Layer 1 first, then 2, then 3. Should reference the schema skill for Layer 1 implementation.",
+      "assertions": [
+        "Explains all three layers distinctly",
+        "Clarifies llms.txt/OKF are not required by Google but help other engines",
+        "Distinguishes citations from recommendations (Layer 3)",
+        "Gives a rollout order (1 → 2 → 3)",
+        "References the schema skill for JSON-LD"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "How do I prove our dual-frontier content is actually working? We only look at Google rankings today.",
+      "expected_output": "Should introduce dual-line validation: measure the SEO line (ranking position, GSC impressions/clicks, featured snippets) AND the GEO line (cited in ChatGPT/Perplexity/AI Overviews, which page, share of voice via Peec AI/Otterly/ZipTie). Should describe a monthly cadence: top 20 queries, record both lines, flag queries where one line lags and apply a targeted fix. Should warn about the attribution blind spot (AI-influenced visits often show as branded/direct, not referral). Should note you can rank #1 yet be invisible in AI answers.",
+      "assertions": [
+        "Measures both SEO line and GEO line, not just rankings",
+        "Names concrete GEO measurement tools or manual checks",
+        "Describes a recurring cadence with a scoring sheet",
+        "Recommends fixing the weaker line with targeted changes",
+        "Warns about the attribution blind spot and rank-without-citation risk"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Can we just generate a bunch of AI-optimized spun articles with made-up stats to rank and get cited fast?",
+      "expected_output": "Should firmly reject fabricated stats and spun content. Should explain that fabricated numbers break both Google E-E-A-T and AI trust simultaneously, and that keyword stuffing actively reduces AI visibility ~10%. Should explain that separate 'AI-only' spun variants risk Google's scaled-content-abuse spam policy. Should reframe toward the legitimate dual-frontier method: one real, sourced, structured document serving both fronts, with real scarcity only and AI crawlers allowed in robots.txt.",
+      "assertions": [
+        "Rejects fabricated stats and spun/AI-only content",
+        "Explains fabricated claims fail both Google and AI trust",
+        "Warns about scaled-content-abuse spam policy for AI-only variants",
+        "Notes keyword stuffing reduces AI visibility",
+        "Reframes toward the legitimate one-document dual-frontier method"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/geo-dual-frontier/references/dual-frontier-content-template.md
+++ b/skills/geo-dual-frontier/references/dual-frontier-content-template.md
@@ -1,0 +1,56 @@
+# Dual-Frontier Content Template (双栖文)
+
+One document, two layers. The same prose serves Google (ranks) and AI (gets cited). Do not write a separate AI version.
+
+## Anatomy
+
+```
+# [H1: exact query phrasing]
+
+## Answer (Layer A — 40–60 words, first)
+Direct answer to the exact question. Self-contained. No "click here to read more".
+Sources inline where a number appears.
+
+## [H2: Fan-out sub-question 1]
+Depth: original data, expert quote, comparison table. One idea per paragraph.
+
+## [H2: Fan-out sub-question 2]
+...
+
+## FAQ (Layer + FAQPage schema)
+Q (natural language) / A (40–60 words each)
+
+Last updated: [date]
+```
+
+## Annotated Example — Wedding Banquet Query
+
+**Q: 天津办婚宴 450㎡ 无柱宴会厅多少钱一桌？实测瑞湾**
+
+> **Answer block (Layer A):**
+> 瑞湾开元名都婚宴 2199 元/桌起（第三方婚嫁平台观测起步价，hunlimao 另列 3380–4880 高端档），主力档 2599 元含五楼开元厅 450㎡ 无柱大厅+专属布置、新娘房、双早。同档滨海酒店普遍 3500+，瑞湾性价比突出。正式报价以酒店销售口径为准。
+
+**Why it works on both fronts:**
+- **Google:** answers the exact search query first → featured-snippet candidate; "Last updated" + structured comparison satisfy E-E-A-T.
+- **AI:** the 40–60 word block is directly extractable; the sourced price range gives AI a verifiable fact to cite (no fabricated precision).
+
+**Depth layer below** covers: how many tables fit (30, no sightline blockage),温泉 water source (1800m underground, in-room), breakfast (200+ types), nearby transport — the fan-out variants a couple might also ask.
+
+## Rules
+
+- **Answer block must stand alone.** If you delete everything after it, it still answers the question.
+- **Every number gets a dated, linked source.** Fabricated stats fail both fronts.
+- **Tables > prose** for comparisons; **numbered lists > prose** for how-to.
+- **One idea per paragraph.** AI extracts passages, not pages.
+- **Show freshness.** "Last updated: [date]" near the top or bottom.
+- **No keyword stuffing.** It actively reduces AI visibility ~10%.
+
+## GEO Block Patterns (reuse across pages)
+
+- **Definition block** — "What is [X]?" → one-paragraph definition.
+- **Statistic block** — claim + number + source link + date.
+- **Comparison table** — "[X] vs [Y]" with feature columns.
+- **FAQ block** — natural-language Q + 40–60 word A.
+- **How-to block** — numbered steps.
+
+For the citation-boost research behind these (Princeton GEO study), see `ai-seo` → Authority pillar.

--- a/skills/geo-dual-frontier/references/dual-frontier-keywords.md
+++ b/skills/geo-dual-frontier/references/dual-frontier-keywords.md
@@ -1,0 +1,43 @@
+# Dual-Frontier Keyword Selection (双栖筛词)
+
+The first step of the dual-frontier method: find queries that deserve **both** an SEO investment and a GEO investment. A keyword that only ranks, or only gets asked to AI, captures only half the value of the same writing effort.
+
+## The Two Axes
+
+### Axis 1 — Demand (SEO worthiness)
+- **Search volume** — how many searches/month (Semrush, Ahrefs, GSC, Keyword Planner).
+- **Difficulty** — can you realistically rank? Low-authority sites need long-tail.
+- **Business value** — does ranking drive revenue or just traffic?
+
+### Axis 2 — AI-Query-Fit (GEO worthiness)
+A query is GEO-worthy when it is phrased the way people actually ask AI assistants:
+- **Natural-language question** — "how much is a wedding banquet per table in Tianjin?" not "Tianjin wedding banquet price".
+- **Comparison intent** — "[X] vs [Y]", "best [category] for [use case]".
+- **Definition intent** — "what is [concept]".
+- **How-to intent** — "how to [solve problem]".
+- **Pricing/spec intent** — "[product] pricing", "[product] specs".
+
+Validate by **asking the AI directly**: paste the query into ChatGPT and Perplexity. Does an AI Overview or cited answer appear? Are competitors cited? That tells you the query is live on the answer-frontier.
+
+## The Matrix
+
+Score each candidate 1–5 on both axes, multiply for a Dual score (1–25).
+
+| Query | Demand | AI-Fit | Dual | Action |
+|-------|:------:|:------:|:----:|--------|
+| "天津婚宴 多少钱一桌" | 4 | 5 | 20 | ✅ Primary dual-target |
+| "best CRM 2026" | 5 | 3 | 15 | ⚠️ SEO-led; add answer block |
+| "our founding story" | 1 | 2 | 2 | ❌ Skip |
+| "how to write a refund policy" | 3 | 4 | 12 | ⚠️ GEO-led; ensure it also ranks |
+
+## Decision Rules
+
+- **Dual ≥ 16** → full dual-frontier treatment (answer block + depth + 3-layer schema).
+- **One axis strong / one weak** → build for the strong axis, add the *minimum* structure for the weak one:
+  - SEO-strong, GEO-weak → add a 40–60 word answer block + FAQ schema so AI can extract it.
+  - GEO-strong, SEO-weak → ensure the page is indexable, has E-E-A-T signals, and targets a real cluster so it can rank.
+- **Both weak** → skip or fold into a broader cluster page.
+
+## Fan-Out Coverage
+
+For each primary dual-target, list the 5–10 related queries the AI will fan out to (synonyms, sub-questions) and confirm your content (or site) covers them. Single-page-per-keyword targeting underperforms on both fronts; topical authority wins. See `ai-seo` → Query Fan-Out and `content-strategy` for cluster planning.

--- a/skills/geo-dual-frontier/references/dual-line-validation.md
+++ b/skills/geo-dual-frontier/references/dual-line-validation.md
@@ -1,0 +1,45 @@
+# Dual-Line Validation (双线验证)
+
+A dual-frontier asset is only "done" when it performs on **both** lines. Validate and report them together; optimize whichever line lags.
+
+## The Two Lines
+
+| Line | Question | Metrics | How to check |
+|------|----------|---------|--------------|
+| **SEO line** | Do we *rank*? | Position, GSC impressions, clicks, featured-snippet wins | GSC; Semrush/Ahrefs |
+| **GEO line** | Are we *cited*? | Cited in AI answer? Which page? Share of voice | Manual (ChatGPT/Perplexity/AI Overviews); Peec AI, Otterly, ZipTie |
+
+You can rank #1 and still be invisible in AI answers — and vice versa. Measuring only one line hides half the picture.
+
+## Monthly Cadence
+
+1. Pick your top 20 dual-frontier queries (from Step 1 matrix).
+2. For each, record:
+   - **SEO:** Google position (manual or GSC), snippet won?
+   - **GEO:** Ask ChatGPT + Perplexity + check AI Overview. Cited? Which URL? Competitors cited instead?
+3. Log month-over-month in a sheet.
+4. Flag any query where one line is strong and the other weak → targeted fix:
+   - Ranks but not cited → add answer block / FAQ schema / statistics with sources.
+   - Cited but not ranking → build E-E-A-T, internal links, acquire a backlink, cover fan-out cluster.
+
+## Scoring Sheet Template
+
+| Query | SEO pos | Snippet? | Cited (ChatGPT) | Cited (Perplexity) | AIO? | Weak line | Fix |
+|-------|:------:|:--------:|:---------------:|:------------------:|:----:|-----------|-----|
+| 天津婚宴 多少钱一桌 | 8 | No | No | Yes (competitor) | No | SEO+Citations | Add answer block, earn 1 backlink |
+| best crm for startups | 3 | Yes | Yes | Yes | Yes | — | Maintain |
+
+## Tools
+
+- **SEO line:** GSC (Performance, Coverage), Semrush, Ahrefs.
+- **GEO line:** Peec AI (ChatGPT/Gemini/Perplexity/Claude/Copilot+), Otterly (ChatGPT/Perplexity/AIO), ZipTie (AIO/ChatGPT/Perplexity).
+- **Referral signal:** GA4 — but note the attribution blind spot: most AI-influenced visits appear as branded search / direct, not "ai.com". Track with prompt tracking + self-reported attribution, not just referral paths.
+
+## What "Good" Looks Like
+
+- Primary dual-targets: ranking on page 1 **and** cited in ≥2 of {ChatGPT, Perplexity, AI Overviews}.
+- Answer block extracted by AI (verify by asking the exact query and seeing your phrasing).
+- Schema validated (Google Rich Results Test passes).
+- `llms.txt` / `/pricing.md` present and current.
+
+For experimenting with which answer-block phrasing or title wins on either line, see **ab-testing**.

--- a/skills/geo-dual-frontier/references/three-layer-schema.md
+++ b/skills/geo-dual-frontier/references/three-layer-schema.md
@@ -1,0 +1,61 @@
+# Three-Layer Schema (三层Schema)
+
+Make dual-frontier content machine-readable on three layers so both Google and AI engines can parse, extract, and cite it. You do not need all three at once — start with Layer 1, add Layer 2/3 as authority grows.
+
+## Layer 1 — On-page JSON-LD (Google rich results)
+
+For implementation details and templates, use the **schema** skill. Key types:
+
+| Content | Schema | Why |
+|---------|--------|-----|
+| Article / blog | `Article`, `BlogPosting` | Author, date, topic ID |
+| FAQ | `FAQPage` | Direct Q&A extraction |
+| How-to | `HowTo` | Step extraction |
+| Product / pricing | `Product`, `Offer` | Price, availability, reviews |
+| Comparison | `ItemList` | Structured comparison |
+| Org | `Organization` | Entity recognition |
+
+Content with proper schema shows **30–40% higher AI visibility** on non-Google engines. Google: structured data is "not required for generative AI search" but recommended for overall SEO.
+
+## Layer 2 — Machine-readable files (AI engines & buying agents)
+
+AI agents increasingly evaluate products programmatically before a human visits. Opaque, JS-rendered, or "contact sales" pricing gets filtered out.
+
+**`/llms.txt`** (llmstxt.org) — a concise context file telling AI what your site is, who it's for, and linking to key pages (including pricing). No confirmed ranking signal yet; treat as protocol-layer registration like early schema.org.
+
+**`/pricing.md` or `/pricing.txt`** — structured, parseable facts:
+
+```markdown
+# Pricing — [Product]
+## Standard
+- Price: ¥2599/table (wedding banquet, observed starting price)
+- Includes: 450㎡ pillar-free hall (5F Kaiyuan), bridal suite, double breakfast
+- Source: third-party wedding platforms; confirm with sales
+## Premium
+- Price: ¥3380–4880/table
+- Includes: full package + premium decor
+```
+
+Best practices: consistent units; specific limits not just feature names; list what's *included* at each tier; keep updated (stale pricing is worse than none); link from sitemap and main pricing page.
+
+**`/okf/` — Open Knowledge Format bundle** (Google-backed, v0.1): a directory of cross-linked markdown files with YAML frontmatter representing site content, agent-readable without scraping. Free generator, WordPress plugin, or by-hand. No confirmed AI-search ranking signal today — protocol-layer registration.
+
+> Google's stance: these files are **not required** for AI Overviews/AI Mode. Include them because non-Google engines (ChatGPT, Claude, Perplexity) and autonomous buying agents reward extractable structure — without harming Google.
+
+## Layer 3 — Entity & third-party presence (drives recommendations)
+
+Citations ≠ recommendations. Getting *cited* means consulted; getting *recommended* (onto the buyer's shortlist) is governed by web-wide consensus:
+
+- **Google Business Profile** + **Merchant Center** feeds — local/business visibility in AI Search.
+- **Wikipedia / entity data** — accurate, current.
+- **Review platforms** — G2, Trustpilot, Capterra, industry-specific.
+- **Authentic community participation** — Reddit, forums, Quora (real, not spam).
+- **Earned media / PR** — press, analyst mentions.
+
+In one 100-query B2B study, 69% of AI Overview citations earned by self-promotional "best [category]" listicles appeared in answers that recommended *competitors* instead. Build offsite consensus; don't rely on self-published listicles for recommendations. See `ai-seo` → citations-vs-recommendations.
+
+## Rollout Order
+
+1. Layer 1 (JSON-LD) — cheap, high payoff, do first.
+2. Layer 2 (`llms.txt` + `/pricing.md`) — once you have stable, factual data.
+3. Layer 3 (entity + reviews) — ongoing, the recommendation lever.

--- a/validate-skills-official.sh
+++ b/validate-skills-official.sh
@@ -5,6 +5,10 @@
 
 SKILLS_DIR="skills"
 SKILLS_REF_DIR="/tmp/agentskills/skills-ref"
+# Capture the script's own directory up front. The install block below does
+# `cd` into SKILLS_REF_DIR, so we cannot rely on `cd "$(dirname "$0")"` later
+# (that resolves relative to the *current* dir at call time, not the repo root).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "🔍 Validating Skills Using Official skills-ref Library"
 echo "========================================================"
@@ -39,7 +43,7 @@ fi
 source "$SKILLS_REF_DIR/.venv/bin/activate"
 
 # Return to the original directory
-cd "$(dirname "$0")"
+cd "$SCRIPT_DIR"
 
 # Track results
 PASSED=0


### PR DESCRIPTION
## Summary

Adds **geo-dual-frontier** — the dual-frontier operating workflow for producing *one* content asset that wins **both** battlefields at once:

- **Search-frontier (SEO):** rank on Google/Bing for high-intent queries.
- **Answer-frontier (GEO):** get extracted and cited by AI assistants (ChatGPT, Perplexity, Gemini, AI Overviews).

Most teams run SEO and GEO as separate calendars. This skill plans, writes, and validates content once, exploiting the large overlap (clear, factual, structured, sourced content rewards both). It complements **ai-seo** (which covers theory + the AI-visibility audit) rather than duplicating it.

## What's included

- SKILL.md — 4-step workflow:
  1. Dual-frontier keyword selection — score every query on Demand x AI-Query-Fit; only build for both.
  2. Dual-frontier content structure — 40-60 word answer block (snippet + extraction bait) + sourced long-form depth; no separate AI-only rewrite (Google spam risk).
  3. Three-layer schema — JSON-LD / llms.txt + /pricing.md + OKF / entity & third-party presence.
  4. Dual-line validation — measure ranking AND AI citation monthly; fix the weaker line.
  - Plus ethics guardrails (no fabricated stats, real scarcity only, do not block AI crawlers).
- references/ — keyword matrix, content template (annotated hotel example), three-layer schema, validation checklist.
- evals/evals.json — 6 quality-gate evals.
- Registered in README + VERSIONS.md; release bumped to 2.11.0.

## Validation

- Local validate-skills.sh: all 50 skills pass (incl. geo-dual-frontier).
- Official skills-ref validate skills/geo-dual-frontier: Valid skill.

## Bonus fix

validate-skills-official.sh had a cd bug: the install block cd's into SKILLS_REF_DIR, then the later cd "$(dirname "$0")" resolved relative to that dir (a no-op), so the skills/*/ glob never matched and every skill falsely failed. Captured SCRIPT_DIR up front and cd back to it. Now the wrapper validates all 50 skills correctly.

## Test plan

- [ ] bash validate-skills.sh passes
- [ ] bash validate-skills-official.sh passes (geo-dual-frontier checkmark)
- [ ] skills-ref validate skills/geo-dual-frontier -> Valid skill