### PR TITLE
fix(marketing-plan): constrain client-slug path to prevent cross-client reads

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -31,7 +31,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
 | marketing-loops | 1.2.0 | 2026-07-10 |
-| marketing-plan | 1.1.0 | 2026-05-29 |
+| marketing-plan | 1.1.1 | 2026-08-23 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
 | onboarding | 2.0.0 | 2026-05-05 |

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: marketing-plan
 description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and an embedded 17-section current-state audit rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For positioning and ICP context before planning, see product-marketing. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
+metadata:
+  version: 1.1.1
 ---
 
 # Marketing Plan
@@ -33,6 +35,8 @@ Examples:
 - `/marketing-plan` (will prompt for client name)
 
 On invocation, the skill reads `~/marketing-plans/{client-slug}/progress.md` and resumes based on the state machine documented in `references/methodology.md` Step 1.1.2 (fresh → INIT → REVIEW → FINALIZE → finalized). Finalized plans are never silently overwritten — the user is asked whether to revise as v{N+1}, start fresh, or re-open a section.
+
+**Path safety.** Build `{client-slug}` only by slugifying the client name to lowercase `[a-z0-9-]` (strip everything else); reject `..`, `/`, and absolute paths, and never read or write outside `~/marketing-plans/`. On a shared machine this keeps one client's plan — and their data — from leaking into another client's context.
 
 ## The three phases
 

--- a/skills/marketing-plan/references/methodology.md
+++ b/skills/marketing-plan/references/methodology.md
@@ -59,6 +59,8 @@ sections/02.md, sections/03.md, ... (list as they're written)
 
 ### Step 1.1.2 — Resumption decision tree
 
+**Path safety (applies to every step below).** `{client-slug}` is the client name slugified to lowercase `[a-z0-9-]` only — reject `..`, `/`, and absolute paths, and never read, create, or delete outside `~/marketing-plans/`.
+
 On every invocation, check state in this order:
 
 1. **No `{client-slug}/` folder** → fresh plan. Create folder + `materials/` + empty `sections/`. Start INIT (Step 1.2).


### PR DESCRIPTION
## What
Constrain the `{client-slug}` path in `marketing-plan` so one client's plan can't be read into another's context.

## Why
The skill reads and writes `~/marketing-plans/{client-slug}/` where `{client-slug}` comes from a user-supplied client name with no sanitization, and `references/methodology.md` (the operational layer) treats it as an opaque placeholder. On a shared machine a crafted or mistaken slug (e.g. `../other-client`) could read another client's confidential plan into the current context. This constrains `{client-slug}` to lowercase `[a-z0-9-]`, rejects `..`, `/`, and absolute paths, and forbids access outside `~/marketing-plans/` — stated in both `SKILL.md` and `methodology.md` so it's reachable wherever the path is built.

Also adds the missing `metadata.version` field (this was the only skill without one, so the update-check couldn't see its version) and bumps `marketing-plan` 1.1.0 → 1.1.1.

## Notes
From a cross-model security review (Claude + Codex + Grok). Release-version bump left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
