### PR TITLE
fix(attribution): Google/GA4 model availability + accuracy polish (2.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,7 +9,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | ai-seo | 2.2.0 | 2026-07-09 |
 | analytics | 2.0.1 | 2026-07-22 |
 | aso | 2.0.0 | 2026-05-05 |
-| attribution | 1.1.0 | 2026-07-23 |
+| attribution | 1.1.1 | 2026-08-05 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
 | co-marketing | 2.0.0 | 2026-05-05 |
 | cold-email | 2.0.0 | 2026-05-05 |
@@ -25,7 +25,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
-| influencer-marketing | 1.0.0 | 2026-07-15 |
+| influencer-marketing | 1.0.1 | 2026-08-05 |
 | launch | 2.0.1 | 2026-06-16 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
@@ -55,6 +55,11 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.10.1 (2026-08-05)
+
+- **attribution** (1.1.0 → 1.1.1): accuracy pass. Clarifies that Google Ads/GA4 retired rule-based models (first-click / linear / time-decay / position-based) — teach them as concepts / DIY on own path data, not Google dropdowns. Updates DDA volume guidance to Google's current ~200 conversions / ~2,000 interactions recommendation. Fixes "six models" wording (last non-direct = last-touch variant). Tightens ghost-ads definition; clarifies Calendly only accepts standard UTMs/`salesforce_uuid` (map anon id into a UTM). Adds click-MTA demand-capture bias, survey-discount + no platform-gap-multiplier guidance, and a short triangulated override / insertion note in `measurement-paradigms.md`. Eval #2 updated accordingly.
+- **influencer-marketing** (1.0.0 → 1.0.1): Related Skills / measurement section now hand branded-search & direct blind spots to **attribution** (keep **ai-seo** for AI-search discovery).
 
 ### 2.10.0 (2026-07-22)
 

--- a/skills/attribution/SKILL.md
+++ b/skills/attribution/SKILL.md
@@ -2,7 +2,7 @@
 name: attribution
 description: When the user wants to figure out which marketing actually drives conversions and revenue, choose or interpret an attribution model, or reconcile conflicting numbers across tools. Also use when the user mentions "attribution," "attribution model," "first-touch vs last-touch," "multi-touch," "which channel drives revenue," "what's my real CAC," "my dashboards disagree," "Google/Meta says X but GA says Y," "media mix model," "MMM," "incrementality," "geo lift," "holdout test," "how did you hear about us," "self-reported attribution," "dark social," or wants to instrument attribution themselves — "stitch my bookings to their source," "SavvyCal/Calendly attribution," "close the identify gap," "track conversions on a third-party domain," "first-party / self-hosted attribution." For event tracking setup and UTMs, see analytics. For ad-platform pixels/CAPI, see ads. For pipeline and CRM revenue reporting, see revops. For the AI-search attribution blind spot, see ai-seo.
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 # Attribution
@@ -43,7 +43,7 @@ When a user demands one true number, reframe: "We can get you a *defensible, con
 
 ### 2. Attribution models
 
-The six standard models and when each one lies:
+The classic rule-based set plus data-driven — and when each one lies. **Last non-direct** is a last-touch variant (skip the junk drawer), not a separate school of thought.
 
 | Model | Credit rule | Best for | How it lies |
 |---|---|---|---|
@@ -55,12 +55,14 @@ The six standard models and when each one lies:
 | **Position-based (U-shaped)** | 40% first, 40% last, 20% middle | B2B with clear "created" + "closed" moments | The 40/40/20 split is arbitrary; middle touches get shortchanged |
 | **Data-driven (algorithmic/Shapley)** | Credit from modeled marginal contribution | High-volume accounts with enough conversions | A black box; needs volume; can't see offline/dark touches it was never fed |
 
+**Platform availability note:** Google Ads and GA4 retired first-click, linear, time-decay, and position-based as selectable reporting models (2023). Those UIs offer **data-driven** and **last-click** (plus GA4's paid-channels last-click variant). Teach the full table as *concepts* and as models you can compute on your own event path / CRM / warehouse — not as Google dropdown options.
+
 **Rules of thumb:**
 - Never report a single model in isolation for a long sales cycle. Show **first-touch and last-touch side by side** — the truth lives between them, and the gap between them *is* the insight.
-- Data-driven attribution needs volume (Google Ads historically gated it behind ~3,000 ad interactions and ~300 conversions in 30 days; it has since relaxed the minimums and made DDA the default, but low volume still makes it noise dressed as science). Use position-based instead when you're thin.
+- Data-driven attribution needs volume. Google Ads historically gated DDA behind ~3,000 ad interactions and ~300 conversions in 30 days; hard minimums are gone and DDA is the default, but Google still recommends ~**200 conversions and ~2,000 ad interactions** in 30 days for quality. Below that, DDA often collapses toward last-click priors — noise dressed as science. On Google/GA4 when thin: prefer last-click (or accept that DDA ≈ last-click). Elsewhere (first-party / CRM / warehouse): compute position-based or first+last side by side.
 - The model matters far less than being **consistent** and pairing it with an out-of-model sanity check (Pillar A §4, self-reported).
 
-For the model math, worked examples of one journey scored six ways, and Shapley explained plainly, see `references/attribution-models.md`.
+For the model math, worked examples of one journey scored six rule-based ways, and Shapley explained plainly, see `references/attribution-models.md`.
 
 ### 3. The three measurement paradigms
 
@@ -68,7 +70,7 @@ Models split credit *within* your tracked data. Paradigms are how you get at *ca
 
 | Paradigm | What it is | Answers | Needs | Watch out |
 |---|---|---|---|---|
-| **MTA** (multi-touch attribution) | Stitch user-level touches, apply a model | "Which touchpoints appear on converting journeys?" | Clean cross-device user-level tracking | Cookie loss + privacy have gutted user-level data; it silently under-measures |
+| **MTA** (multi-touch attribution) | Stitch user-level touches, apply a model | "Which touchpoints appear on converting journeys?" | Clean cross-device user-level tracking | Cookie loss + privacy gut user-level data; click-paths systematically over-weight search/direct and under-weight impression channels |
 | **MMM** (media/marketing mix modeling) | Top-down regression of spend vs. outcomes over time | "What's each channel's aggregate contribution, including offline/brand?" | 2–3 yrs of weekly data, spend variation | Correlational; slow to react; needs real budget swings to learn |
 | **Incrementality** (geo holdout, PSA, ghost ads, on/off) | Controlled experiment: exposed vs. withheld | "Did this channel *cause* lift I wouldn't have gotten anyway?" | Ability to withhold; enough volume for significance | The gold standard, but you can only test a few things at a time |
 
@@ -83,7 +85,7 @@ The most underused signal, and often the most honest for long cycles and dark so
 - **When it beats tracking:** long consideration cycles, high word-of-mouth, brand/community-led, or heavy dark-social (see §5). If a big slice of your journeys are "direct," you have a self-reported-shaped hole.
 - **Ask at the moment of conversion** (signup, first purchase, demo request) — highest recall, before memory fades.
 - **Wording:** open-ended ("How did you first hear about us?") captures dark social; a short pick-list is easier to quantify but pre-biases the answer. Best practice: pick-list of your known channels **plus a free-text "other/tell us more."**
-- **Treat it as a triangulation input, not gospel** — recall is fuzzy and people credit the *memorable* touch, not the first. It's the out-of-model check that keeps your tracked models honest.
+- **Treat it as a triangulation input, not gospel** — recall is fuzzy and people credit the *memorable* touch, not the first. **Discount survey share when turning it into credit** (e.g. 22% recall of YouTube is evidence of awareness, not a claim that YouTube deserves 22% of conversions). Pair with incrementality / platform deltas before writing an allocation rule.
 - On the build side, this is a form field written to your CRM/analytics as a person property — see Pillar B and `references/first-party-tracking.md`.
 
 ### 5. Reconciling conflicting sources
@@ -103,8 +105,9 @@ The request behind most attribution work: **"Google says 50, Meta says 40, GA sa
 1. **Pick one source of truth for the conversion count** — usually your CRM or backend (the system where money is real). Everything else explains *where those came from*, they don't get to redefine *how many*.
 2. **Never sum across platforms.** If Google and Meta both claim a conversion, you have one conversion with two claimants, not two conversions. De-dupe against the source-of-truth total.
 3. **Read directional agreement, not absolute match.** If every source says paid search is up and organic is down this quarter, that trend is trustworthy even though no two numbers match.
-4. **Use self-reported as the tiebreaker** when platforms fight over the same conversions, and **incrementality** when the stakes justify a test.
+4. **Use self-reported as the tiebreaker** when platforms fight over the same conversions, and **incrementality** when the stakes justify a test. Do **not** turn a platform-vs-GA gap into a multiplier rule (Meta claims 2× GA ≠ "double Meta") — investigate windows and view-through, then ground any override in incrementality.
 5. **Expect and budget for the gap.** Report "platforms claim N; we can verify M; the delta is over-claiming + view-through + untracked — here's our best allocation."
+6. **Operationalize triangulation as rules when you can** — once you have a holdout or a trusted survey band for a channel, apply a documented **channel-level override** on reporting (shift credit from Direct/branded into the under-credited channel for the test window) rather than pretending raw MTA is truth. Details in `references/measurement-paradigms.md`.
 
 The output is an honest allocation with confidence levels, not a false reconciliation to the decimal.
 

--- a/skills/attribution/evals/evals.json
+++ b/skills/attribution/evals/evals.json
@@ -19,12 +19,12 @@
     {
       "id": 2,
       "prompt": "Should we use first-touch or last-touch attribution? We're a B2B SaaS with a sales cycle that runs about two months and multiple people involved in each deal.",
-      "expected_output": "Should refuse to pick one in isolation and recommend showing first-touch and last-touch side by side, because the gap between them is the insight for a long cycle. Should explain what each model over/under-credits (first-touch ignores what closed; last-touch over-credits branded search/direct and defunds top of funnel). Should recommend position-based as a defensible primary for B2B (credits created + closed bookends), and lean on self-reported attribution at demo/signup given offline touches. Should point to CRM/pipeline as source of truth (revops) and note data-driven attribution needs volume this business likely lacks. May reference references/attribution-models.md and references/by-business-type.md.",
+      "expected_output": "Should refuse to pick one in isolation and recommend showing first-touch and last-touch side by side, because the gap between them is the insight for a long cycle. Should explain what each model over/under-credits (first-touch ignores what closed; last-touch over-credits branded search/direct and defunds top of funnel). Should recommend position-based as a defensible primary for B2B on the team's own path/CRM data (credits created + closed bookends) — not as a Google Ads/GA4 dropdown option (those UIs retired rule-based models). Should lean on self-reported attribution at demo/signup given offline touches. Should point to CRM/pipeline as source of truth (revops) and note data-driven attribution needs volume this business likely lacks. May reference references/attribution-models.md and references/by-business-type.md.",
       "assertions": [
         "Does not recommend a single model in isolation",
         "Recommends showing first-touch and last-touch together",
         "Explains what first-touch and last-touch each distort",
-        "Recommends position-based as a strong B2B primary",
+        "Recommends position-based as a strong B2B primary on own/CRM data (not as a Google UI model)",
         "Emphasizes self-reported attribution for long/offline B2B cycles",
         "References pipeline/CRM as the revenue source of truth (revops boundary)"
       ],

--- a/skills/attribution/references/attribution-models.md
+++ b/skills/attribution/references/attribution-models.md
@@ -1,6 +1,8 @@
 # Attribution Models — The Math, Worked
 
-Six standard models, one journey scored six ways, and data-driven attribution explained without the black box. Use this when the user wants to understand *why* two models disagree, or needs to pick one defensibly.
+Six rule-based credit rules on one journey, plus data-driven attribution explained without the black box. Use this when the user wants to understand *why* two models disagree, or needs to pick one defensibly.
+
+**Availability:** Google Ads and GA4 no longer offer first-click, linear, time-decay, or position-based as reporting models (retired 2023). Use this file for *concepts* and for scoring journeys on your own data (CRM, warehouse, first-party path). In Google UIs today: data-driven and last-click only.
 
 ## The worked journey
 
@@ -16,9 +18,9 @@ A single B2B buyer's path to a $12,000 annual deal, five touches over 38 days:
 
 The whole point: **the touch that gets credit depends entirely on the model, and each model tells a different story about where your $12k came from.**
 
-## The six models, applied
+## The six rule-based models, applied
 
-Credit for the $12,000 deal under each model:
+Credit for the $12,000 deal under each rule (last non-direct is a last-touch variant that skips Direct):
 
 | Touch | Channel | First-touch | Last-touch | Last non-direct | Linear | Time-decay | Position (U) |
 |---|---|---|---|---|---|---|---|
@@ -54,7 +56,7 @@ The plain-English version:
 So if journeys with a retargeting touch convert meaningfully more often than identical journeys without it, retargeting earns real credit. If adding a channel changes nothing, it earns ~zero — even if it appears on every path.
 
 **When it's worth it:**
-- You have **volume** — the counterfactuals need enough conversions to be stable. (Google Ads historically gated data-driven attribution behind ~3,000 ad interactions and ~300 conversions in 30 days; it has since relaxed the hard minimums and made data-driven the default model, but the underlying reality is unchanged: below real volume, DDA is noise dressed as science.) Use position-based instead when you're thin.
+- You have **volume** — the counterfactuals need enough conversions to be stable. Google Ads historically gated DDA behind ~3,000 ad interactions and ~300 conversions in 30 days; hard gates are gone and DDA is the default, but Google still recommends ~**200 conversions and ~2,000 ad interactions** in 30 days for quality. Below that, DDA often looks a lot like last-click. On Google/GA4 when thin: use last-click (or accept noisy DDA). On your own data: prefer position-based or first+last side by side.
 - Your journeys are **mostly digital and tracked** — Shapley can only weigh touches it was fed. Offline events, dark social, and cookie-lost touches are invisible to it, so a high-word-of-mouth B2B motion will get a confidently-wrong DDA. Pair it with self-reported (SKILL.md §4).
 
 **Its honest limitations:**
@@ -65,7 +67,7 @@ So if journeys with a retargeting touch convert meaningfully more often than ide
 ## Choosing — a short decision guide
 
 - **Short cycle, few touches, small volume** → last non-direct, plus a self-reported survey. Don't over-model.
-- **Long B2B cycle, clear created/closed moments** → position-based as the primary, first-touch + last-touch shown alongside.
+- **Long B2B cycle, clear created/closed moments** → position-based as the primary *on your own path data*, first-touch + last-touch shown alongside. (Not a Google Ads model picker option.)
 - **High volume, mostly-digital, need day-to-day allocation** → data-driven, validated periodically by incrementality.
 - **Offline + brand-heavy, real budget** → don't rely on any user-level model; go MMM + incrementality (see `measurement-paradigms.md`).
 

--- a/skills/attribution/references/first-party-tracking.md
+++ b/skills/attribution/references/first-party-tracking.md
@@ -232,7 +232,7 @@ A channel breakdown living in your analytics tool is a *report*. The thing sales
 | Anonymous id | `distinct_id` / `$device_id` | Segment `anonymousId`, Amplitude `deviceId`, GA4 client_id |
 | Merge call | `$identify` + `$anon_distinct_id` | Segment `identify` (known `userId`, same `anonymousId`) + `alias` where needed; Amplitude `setUserId` on the session that still holds the anonymous `deviceId` (the stitch is deviceId↔userId — Amplitude's Identify API only sets user *properties*, it does not merge); GA4 `user_id` on the same `client_id` |
 | Ingestion | `/batch/` | Segment HTTP API, Amplitude HTTP v2, GA4 Measurement Protocol |
-| Third-party passthrough | SavvyCal `metadata[...]` | Calendly UTM/`salesforce_uuid`, Cal.com metadata, Stripe `client_reference_id`/metadata |
+| Third-party passthrough | SavvyCal `metadata[...]` | **Calendly:** only standard UTMs (`utm_source`/`medium`/`campaign`/`content`/`term`) plus `salesforce_uuid` — map the anon id into a supported UTM (e.g. `utm_term`), not a free-form `metadata[]` param. Cal.com metadata; Stripe `client_reference_id`/metadata |
 | First-touch props | `$initial_*` | Segment/Amplitude first-touch, GA4 first_user_* dimensions |
 
 The shape never changes: **grab the anonymous id → carry it across the boundary → merge on the far side → break the conversion down by first-touch.**

--- a/skills/attribution/references/measurement-paradigms.md
+++ b/skills/attribution/references/measurement-paradigms.md
@@ -21,7 +21,9 @@ Attribution *models* (see `attribution-models.md`) split credit *within* your tr
 
 **Where it shines:** day-to-day, tactical decisions. "Is this campaign showing up on converting journeys?" Fast, granular, cheap if your tracking exists.
 
-**Why it's structurally weakening:** MTA depends on tracking one person across touches and devices, and that data keeps eroding — Safari/Firefox ITP-style cookie limits, iOS ATT, browser consent gating, ad blockers, and ordinary cross-device behavior (research on mobile, buy on desktop). (Chrome's third-party-cookie deprecation was announced, then walked back, so "cookies are going away" is no longer the clean story — but everything else on that list already limits user-level tracking today.) MTA doesn't announce the gap: it silently under-measures anything it can't follow (dumping it into direct) and over-measures what it *can* see. So treat MTA as **incomplete and directionally biased** — not a clean lower bound (its retargeting/branded numbers are often *over*-stated) — and never the sole basis for a big reallocation.
+**Why it's structurally weakening:** MTA depends on tracking one person across touches and devices, and that data keeps eroding — Safari/Firefox ITP-style cookie limits, iOS ATT, browser consent gating, ad blockers, and ordinary cross-device / in-app-browser behavior (research on mobile, buy on desktop). (Chrome's third-party-cookie deprecation was announced, then walked back, so "cookies are going away" is no longer the clean story — but everything else on that list already limits user-level tracking today.)
+
+Click-based paths add a second bias: **impression channels (social, video, display) often never enter the journey** — a view with no click leaves no stitchable touch — so MTA systematically **over-weights demand-capture** (search, email, direct) and **under-weights demand-creation**. MTA doesn't announce the gap: it silently under-measures anything it can't follow (dumping it into direct) and over-measures what it *can* see. Treat MTA as **incomplete and directionally biased** — not a clean lower bound (its retargeting/branded numbers are often *over*-stated) — and never the sole basis for a big reallocation.
 
 **Use it for:** ongoing optimization and trend-watching — never as the sole basis for a big budget reallocation.
 
@@ -48,7 +50,7 @@ Attribution *models* (see `attribution-models.md`) split credit *within* your tr
 **Common designs:**
 - **Geo holdout / geo-lift** — run the channel in some regions, hold it out of comparable ones; compare outcomes. The workhorse for channels you can't split at the user level. *(Meta's GeoLift, Google's geo experiments.)*
 - **PSA tests** — the control group is shown a *public-service ad* in your ad's place, so both groups are equally targeted and "ad-exposed"; the only difference is whether they saw *your* ad. Isolates ad effect from audience-quality bias (the exposed group isn't just "people the algorithm judged likely to convert").
-- **Ghost ads** — the control group is *held out of the auction* but the platform logs the ad that *would* have served them (no placeholder is shown); you compare converters among the would-have-been-exposed vs. actually-exposed. Cleaner and cheaper than PSAs (no wasted PSA spend), and the modern default where the platform supports it.
+- **Ghost ads** — the platform runs the auction but **withholds your ad** from the control group and logs the impression that *would* have served; the control user may see another advertiser's ad (or organic inventory) instead of a PSA placeholder. You compare converters among would-have-been-exposed vs. actually-exposed. Cleaner and cheaper than PSAs (no wasted PSA spend), and the modern default where the platform supports it. (Distinct from crude intent-to-treat, which withholds without logging the would-have-served set.)
 - **Intent-to-treat / on-off (pulse) tests** — turn a channel fully off for a defined window, watch what happens to total conversions. Crude but revealing, especially for "is branded search paid cannibalizing organic?"
 - **Holdout audiences** — withhold a random % from a retargeting or email program; the delta is the program's true lift.
 
@@ -68,7 +70,16 @@ You don't need to compute significance by hand, but you must read a result hones
 They're layers, not competitors:
 
 - **MTA** for daily/weekly tactical optimization and trend-watching — cheap, granular, directional.
-- **MMM** for quarterly/annual portfolio allocation across the full mix including offline — durable, holistic.
+- **MMM** for quarterly/annual portfolio allocation across the full mix including offline — durable, holistic. Prefer **marginal ROI / saturation curves** over average platform ROAS when allocating the next dollar.
 - **Incrementality** as the **calibration and tiebreaker** — the ground-truth that keeps MTA and MMM honest, run on your biggest bets.
+
+### Triangulated overrides (making MTA "closer to reality")
+
+When incrementality, surveys, and platform gaps all say the same channel is under-credited in click-MTA, **don't invent a platform-gap multiplier**. Document a rule:
+
+1. **Channel-level override (reporting layer):** after MTA runs, shift a bounded share of conversions from Direct / branded search into the under-credited channel for the window you have evidence for (holdout dates, campaign flight). Keep the raw MTA table intact; decision dashboards read the adjusted table. Fast to ship; channel-level only.
+2. **User-level insertion (advanced):** before MTA runs, add synthetic touchpoints (e.g. "YouTube impression") onto a subset of Direct journeys where survey match, geo-test membership, or platform exposure logs justify it — then re-score. Needs engineering; unlocks creative/audience granularity.
+
+Start with one channel, one override, temporal bounds, and a conservative slice of measured lift (not 100% of a noisy point estimate). Expand only after stakeholders trust the first rule.
 
 **Scale to the user:** most SMBs need good UTMs + last-non-direct + a self-reported survey + the occasional on/off test — not an MMM. Bring MMM in when offline/brand spend is material and MTA visibly can't see it. Bring in formal incrementality when a single channel's budget is big enough that being wrong about it is expensive. Match the rigor to the size of the decision.

--- a/skills/influencer-marketing/SKILL.md
+++ b/skills/influencer-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: influencer-marketing
 description: "When the user wants to run influencer, creator, or ambassador partnerships to promote their product — finding and vetting partners, structuring deals, briefing creators, disclosure compliance, and measuring ROI. Also use when the user mentions 'influencer marketing,' 'creator partnerships,' 'sponsorships,' 'YouTube sponsorships,' 'podcast sponsorships,' 'brand ambassador,' 'ambassador program,' 'creator program,' 'UGC creators,' 'B2B influencers,' 'thought leader ads,' 'gifting,' 'product seeding,' 'whitelisting creator content,' 'how much to pay an influencer,' or 'FTC disclosure.' For affiliate/referral payout mechanics, see referrals. For community-led advocacy, see community-marketing. For turning creator content into paid ads, see ad-creative."
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Influencer & Creator Marketing
@@ -123,7 +123,7 @@ Influencer marketing suffers from attribution gaps — fix them upfront, before 
 - **Unique promo codes** (e.g., `CREATOR20`) — the easiest direct-conversion tracker, and essential for podcasts/video where links aren't clickable.
 - **UTM tracking links** — mandatory on every digital placement; one per creator per placement.
 - **Vanity / dedicated landing pages** — `yourdomain.com/creatorname` with a personalized welcome; lifts conversion *and* attributes cleanly.
-- **Post-purchase survey** — "How did you hear about us?" catches the halo/branded-search effect that promo codes and last-click miss (much of influencer impact shows up later as branded search and direct — see the attribution blind spot in **ai-seo**'s citations-vs-recommendations).
+- **Post-purchase survey** — "How did you hear about us?" catches the halo/branded-search effect that promo codes and last-click miss (much of influencer impact shows up later as branded search and direct — see **attribution** for the blind-spot framework; **ai-seo** when the discovery path was AI search).
 - **Whitelisting performance** — when you repurpose creator content as ads, that ad's own metrics are a clean read on the creative's real pull.
 
 Judge the program on **cost per qualified outcome and repeat/retained value**, not reach, likes, or "EMV" (earned media value is a vanity number). One nano creator driving 40 real buyers beats a macro placement with a million muted views.
@@ -193,5 +193,6 @@ Dedicated creator-discovery/CRM platforms (e.g., Modash, GRIN, Aspire, Upfluence
 - **ad-creative** — repurpose creator content into paid ads (whitelisting); creative review page for sign-off
 - **cold-email** — the creator outreach itself (personalization, deliverability, follow-up)
 - **customer-research** — find existing advocates and ground the talking points
-- **ai-seo** — the branded-search/direct attribution blind spot that hides influencer impact
+- **attribution** — reconciling promo-code / UTM / survey / platform numbers; branded-search and direct blind spots that hide influencer impact
+- **ai-seo** — when discovery happened in AI search (citations vs. recommendations)
 - **social** — organic content strategy the partnerships plug into


### PR DESCRIPTION
## Summary

Accuracy follow-up to the attribution skill (#473 / #507). Stops agents from recommending Google Ads / GA4 attribution models that Google removed, updates volume guidance, and cleans up a few related wording and skill-handoff issues.

**Skills touched:** `attribution` (main), `influencer-marketing` (small handoff)

## Type of update

- [x] Bug fix (incorrect Google / GA4 guidance)
- [x] Improved instructions
- [ ] Added references/scripts
- [x] Other (VERSIONS / plugin patch bump)

## What changed

In plain English:

- **Don’t tell people to pick “position-based” in Google Ads or GA4.** Those options were removed in 2023. Google only offers data-driven and last-click there now. Position-based is still fine as a way to score journeys on *your own* CRM or analytics data.
- **When Google’s data-driven model doesn’t have much data,** prefer last-click (or accept that data-driven will look a lot like last-click) — not “switch to position-based in Google.”
- **Update the volume tip** to match Google’s current guidance: about 200 conversions and 2,000 ad interactions in 30 days for better quality (the old 300 / 3,000 gate is kept only as history).
- **Clarify the model list:** “last non-direct” is a flavor of last-touch, not a seventh separate model family.
- **Calendly note:** you can’t pass free-form metadata like SavvyCal; put the anonymous visitor id in a normal UTM field.
- **Ghost ads note:** your ad is held back; the system still records that it *would* have shown — the control person isn’t simply “left out of the auction” with no logging.
- **When click-based attribution under-credits a channel** (often social/video), and you have a holdout or a trusted survey, adjust the *report* with a documented rule for that time window — don’t invent a “Meta is 2× GA so double Meta” multiplier.
- **Influencer skill:** when influencer results show up as branded search or direct, point people to the attribution skill (keep ai-seo for AI-search discovery).
- **Versions:** attribution `1.1.0` → `1.1.1`, influencer-marketing `1.0.0` → `1.0.1`, repo `2.10.0` → `2.10.1`.

## Checklist

- [x] Changes are focused and minimal
- [x] `SKILL.md` is still under 500 lines (227)
- [x] No sensitive data or credentials
- [ ] Tested locally with AI agent
- [x] Closes #507