### PR TITLE
Add whatsapp-marketing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.10.0",
+    "version": "2.11.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "49 marketing skills for technical marketers and founders: CRO, copywriting, cold email, prospecting, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, comprehensive AARRR-structured marketing plans, public relations and earned media, offer design, and more",
+      "description": "50 marketing skills for technical marketers and founders: CRO, copywriting, cold email, prospecting, SEO, AI SEO, paid ads, SMS, WhatsApp marketing, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, comprehensive AARRR-structured marketing plans, public relations and earned media, offer design, and more",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
-  "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.10.0",
+  "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, WhatsApp, and growth",
+  "version": "2.11.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See each skill's **Related Skills** section for the full dependency map.
 | [sms](skills/sms/) | When the user wants to plan, build, or optimize SMS or MMS marketing — including welcome flows, abandoned cart texts,... |
 | [social](skills/social/) | When the user wants help creating, scheduling, or optimizing social media content for LinkedIn, Twitter/X, Instagram,... |
 | [video](skills/video/) | When the user wants to create, generate, or produce video content using AI tools or programmatic frameworks. Also use... |
+| [whatsapp-marketing](skills/whatsapp-marketing/) | When the user wants to plan, build, or optimize WhatsApp marketing campaigns — Click-to-WhatsApp ads, cart recovery, templates,... |
 <!-- SKILLS:END -->
 
 ## Installation

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -53,8 +53,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | sms | 1.0.0 | 2026-05-21 |
 | social | 2.2.0 | 2026-07-09 |
 | video | 2.1.0 | 2026-07-14 |
+| whatsapp-marketing | 1.0.0 | 2026-08-18 |
 
 ## Recent Changes
+
+### 2.11.0 (2026-08-18)
+
+- **New skill: `whatsapp-marketing`** (1.0.0) — Plan, build, and optimize WhatsApp marketing programs, conversational commerce funnels, Click-to-WhatsApp (CTWA) ads, cart recovery workflows, Meta 24-hour service window compliance, interactive button templates, and anti-ban deliverability protection.
 
 ### 2.10.0 (2026-07-22)
 

--- a/skills/whatsapp-marketing/SKILL.md
+++ b/skills/whatsapp-marketing/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: whatsapp-marketing
+description: When the user wants to plan, build, or optimize WhatsApp marketing campaigns — including Click-to-WhatsApp ads, automated abandoned cart recovery, customer onboarding, VIP broadcast drops, interactive chatbot flows, or Meta Cloud API templates. Also use when the user mentions "WhatsApp marketing," "WhatsApp Business API," "Click to WhatsApp," "WhatsApp bot," "WhatsApp cart recovery," "conversational commerce," "WhatsApp templates," "Wati," "ManyChat WhatsApp," "Twilio WhatsApp," or "WhatsApp newsletter." For SMS marketing, see sms. For email automation, see emails. For ad creative and copy, see ad-creative and copywriting.
+metadata:
+  version: 1.0.0
+---
+
+# WhatsApp Marketing
+
+You are an expert in WhatsApp marketing, conversational commerce, and Meta Business Messaging. Your goal is to help plan, build, and optimize high-converting WhatsApp marketing funnels, automated flows, and compliant message templates that drive measurable revenue and retention while strictly adhering to Meta's Business Messaging policies.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`), read it before asking questions. Use that context and only ask for missing details.
+
+Gather this context (ask if not provided):
+
+### 1. Business & Target Market
+- Business type: B2C E-commerce, B2B SaaS, Professional Services, Fintech, Edtech
+- Geographic regions: Africa, Latin America, Europe, Southeast Asia, Middle East, US/Global (WhatsApp adoption and carrier pricing vary drastically by market)
+- Average Order Value (AOV) / Customer Lifetime Value (LTV)
+
+### 2. WhatsApp Infrastructure & Tech Stack
+- **WhatsApp Business App** (Solo founders/SMEs, manual/quick replies, max 256 broadcast list) vs.
+- **WhatsApp Business Cloud API / BSP** (Wati, ManyChat, Twilio, MessageBird, Infobip, Klaviyo WhatsApp, Intercom)
+- Current messaging tier & quality rating (Tier 1: 1k/day, Tier 2: 10k/day, etc.)
+
+### 3. Campaign Objective
+- **Acquisition**: Click-to-WhatsApp (CTWA) ads from Meta (IG/FB), website QR codes, lead qualification
+- **Conversion / Sales**: Abandoned cart recovery, flash sale drops, conversational checkout
+- **Retention & Lifecycle**: Post-purchase updates, onboarding milestone nudges, VIP broadcasts
+
+---
+
+## When WhatsApp Beats Email & SMS
+
+| Channel Attribute | WhatsApp | SMS | Email |
+| :--- | :--- | :--- | :--- |
+| **Open Rate** | **95–98%** (within 10 min) | 90–95% | 18–25% |
+| **CTR / Engagement** | **40–60%** | 10–15% | 2–4% |
+| **Interactivity** | **Rich** (Buttons, Lists, Media, Catalog) | Limited (MMS images/links) | High (HTML/Layouts) |
+| **Global Reach** | #1 in 100+ countries (EMEA, LATAM, APAC) | Strong in US/Canada | Global universal |
+| **2-Way Dialogue** | **Instant conversational support** | Clunky/Fragmented | Slow/Asynchronous |
+
+**Core Rule**: Treat WhatsApp like a direct chat with a trusted concierge. Never blast walls of generic marketing text. Every message must offer immediate value, quick-action buttons, or instant problem resolution.
+
+---
+
+## The 24-Hour Rule & Template Architecture
+
+Every outbound strategy must align with Meta's messaging framework:
+
+### 1. Inbound (Customer-Initiated)
+* Customer sends a message → Opens a **24-hour free-form session window**.
+* You can send rich text, custom interactive bot menus, and support replies without pre-approval.
+* Every customer reply resets the 24-hour clock.
+
+### 2. Outbound (Business-Initiated)
+* Outbound messages sent outside the 24-hour window **must use pre-approved Meta Templates**.
+* Templates are classified into:
+  - **Marketing**: Promotions, offers, product drops, cart recovery (higher cost).
+  - **Utility**: Order confirmations, tracking updates, appointment reminders (lower cost).
+  - **Authentication**: OTPs and login codes.
+* Any template with promotional language submitted as Utility will be rejected or re-categorized as Marketing by Meta.
+
+For full template submission guidelines, parameters, and pricing tiers, see [references/compliance-and-templates.md](references/compliance-and-templates.md).
+
+---
+
+## Core WhatsApp Funnels
+
+### 1. Click-to-WhatsApp (CTWA) Ad Funnels
+Convert cold social traffic into qualified sales conversations with low ad friction:
+1. **Ad Creative**: Offer a high-value hook (e.g., instant quiz, pricing calculator, exclusive catalog).
+2. **Pre-filled Text**: Pre-populate the user's message when they open WhatsApp (e.g., *"Hi! I'd like to claim the 15% VIP discount code."*).
+3. **Instant Qualification Bot**: Use Quick Reply buttons to ask 2–3 questions (Budget, Use case, Timeline).
+4. **Handoff or Conversion**: Send a dynamic single-tap checkout link or route high-value leads to a live sales rep.
+
+### 2. Abandoned Cart Recovery (E-commerce / DTC)
+* **Trigger**: 45–60 minutes post-abandonment.
+* **Format**: Dynamic product image + personalized copy + single-tap checkout button + "Need help?" button.
+* **Conversion Rate**: WhatsApp cart recovery typically converts at 15–30% (vs. 3–5% on email).
+
+### 3. VIP Broadcasts & Product Drops
+* **Audience**: Explicitly segmented opt-in lists.
+* **Format**: High urgency, short copy, media header (video/image), clear CTA button.
+* **Frequency Cap**: Maximum 1–2 broadcasts per week to protect quality ratings.
+
+For ready-to-use conversation scripts and branching logic, see [references/playbooks-and-scripts.md](references/playbooks-and-scripts.md).
+
+---
+
+## Conversational Copywriting Guidelines
+
+WhatsApp is a personal messaging app. Follow these rules:
+
+1. **Keep it under 60 words**: Avoid long blocks of text. Use 1–3 short sentences per bubble.
+2. **Use Natural Formatting**:
+   - Bold (`*key terms*`) for emphasis.
+   - Bullet points (`- item`) for scannability.
+   - Emojis strategically (1–2 per message) to set a friendly tone.
+3. **Interactive Buttons over Plain Links**: Always use **Quick Reply** (up to 3 buttons) or **Call-to-Action (URL)** buttons instead of pasting raw URLs in text.
+4. **Always Provide a Fast Opt-Out**: Include a Quick Reply button `[Stop Promotions]` or footer `"Reply STOP to opt out"` to avoid recipients clicking Meta's native "Report / Block" button.
+
+---
+
+## Anti-Ban & Deliverability Protection
+
+Getting banned on WhatsApp Business destroys marketing operations. Follow these defensive practices:
+
+1. **Strict Opt-In Verification**: Never purchase phone lists. Ensure explicit opt-in via website forms, CTWA ads, or inbound keyword triggers.
+2. **Immediate STOP Processing**: When a contact replies `STOP` or clicks unsubscribe, remove them instantly.
+3. **Tier Warming**: When launching a new number, start with 100–200 high-intent contacts on Day 1 to build a solid Green quality score before scaling to thousands.
+4. **Pacing / Rate Limiting**: Spread broadcast campaigns across multiple hours rather than blasting 10,000 messages in a single second.
+
+---
+
+## Structured Output Format
+
+When generating a WhatsApp marketing plan or campaign flow, provide the output in this format:
+
+```markdown
+### 1. Campaign Strategy & Objectives
+- **Target Audience & Segment**: [Who is receiving this]
+- **Channel Stage**: [CTWA Lead Gen / Cart Recovery / Broadcast / Retention]
+- **Platform/Tool Recommendation**: [Cloud API / Wati / ManyChat / etc.]
+
+### 2. Message Template Spec (for Meta Approval)
+- **Category**: [Marketing / Utility]
+- **Header**: [Text / Image / Video / None]
+- **Body Text**:
+  > "[Exact copy with {{1}}, {{2}} dynamic variables]"
+- **Footer**: "Reply STOP to unsubscribe"
+- **Interactive Buttons**:
+  - Button 1: [Quick Reply / URL CTA: "Button Text"]
+  - Button 2: [Quick Reply / URL CTA: "Button Text"]
+
+### 3. Automated Interactive Flow & Branching Logic
+- **Trigger**: [Event / User selection]
+- **Step-by-step bot replies**: [Message copy + button payloads]
+- **Human Handoff Trigger**: [Conditions when a live agent takes over]
+
+### 4. Compliance & Deliverability Checklist
+- [ ] Explicit opt-in captured
+- [ ] 24-hour service window compliance verified
+- [ ] Opt-out keyword / button included
+- [ ] Number tier warming strategy confirmed
+```
+
+---
+
+## Related Skills
+
+- For SMS marketing campaigns and US 10DLC compliance: [sms](../sms/)
+- For email drip flows and newsletter funnels: [emails](../emails/)
+- For landing page CRO and checkout optimization: [cro](../cro/)
+- For ad creative to drive Click-to-WhatsApp ads: [ad-creative](../ad-creative/)
+- For core value proposition and tone of voice: [copywriting](../copywriting/)

--- a/skills/whatsapp-marketing/evals/evals.json
+++ b/skills/whatsapp-marketing/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "skill_name": "whatsapp-marketing",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We run an e-commerce brand selling fashion accessories in the UK and Nigeria. We get 1,500 abandoned carts every week and want to use WhatsApp to recover them. How should we set this up?",
+      "expected_output": "Should check for product-marketing.md first. Should explain Meta WhatsApp Business API vs standard app requirements. Should design an abandoned cart recovery flow triggered 45-60 minutes after abandonment. Should specify the required Meta template category (Marketing). Should include dynamic variables for customer name, item name, and discount code. Should mandate an opt-out button or STOP keyword footer. Should provide interactive buttons (Deep-linked Checkout URL + Quick Reply for customer support). Should mention conversion rate benchmarks (15-30% on WhatsApp vs 3-5% on email).",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Recommends WhatsApp Business Cloud API / BSP setup",
+        "Specifies 45-60 minute trigger timing",
+        "Categorizes template as Marketing",
+        "Includes personalized copy with dynamic variables",
+        "Provides interactive buttons (URL checkout + Quick Reply support)",
+        "Includes mandatory opt-out mechanism (STOP / opt-out button)",
+        "Mentions conversion benchmarks"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Can we just blast our existing customer phone list with a 20% off discount on WhatsApp?",
+      "expected_output": "Should caution against unverified bulk blasts on WhatsApp. Should explain Meta's strict anti-spam policy and phone number Quality Rating system (Green/Yellow/Red). Should explain that high user blocks/reports will immediately degrade quality ratings and throttle or suspend messaging limits. Should explain the 24-hour customer service window rule and the requirement to use pre-approved Meta Marketing templates with explicit opt-in consent. Should recommend a safe tier-warming approach (starting with 100-200 recent, high-intent opt-ins).",
+      "assertions": [
+        "Warns against unverified cold/bulk blasting",
+        "Explains Meta Quality Rating system (Green/Yellow/Red)",
+        "Explains risk of phone number blocking / tier suspension",
+        "Enforces pre-approved Meta Marketing template requirement",
+        "Enforces explicit opt-in requirement",
+        "Recommends tier warming strategy"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We want to run Click-to-WhatsApp ads on Instagram for our B2B SaaS consulting service. Design the conversational lead qualification flow.",
+      "expected_output": "Should design an end-to-end Click-to-WhatsApp (CTWA) campaign. Should provide the ad hook and pre-filled user message. Should build an automated qualifying chat flow using Quick Reply buttons (2-3 qualifying questions like company stage/budget). Should handle user URL input. Should provide clear call-to-action routing (booking a calendar link or instant live human handoff). Should explain that user-initiated ad conversations open a 24-hour free-form session window.",
+      "assertions": [
+        "Defines ad pre-filled message",
+        "Builds automated qualification bot flow",
+        "Uses interactive Quick Reply buttons for questions",
+        "Captures lead qualification details",
+        "Includes calendar booking / live agent handoff",
+        "Mentions the 24-hour user-initiated session window"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/whatsapp-marketing/references/compliance-and-templates.md
+++ b/skills/whatsapp-marketing/references/compliance-and-templates.md
@@ -1,0 +1,102 @@
+# WhatsApp Marketing Compliance & Template Guide
+
+This reference provides the technical and regulatory framework for running WhatsApp marketing programs across both the **WhatsApp Business App** and the **WhatsApp Business Cloud API / On-Premises API**.
+
+---
+
+## 1. The Meta 24-Hour Customer Service Window
+
+Understanding conversation windows is critical to avoid failed message deliveries and high costs:
+
+### User-Initiated Conversations (Inbound)
+* When a customer sends a message to your WhatsApp Business number, a **24-hour service window** opens.
+* During this 24-hour window, you can send free-form session messages (text, media, audio, interactive menus) without pre-approval from Meta.
+* Every inbound reply from the customer resets the 24-hour timer.
+
+### Business-Initiated Conversations (Outbound)
+* Any message sent **outside** the 24-hour window (or initiating a new chat from your side) **MUST** use a pre-approved **Meta Message Template**.
+* Free-form text will be rejected with an API error (`131047: Re-engagement message`).
+
+---
+
+## 2. Meta Conversation Categories & Pricing
+
+Meta categorizes all outbound WhatsApp template messages into 4 types:
+
+| Category | Description | Example |
+| :--- | :--- | :--- |
+| **Marketing** | Promotions, product announcements, discount drops, cart recovery, re-engagement. | *"Hey Alex! Your cart items are selling out fast. Get 15% off with code FLASH15."* |
+| **Utility** | Order confirmations, tracking updates, billing statements, booking confirmations. | *"Your order #4921 has shipped! Track delivery here: [Link]"* |
+| **Authentication** | One-time passcodes (OTP), account verification, 2FA logins. | *"Your verification code is 849201. It expires in 10 minutes."* |
+| **Service** | User-initiated support responses within the 24-hour window. | Free-form problem-solving and support replies. |
+
+> [!IMPORTANT]
+> Meta automatically re-classifies templates upon submission. If a utility template includes promotional language (e.g. *"Your order has shipped! Also check out our new arrivals"*), it will be rejected or re-categorized as **Marketing** (which incurs higher per-message fees).
+
+---
+
+## 3. Opt-In & Opt-Out Requirements
+
+WhatsApp has a zero-tolerance policy for unsolicited spam. A high block/report rate will immediately downgrade your phone number's quality score and suspend your messaging tier.
+
+### Valid Opt-In Methods
+1. **Website Checkbox / Form**: An explicit, unchecked opt-in checkbox during checkout, lead capture, or account registration (e.g., *"Receive order updates and exclusive deals on WhatsApp"*).
+2. **Click-to-WhatsApp (CTWA) Ads**: When a user clicks a Facebook/Instagram ad with a pre-filled message, their initial message constitutes opt-in for that specific conversation.
+3. **Keyword Inbound / QR Codes**: User scans a physical/digital QR code or texts a keyword like `JOIN` or `DEALS` to your number.
+4. **Interactive Chat Opt-In**: Asking the customer inside a support conversation: *"Would you like us to notify you via WhatsApp when this item is back in stock?"* with a Quick Reply button `[Yes, notify me]`.
+
+### Mandatory Opt-Out Mechanics
+* **Marketing templates must include a 1-tap opt-out button** (Quick Reply `[Stop Promotions]` or `[Unsubscribe]`) or standard keyword instruction (`Reply STOP to unsubscribe`).
+* When a user sends `STOP`, `UNSUBSCRIBE`, `CANCEL`, or clicks the opt-out button:
+  1. The CRM/system must immediately flag the contact as unsubscribed.
+  2. Send a single confirmation message: *"You've been unsubscribed from promotional updates. Reply START anytime to re-subscribe."*
+  3. Cease all non-transactional outbound templates immediately.
+
+---
+
+## 4. Phone Number Quality Rating & Messaging Limits
+
+Every WhatsApp Business API phone number has a **Quality Rating** and a **Messaging Tier**:
+
+### Quality Ratings
+* **Green (High Quality)**: Low block/report rate. Full messaging speed and capacity.
+* **Yellow (Medium Quality)**: Warning state. Increased user complaints or blocks.
+* **Red (Low Quality)**: Critical state. High block rate. Number is at risk of being throttled or suspended.
+
+### Messaging Tiers (Daily Unique Contacts)
+* **Tier 1**: 1,000 unique business-initiated contacts per 24 hours.
+* **Tier 2**: 10,000 unique business-initiated contacts per 24 hours.
+* **Tier 3**: 100,000 unique business-initiated contacts per 24 hours.
+* **Tier 4 (Unlimited)**: Unlimited unique contacts per 24 hours.
+
+### How to Upgrade Tiers Safely
+* You automatically jump to the next tier when:
+  1. Your quality rating is **High (Green)**.
+  2. In the past 7 days, you sent messages to at least 50% of your current tier limit.
+* **Warming up a new number**: Never blast 1,000 cold contacts on day one. Start with 100–200 high-intent, recent opt-ins who expect your message to establish a clean initial quality rating.
+
+---
+
+## 5. Standard Interactive Message Formats
+
+Interactive WhatsApp messages convert 2–3x higher than plain text blocks.
+
+### Format A: Quick Reply Buttons (Up to 3 buttons)
+```json
+{
+  "type": "button",
+  "sub_type": "quick_reply",
+  "index": "0",
+  "parameters": [
+    { "type": "payload", "payload": "OPT_IN_VIP" }
+  ]
+}
+```
+* Use for simple choices: `[Yes, Claim 15%]`, `[Ask a Question]`, `[Stop Promotions]`.
+
+### Format B: Call-to-Action Buttons (Up to 2 buttons)
+* **URL Button**: Opens browser (e.g. `[Complete Checkout 🛒]`).
+* **Phone Call Button**: Initiates phone call (e.g. `[Call Support 📞]`).
+
+### Format C: Interactive List Messages (Up to 10 items)
+* Best for catalog browsing, booking slots, or multi-step qualification flows.

--- a/skills/whatsapp-marketing/references/playbooks-and-scripts.md
+++ b/skills/whatsapp-marketing/references/playbooks-and-scripts.md
@@ -1,0 +1,109 @@
+# WhatsApp Marketing Playbooks & Scripts
+
+Ready-to-deploy playbooks, conversation flows, and interactive message templates for high-converting WhatsApp marketing programs.
+
+---
+
+## Playbook 1: Click-to-WhatsApp (CTWA) Lead Gen Funnel
+
+**Goal**: Convert traffic from Facebook/Instagram ads into qualified leads directly within a WhatsApp chat.
+
+### Ad Setup:
+* **Objective**: Engagement or Leads (Destination: WhatsApp).
+* **Pre-filled User Message**: *"Hi! I'd like to get the free Growth Audit for my SaaS."*
+
+### Automated Chat Flow (Triggered on Inbound message):
+```text
+Bot (Message 1 - Instant):
+Hey {{1}}! 👋 Thanks for reaching out about the Growth Audit. 
+
+To make sure we prepare the exact audit for your team, what's your current stage?
+
+Buttons:
+[ 🚀 Pre-revenue / Idea ]
+[ 📈 $1k - $10k MRR ]
+[ 🏆 $10k+ MRR ]
+```
+
+```text
+Bot (Message 2 - Branching based on selection):
+Got it! What is your product website URL? (Just type it below)
+```
+
+```text
+User:
+https://example.com
+
+Bot (Message 3 - Confirmation & Calendar Booking):
+Awesome! We received your details. Would you like our growth lead to send your audit video here or schedule a 15-min live walkthrough?
+
+Buttons:
+[ 🎥 Send Video Here ]
+[ 📅 Book Live Walkthrough ]
+```
+
+---
+
+## Playbook 2: E-Commerce Abandoned Cart Recovery
+
+**Timing**: Send 45–60 minutes after cart abandonment. (Do not send immediately; allow organic completion).
+
+### Message Template (Category: MARKETING):
+* **Header**: Image of the abandoned item (dynamic media ID)
+* **Body**:
+  ```text
+  Hey {{1}}, you left something in your bag at {{2}}! 🛍️
+
+  Your {{3}} is reserved, but stock is running low. Finish your order now and take an extra 10% off with code SAVE10.
+  ```
+* **Footer**: *Reply STOP to unsubscribe*
+* **Buttons**:
+  1. URL Button: `[ Complete Order 🛒 ]` (Deep-linked to pre-filled checkout)
+  2. Quick Reply: `[ Need Help? 💬 ]` (Routes to live agent or FAQ bot)
+
+---
+
+## Playbook 3: High-Touch Post-Purchase & Review Generation
+
+**Timing**: Send 3–5 days after confirmed delivery.
+
+### Message 1 (Category: UTILITY or MARKETING):
+```text
+Hey {{1}}, your order of {{2}} arrived a few days ago! How are you enjoying it so far?
+
+Buttons:
+[ ⭐ Loving it! ]
+[ ❓ Have questions ]
+```
+
+### Branching:
+* **If "Loving it!"**:
+  ```text
+  That makes our day! 🙌 Would you mind taking 30 seconds to share your review on Trustpilot/Google? Here's the direct link: {{3}}
+  ```
+* **If "Have questions"**:
+  ```text
+  We're here to help! Let us know what's going on or reply to this message and our support team will jump right in.
+  ```
+
+---
+
+## Playbook 4: VIP Broadcast & Flash Drop (High Urgency)
+
+**Audience**: Engaged customers who opted in for VIP drops.
+**Frequency**: Maximum 1–2 times per month to preserve list health.
+
+### Template (Category: MARKETING):
+* **Header**: Video / Image Preview
+* **Body**:
+  ```text
+  🚨 VIP EARLY ACCESS: {{1}} is officially live!
+
+  Because you're on our VIP WhatsApp list, you get first access 2 hours before the public launch.
+
+  Use VIP code {{2}} for free express shipping. Only 200 units available.
+  ```
+* **Footer**: *Reply STOP to opt out*
+* **Buttons**:
+  1. URL Button: `[ Shop VIP Drop ⚡ ]`
+  2. Quick Reply: `[ Check Sizing 📏 ]`


### PR DESCRIPTION
### Summary
Adds the new `whatsapp-marketing` agent skill (v1.0.0) covering conversational commerce, Click-to-WhatsApp ad funnels, cart recovery, and Meta Business Messaging compliance.

### What's Included
- `skills/whatsapp-marketing/SKILL.md`: Core workflow, 24-hour service window rules, template classification, interactive button architecture, and anti-ban deliverability guide.
- `skills/whatsapp-marketing/references/compliance-and-templates.md`: Deep dive on Meta messaging policies, opt-in/opt-out mechanics, quality ratings, and button JSON schemas.
- `skills/whatsapp-marketing/references/playbooks-and-scripts.md`: Ready-to-deploy conversational scripts and branching logic for CTWA lead gen, cart recovery, post-purchase reviews, and VIP drops.
- `skills/whatsapp-marketing/evals/evals.json`: Standardized test cases and assertions.
- Bumped version to `2.11.0` in `plugin.json`, `marketplace.json`, and `VERSIONS.md`.

### Validation
- [x] Passed `./validate-skills.sh` (50/50 skills valid)
- [x] Passed `skills-ref validate skills/whatsapp-marketing`
- [x] Follows Agent Skills specification and naming conventions
