### PR TITLE
feat: enrich onboarding with MPTV, activation models & psychology

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -34,7 +34,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
-| onboarding | 2.0.0 | 2026-05-05 |
+| onboarding | 2.0.1 | 2026-08-23 |
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -2,7 +2,7 @@
 name: onboarding
 description: When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions "onboarding flow," "activation rate," "user activation," "first-run experience," "empty states," "onboarding checklist," "aha moment," "new user experience," "users aren't activating," "nobody completes setup," "low activation rate," "users sign up but don't use the product," "time to value," or "first session experience." Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup. For ongoing email sequences, see emails.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Onboarding CRO
@@ -25,7 +25,7 @@ Before providing recommendations, understand:
 ## Core Principles
 
 ### 1. Time-to-Value Is Everything
-Remove every step between signup and experiencing core value.
+Remove every step between signup and experiencing core value. Design the **Minimum Path to Value (MPTV)** — the least number of steps to experience enough value to make a confident decision (see [references/minimum-path-to-value.md](references/minimum-path-to-value.md)).
 
 ### 2. One Goal Per Session
 Focus first session on one successful outcome. Save advanced features for later.
@@ -34,11 +34,44 @@ Focus first session on one successful outcome. Save advanced features for later.
 Interactive > Tutorial. Doing the thing > Learning about the thing.
 
 ### 4. Progress Creates Motivation
-Show advancement. Celebrate completions. Make the path visible.
+Show advancement. Celebrate completions. Make the path visible. (See onboarding psychology below for the mechanisms.)
+
+---
+
+## Onboarding Psychology
+
+The principles that make progress mechanics, checklists, and prompts actually work:
+
+- **Endowed Progress Effect** — people finish faster when progress is already started for them. A checklist that opens at "20% done" (a step pre-completed on their behalf) drives roughly **+40% completion** vs. starting at 0%. Give users a head start, don't make them start from nothing.
+- **Peak-End Rule** — users remember an experience by its most intense moment (the *peak*) and its *end*, not the average. Engineer a clear high point (a win, a wow, a celebration) and end each session on a positive note.
+- **Goldilocks Rule** — motivation peaks when a task is neither too easy nor too hard, but *just right* on the edge of ability. Tune early steps so they're achievable but not trivial.
+- **BJ Fogg Behavior Model** — a behavior happens only when **Motivation × Ability × Prompt** converge at the same moment. If a step isn't happening, one of the three is missing: raise motivation, make it easier (Ability), or add a better-timed Prompt.
+- **Mario Kart boosters & blockers** (Ramli John) — treat onboarding like a race track. Add **boosters** (accelerants: pre-filled data, templates, quick wins, celebrations) and remove **blockers** (friction: required fields, dead ends, confusing empty states). Speed users toward value and clear obstacles from the lane.
+
+## Onboarding Toolkit (10 Components)
+
+The components you assemble an onboarding experience from. Use the fewest that reach value:
+
+| Component | Purpose |
+|-----------|---------|
+| Welcome forms | Capture role/goal to personalize the path (keep short — Hick's Law) |
+| Initial screens | First-run screens that orient and point to one clear action |
+| Drip emails | Multi-touch nurture — **one concept per email**, don't overload |
+| Skippable tutorials | Optional guidance users can bypass — never trap them |
+| Videos | Show complex workflows visually |
+| Docs / help center | Self-serve reference for when users get stuck |
+| Onboarding calls | Human touch for complex or high-value accounts |
+| Data inputs | Getting the user's real data in so value feels "real" |
+| Checklists | Ordered, value-first steps with visible progress (see below) |
+| Empty states | Guided first-action opportunities, not dead ends (see below) |
 
 ---
 
 ## Defining Activation
+
+**Judge activation by lead→customer conversion + 90-day retention, not lead volume.** More signups mean nothing if they don't convert and stick.
+
+Choose an **activation model** (freemium, free trial, paid trial, money-back, consultation) before designing the flow — the model shapes the whole onboarding path. See [references/activation-models.md](references/activation-models.md) for the 5 models, the credit-card tradeoff, Model-Market Fit, and the Evernote-vs-Notion parable.
 
 ### Find Your Aha Moment
 
@@ -199,6 +232,14 @@ When recommending experiments, consider tests for:
 - Support and help availability
 
 **For comprehensive experiment ideas**: See [references/experiments.md](references/experiments.md)
+
+---
+
+## References
+
+- **[references/minimum-path-to-value.md](references/minimum-path-to-value.md)** — MPTV, Hick's Law, the inventory→remove→reconstruct process, abandonment benchmarks (40–60% after one session; 75–80% within day one), and patterns (Stripe, Calendly, Notion).
+- **[references/activation-models.md](references/activation-models.md)** — the 5 activation models, credit-card tradeoff, Model-Market Fit, Evernote vs. Notion.
+- **[references/experiments.md](references/experiments.md)** — comprehensive A/B test and experiment ideas.
 
 ---
 

--- a/skills/onboarding/evals/evals.json
+++ b/skills/onboarding/evals/evals.json
@@ -87,6 +87,22 @@
         "Does not attempt signup form redesign using onboarding patterns"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're launching a new B2B analytics product and can't decide how to let people try it. Should we do a free tier, a free trial, require a credit card, or something else? And once they're in, how do we make sure they actually reach value fast?",
+      "expected_output": "Should walk through the 5 activation models (freemium, free trial with 3/7/14/30-day options, paid trial, money-back guarantee, consultation/Superhuman-style) and help choose based on Model-Market Fit (Balfour — the market dictates the model). Should explain the credit-card tradeoff: requiring a card cuts signups 50–70% but converts 2–3× better. Should reference the Evernote-vs-Notion lesson (hook then limit vs. give away too much). Should then design the Minimum Path to Value (MPTV) — the least steps to enough value to decide — grounded in Hick's Law, using inventory → remove → reconstruct. Should cite abandonment reality (40–60% abandon after one session; 75–80% within the first day). May reference psychology mechanisms (Endowed Progress Effect, Peak-End, BJ Fogg, Mario Kart boosters/blockers). Should point to the activation-models and minimum-path-to-value references.",
+      "assertions": [
+        "Presents the 5 activation models",
+        "Applies Model-Market Fit to the choice",
+        "Explains the credit-card tradeoff (cuts signups 50-70%, 2-3x conversion)",
+        "References Evernote-vs-Notion hook-then-limit lesson",
+        "Designs a Minimum Path to Value grounded in Hick's Law",
+        "Uses inventory -> remove -> reconstruct process",
+        "Cites first-session/first-day abandonment stats",
+        "Points to activation-models.md and minimum-path-to-value.md references"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/onboarding/references/activation-models.md
+++ b/skills/onboarding/references/activation-models.md
@@ -1,0 +1,57 @@
+# Activation Models
+
+The activation model is *how* you let a user experience value before they pay. It shapes signup volume, conversion, and the entire onboarding path. Pick the model before you design the flow.
+
+## The 5 activation models
+
+### 1. Freemium
+A free tier that never expires, with paid tiers for more capacity or features.
+
+- Best when: the free tier delivers real value *and* naturally hits limits that motivate upgrading.
+- Risk: give away too much and users never need to pay (see Evernote below).
+
+### 2. Free trial
+Full (or near-full) access for a fixed window: **3, 7, 14, or 30 days**.
+
+- Shorter trials create urgency and force faster time-to-value; longer trials suit complex products with longer setup.
+- **Credit-card requirement is the key lever**: requiring a card up front **cuts signups by 50–70%**, but the users who do sign up **convert 2–3× better**. Fewer, higher-intent leads vs. more, lower-intent leads — choose based on your funnel goals.
+
+### 3. Paid trial
+A low-cost paid entry, typically **$7–10 for 7 days**.
+
+- Filters out tire-kickers while lowering the barrier vs. full price.
+- Signals seriousness on both sides and pre-collects payment details.
+
+### 4. Money-back guarantee
+Charge full price up front, with a no-questions refund window.
+
+- Removes purchase risk without giving anything away for free.
+- Works when the product delivers value quickly enough to beat the refund window.
+
+### 5. Consultation / white-glove
+A human conversation (demo, call, or hands-on setup) gates access — the **Superhuman** model.
+
+- Best for high-touch, high-price, or complex products where a human ensures the user reaches value.
+- Doesn't scale cheaply, but converts and retains well when done right.
+
+## Model-Market Fit
+
+**Model-Market Fit (Brian Balfour): "your market dictates your model."**
+
+You don't get to freely choose your activation model — your market chooses it for you. Price point, buyer sophistication, sales complexity, time-to-value, and competitor norms all constrain what will work. A self-serve $20/mo tool and a $50k enterprise platform cannot use the same model. Match the model to the market before optimizing the onboarding inside it.
+
+## The Evernote vs. Notion parable
+
+Two lessons on how much to give away:
+
+- **Evernote — gave away too much free.** The free tier was generous enough that most users never needed to upgrade. Free was a destination, not a doorway. Growth without matching monetization.
+- **Notion — hook, then limit.** Let users experience real value, then hit meaningful limits (blocks, members, features) that create a natural, well-timed reason to pay.
+
+The principle: **the free experience should hook, not satisfy.** Give enough value to prove the product and build the habit — but structure the limits so that continued value requires upgrading.
+
+## Choosing
+
+1. Start from your market (Model-Market Fit), not your preference.
+2. Decide the card-vs-no-card tradeoff explicitly: volume of leads vs. quality of leads.
+3. Design the free/trial experience to hook and then limit — never to fully satisfy.
+4. Whatever the model, the onboarding inside it still needs the shortest possible path to value (see [minimum-path-to-value.md](minimum-path-to-value.md)).

--- a/skills/onboarding/references/minimum-path-to-value.md
+++ b/skills/onboarding/references/minimum-path-to-value.md
@@ -1,0 +1,49 @@
+# Minimum Path to Value (MPTV)
+
+**Minimum Path to Value (MPTV)** — the least number of steps to experience *enough* value to make a confident decision.
+
+Not the fastest path to *any* value, and not the full feature tour. It's the shortest route to a moment that's convincing enough for the user to decide "yes, this is for me." Everything else waits.
+
+## Why fewer steps win: Hick's Law
+
+**Hick's Law** — the time and effort to make a decision grows with the number and complexity of choices. Every step, field, and option in onboarding is another decision. More decisions = more hesitation, more drop-off.
+
+MPTV is the deliberate application of Hick's Law to onboarding: strip the path down to the fewest decisions required to reach value.
+
+## The abandonment reality
+
+You have far less time and patience than you think:
+
+- **40–60% of users who sign up for a free trial abandon after a single session** — and never return.
+- **75–80% of trial abandonment happens within the first day.**
+
+The decision to stick or bail is made almost immediately. If value isn't reached in the first session, most users are already gone. MPTV exists because the window is that small.
+
+## The process: inventory → remove → reconstruct
+
+Build (or fix) your MPTV in three passes:
+
+1. **Take inventory.** List *every* step between signup and value — every screen, form field, click, confirmation, permission prompt, and empty state. Be exhaustive and honest. Most teams underestimate their own step count by half.
+
+2. **Remove the nonessential.** For each step ask: does the user *have* to do this to reach value right now? If not, cut it, defer it, pre-fill it, or make it skippable. Default to removal. Configuration, profile completeness, advanced settings, and "nice to know" education are almost never essential to first value.
+
+3. **Reconstruct / iterate.** Rebuild the path with only what survived, in value-first order. Then measure and iterate — the first reconstruction is a hypothesis, not a finish line. Watch where users still stall and cut again.
+
+## Benchmark patterns
+
+Products with famously short paths to value:
+
+| Product | MPTV pattern |
+|---------|--------------|
+| **Stripe** | Get a working payment integration in **~7 lines of code / ~60% activation** — value (a real charge) before any account polish. |
+| **Calendly** | **3-step** setup to a shareable, working booking link. Value is a link you can send immediately. |
+| **Notion** | **Progressive disclosure** — starts nearly empty, reveals features only as the user needs them. The path to first value (a written page) is trivial; depth unfolds later. |
+
+The pattern across all three: reach a real, usable outcome fast, and hide complexity until it's asked for.
+
+## Applying it
+
+- Define the value moment first (the aha moment — see SKILL.md). MPTV is the path *to* that moment.
+- Count your current steps before optimizing. You can't remove what you haven't inventoried.
+- Treat every retained step as guilty until proven essential.
+- Measure step-completion and time-to-value after each reconstruction; the abandonment stats mean your margin for error is one session.


### PR DESCRIPTION
Adapts *Founding Marketing* ch.16 (activation & onboarding half) into the `onboarding` skill. Terse voice, coined frameworks/stats kept faithful. The chapter's pricing-rollout half is handled by a separate PR on the `pricing` skill — not touched here.

## What's added

**New references**
- `references/minimum-path-to-value.md` — **Minimum Path to Value (MPTV)** ("least steps to experience enough value to make a confident decision"), grounded in **Hick's Law**; the **inventory → remove → reconstruct/iterate** process; benchmarks (40–60% abandon after one session; 75–80% within the first day; Stripe ~7-line/60% activation; Calendly 3-step; Notion progressive disclosure).
- `references/activation-models.md` — the **5 activation models** (freemium; free trial 3/7/14/30-day with the credit-card tradeoff: cuts signups 50–70% but 2–3× conversion; paid trial $7–10/7-day; money-back guarantee; consultation/Superhuman); **Model-Market Fit** (Balfour); the **Evernote-vs-Notion** parable.

**SKILL.md**
- New **Onboarding Psychology** section: Endowed Progress Effect ("already 20% done" → +40%), Peak-End Rule, Goldilocks Rule, BJ Fogg (Motivation × Ability × Prompt), Mario Kart boosters/blockers (Ramli John).
- New **10-component onboarding toolkit** table (welcome forms, initial screens, drip emails "one concept per email," skippable tutorials, videos, docs, calls, data inputs, checklists, empty states).
- Activation judged by lead→customer conversion + 90-day retention; MPTV wired into Time-to-Value principle; both references wired into routing.

**Evals / versioning**
- New eval `id 7` (activation-model choice + MPTV).
- `onboarding` 2.0.0 → 2.0.1; `VERSIONS.md` row updated (2026-08-23).

## Validation
- `bash validate-skills.sh` → all 49 skills valid.
- `evals.json` valid JSON, ids 1–7 contiguous.
- SKILL.md 261 lines (<500); description unchanged (624 chars).

## Suggested Recent Changes bullet
- Enriched `onboarding` (2.0.1): added MPTV + activation-models references, an onboarding-psychology section, and the 10-component toolkit (adapted from *Founding Marketing* ch.16).

## Risks
- Adds two references + a psychology section to a previously lean skill; content is accurate to the source but broadens the skill's surface area. No changes outside the onboarding skill and its VERSIONS row. Repo release version (plugin.json/marketplace.json) intentionally not bumped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)