### PR TITLE
docs: fix broken PR template links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,9 @@ skills/your-skill-name/
 3. Make your changes
 4. Test locally with an AI agent
 5. Submit a pull request using the appropriate template:
-   - [New Skill](?template=new-skill.md)
-   - [Skill Update](?template=skill-update.md)
-   - [Documentation](?template=documentation.md)
+   - [New Skill](.github/PULL_REQUEST_TEMPLATE/new-skill.md)
+   - [Skill Update](.github/PULL_REQUEST_TEMPLATE/skill-update.md)
+   - [Documentation](.github/PULL_REQUEST_TEMPLATE/documentation.md)
 
 ## Skill Quality Checklist
 


### PR DESCRIPTION
## Summary
- The "Submitting Your Contribution" section links to PR templates using a bare `?template=...` query string, which just appends to the current CONTRIBUTING.md page URL instead of resolving to anything.
- Point the links at the actual template files under `.github/PULL_REQUEST_TEMPLATE/` so they resolve correctly.

## Test plan
- [x] Verified the three template files exist at `.github/PULL_REQUEST_TEMPLATE/{new-skill,skill-update,documentation}.md`
- [x] Confirmed the new relative links resolve to those files