### PR TITLE
feat: enrich guerrilla marketing idea (#121) with framework + case library

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -29,7 +29,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | launch | 2.0.1 | 2026-06-16 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
-| marketing-ideas | 2.0.0 | 2026-05-05 |
+| marketing-ideas | 2.0.1 | 2026-08-23 |
 | marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |

--- a/skills/marketing-ideas/SKILL.md
+++ b/skills/marketing-ideas/SKILL.md
@@ -2,7 +2,7 @@
 name: marketing-ideas
 description: "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (ads, social, emails, etc.)."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Marketing Ideas for SaaS
@@ -38,13 +38,16 @@ When asked for marketing ideas:
 | Launches | 77-86 | Product Hunt, Lifetime deals, Giveaways |
 | Product-Led | 87-96 | Viral loops, Powered-by marketing, Free migrations |
 | Content Formats | 97-109 | Podcasts, Courses, Annual reports, Year wraps |
-| Unconventional | 110-122 | Awards, Challenges, Guerrilla marketing |
+| Unconventional | 110-122 | Awards, Challenges, [Guerrilla marketing](references/guerrilla-marketing.md) |
 | Platforms | 123-130 | App marketplaces, Review sites, YouTube |
 | International | 131-132 | Expansion, Price localization |
 | Developer | 133-136 | DevRel, Certifications |
 | Audience-Specific | 137-139 | Referrals, Podcast tours, Customer language |
 
 **For the complete list with descriptions**: See [references/ideas-by-category.md](references/ideas-by-category.md)
+
+**Deep dives** (full framework + case library for a single idea):
+- **Guerrilla marketing (#121)**: [references/guerrilla-marketing.md](references/guerrilla-marketing.md) — the direct-mail 3-rule framework (relevance / relationship-building / precision targeting), ROI discipline, "think in stories, not campaigns," "test small before going big," and a named case library (WePay, Xero, Red Bull, Antimetal, Arrows, ProfitWell, Buzzsprout, Wistia).
 
 ---
 

--- a/skills/marketing-ideas/evals/evals.json
+++ b/skills/marketing-ideas/evals/evals.json
@@ -85,6 +85,21 @@
         "May briefly mention as a marketing idea"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We sell a $30k/year data platform and can't get marketing VPs at target accounts to reply to email or take calls. We have budget for something creative. What guerrilla tactics could break through?",
+      "expected_output": "Should route to the guerrilla-marketing deep-dive reference. Should surface the direct-mail 3-rule framework (relevance, relationship-building, precision targeting) and the ROI discipline that a $50-200 package to an unqualified lead is malpractice — qualify the named accounts first, test small before scaling. Should note the deal size ($30k/year) justifies high-cost mailers. Should draw on the case library for inspiration (e.g. Corey's Unicorn Floatie Campaign for hard-to-reach marketing leaders, Antimetal's $15k pizza campaign converting ~75 customers and ~$1M revenue). Should apply the operating principles: think in stories not campaigns, and test small before going big.",
+      "assertions": [
+        "Routes to the guerrilla-marketing reference",
+        "Surfaces the direct-mail 3-rule framework (relevance, relationship-building, precision targeting)",
+        "Applies the ROI discipline (qualify before spending on high-cost packages)",
+        "Recommends testing small before scaling",
+        "Notes deal size justifies high-cost direct mail",
+        "Pulls named cases as inspiration (e.g. Unicorn Floatie, Antimetal pizza)",
+        "Applies 'think in stories, not campaigns' principle"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/marketing-ideas/references/guerrilla-marketing.md
+++ b/skills/marketing-ideas/references/guerrilla-marketing.md
@@ -1,0 +1,56 @@
+# Guerrilla Marketing (#121)
+
+Unconventional stunts that earn attention in unexpected places — then get turned into repeatable strategy. The point isn't the one-off spectacle. It's finding a memorable, low-cost way to break through, proving it works small, and running it again.
+
+Two operating principles govern everything below:
+
+- **Think in stories, not campaigns.** People don't share your funnel. They share a story worth retelling. Design the moment so the person who receives it wants to tell someone else.
+- **Test small before going big.** A guerrilla idea is a hypothesis. Prove it on a handful of targets before you spend real money scaling it.
+
+---
+
+## Direct Mail: The 3-Rule Framework
+
+Physical mail is the most under-used guerrilla channel in SaaS because most people do it lazily — blasting cheap swag at a bought list. Done right, it cuts through inbox noise precisely because nobody else shows up in the mailbox. Every direct-mail play must satisfy all three rules:
+
+1. **Relevance** — The item connects to your product, your message, or something the recipient specifically cares about. A random branded mug is noise. A gift that lands a joke about their exact problem is a story.
+2. **Relationship-building** — The mailer opens or deepens a relationship. It's a gift, not a pitch. If the recipient feels sold to, you've spent money to annoy someone.
+3. **Precision targeting** — You know exactly who is receiving it and why. Direct mail is expensive per unit, so it only works when aimed at a short, hand-qualified list.
+
+### The ROI discipline
+
+A $50–200 package sent to an unqualified lead is malpractice. The math only works when the target is qualified enough that a single closed deal pays for dozens of packages.
+
+- **Qualify before you spend.** Reserve high-cost mailers for named accounts and hard-to-reach decision-makers where the deal size justifies the cost.
+- **Test small before scaling.** Send to a handful first. Measure reply and meeting rates. Only scale the version that actually earns responses.
+
+### Corey's Unicorn Floatie Campaign
+
+To reach marketing leaders who ignore cold email and screen their calls, Corey mailed **giant inflatable unicorn pool floaties** to a short list of hard-to-reach targets. The floatie is absurd, oversized, and impossible to ignore — it lands as a story, not a pitch (relevance + relationship), aimed at a hand-picked list where each closed deal dwarfs the package cost (precision + ROI discipline). Recipients remembered it, mentioned it, and replied.
+
+---
+
+## Case Library (inspiration fuel)
+
+Steal the *pattern*, not the prop. Each of these turned a small, unconventional act into outsized attention or revenue.
+
+- **WePay's 600-lb ice block** — At PayPal's developer conference, WePay dropped a 600-pound block of ice with money frozen inside and a sign reading **"PayPal Freezes Your Accounts."** A pointed, physical jab at a competitor's real weakness, staged exactly where the audience was.
+- **Xero skywriting** — Xero paid for **skywriting over TechCrunch Disrupt**, hijacking a competitor-heavy event's attention from above without buying a booth.
+- **Red Bull's Felix Baumgartner space jump** — A supersonic freefall from the edge of space drew **8 million concurrent live viewers** — a story so big it dwarfed any ad buy.
+- **Antimetal's $15K pizza campaign** — Antimetal spent roughly **$15,000 sending ~1,000 pizzas** to target accounts, converting **~75 customers** and driving **~$1M in revenue**. Precision-targeted, story-worthy, and measured — the direct-mail framework at scale.
+- **Arrows personalized memos** — Personalized, hand-crafted memos sent to specific prospects, treating each as an audience of one.
+- **ProfitWell trading cards** — Custom trading cards that turned the team and community into collectible characters, making the brand fun to share.
+- **Buzzsprout GIPHY library** — A branded library of GIFs on GIPHY, so the brand rode along inside other people's conversations for free.
+- **Wistia "Gear Squad vs Dr. Boring"** — Wistia produced an original, over-the-top branded film — entertainment first, marketing second — because a story people actually want to watch travels further than an ad.
+
+---
+
+## How to Use This With a Client
+
+1. **Pick the story.** What's the one memorable thing a target would retell? Start from the story, then reverse-engineer the tactic.
+2. **Qualify the list.** For any high-cost play (direct mail especially), name the exact accounts and confirm the deal size justifies the spend.
+3. **Run the 3-rule check** on physical mail: relevance, relationship-building, precision targeting. If it fails any one, redesign it.
+4. **Test small.** Ship to a handful, measure replies/meetings/coverage, and only scale what earns a response.
+5. **Turn the stunt into a system.** If it works, make it repeatable — a recurring mailer program, a series of films, an ongoing library — rather than a one-time spike.
+
+*Source: Corey Haines, Founding Marketing, ch. 13.*

--- a/skills/marketing-ideas/references/ideas-by-category.md
+++ b/skills/marketing-ideas/references/ideas-by-category.md
@@ -311,7 +311,7 @@ Complete list of proven marketing approaches organized by category.
 
 120. **Marketing Stunts** - Bold, attention-grabbing marketing moments.
 
-121. **Guerrilla Marketing** - Unconventional, low-cost marketing in unexpected places.
+121. **Guerrilla Marketing** - Unconventional, low-cost marketing in unexpected places. Deep dive: direct-mail 3-rule framework (relevance / relationship / precision), ROI discipline, and a named case library in [guerrilla-marketing.md](guerrilla-marketing.md).
 
 122. **Humor Marketing** - Use humor to stand out and create memorability.
 


### PR DESCRIPTION
## Summary

Enriches the `marketing-ideas` skill's guerrilla marketing entry (#121) — previously a single one-liner — into a full deep-dive reference, adapted from Corey Haines's *Founding Marketing*, ch. 13.

### What's new
- **`references/guerrilla-marketing.md`** (new):
  - **Direct-mail 3-rule framework**: relevance, relationship-building, precision targeting — plus the ROI discipline (a $50–200 package to an unqualified lead is malpractice; qualify first, test small before scaling).
  - **Corey's Unicorn Floatie Campaign** as the anchor example (giant pool floaties mailed to hard-to-reach marketing leaders).
  - **Named case library**: WePay's 600-lb ice block ("PayPal Freezes Your Accounts"), Xero skywriting over TechCrunch Disrupt, Red Bull's Felix Baumgartner space jump (8M live viewers), Antimetal's $15K pizza → ~$1M revenue (~1,000 pizzas, ~75 customers), Arrows personalized memos, ProfitWell trading cards, Buzzsprout GIPHY library, Wistia "Gear Squad vs Dr. Boring."
  - Operating principles: **"think in stories, not campaigns"** and **"test small before going big."**
- **`SKILL.md`**: links the reference from the category table and a new deep-dive note; version bumped 2.0.0 → 2.0.1.
- **`references/ideas-by-category.md`**: #121 entry now links to the deep dive.
- **`evals/evals.json`**: added eval #7 (hard-to-reach VP scenario → guerrilla routing).
- **`VERSIONS.md`**: marketing-ideas row → 2.0.1 (2026-08-23).

### Validation
- `bash validate-skills.sh` → all 49 skills pass.
- `evals.json` valid JSON.
- SKILL.md 171 lines (< 500).

### Suggested Recent Changes bullet
- Enriched `marketing-ideas` #121 (Guerrilla Marketing) into a full deep-dive reference — direct-mail 3-rule framework + ROI discipline (Unicorn Floatie Campaign) and a named case library (WePay, Xero, Red Bull, Antimetal, Arrows, ProfitWell, Buzzsprout, Wistia); from *Founding Marketing* ch. 13. marketing-ideas 2.0.0 → 2.0.1.

> Note: repo release version (plugin.json/marketplace.json) intentionally untouched — flag for a catch-up bump per the versioning rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
