### PR TITLE
feat: add partnership-type taxonomy to co-marketing

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,7 +11,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | aso | 2.0.1 | 2026-08-19 |
 | attribution | 1.1.0 | 2026-07-23 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
-| co-marketing | 2.0.0 | 2026-05-05 |
+| co-marketing | 2.0.1 | 2026-08-23 |
 | cold-email | 2.0.0 | 2026-05-05 |
 | community-marketing | 2.0.0 | 2026-05-05 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |

--- a/skills/co-marketing/SKILL.md
+++ b/skills/co-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: co-marketing
 description: "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referrals. For launch-specific partnerships, see launch."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 You are a co-marketing strategist who helps SaaS companies identify ideal partners and brainstorm high-impact joint campaigns.
@@ -76,6 +76,26 @@ Rate potential partners (1-5) on:
 - Customer surveys ("what else do you use?")
 - G2/Capterra category neighbors
 - Job postings mentioning your tool + others
+
+---
+
+## Partnership Types
+
+Co-marketing is one of **five partnership types**. Know the taxonomy so you route a request to the right play instead of defaulting to joint content.
+
+| Type | What it is | Primary payoff |
+|------|-----------|----------------|
+| **Integrations** | Your product connects to another's (native, Zapier, API-first, embedded) | Retention, expansion, marketplace discovery |
+| **Reseller** | Partners sell your product + services | Distribution + services revenue |
+| **Affiliate** | Promoters earn commission on referrals | Low-risk, pay-for-performance reach |
+| **Co-marketing** | Joint content/campaigns with a peer | Borrowed audience, brand halo |
+| **App Store / Marketplace** | List inside a platform's ecosystem | Built-in distribution, effective CAC |
+
+**Flagship proof:** HubSpot's partner program = **$100M ARR, ~40% of revenue, 3,400+ partners.** Mature programs average **~28% of revenue and 2× growth**.
+
+Standout moves: **integrations** as a decision factor (83% of enterprise buyers), Calendly's staged ladder (calendar → sales → marketing); **affiliate** power law (20% of affiliates drive 80% of revenue) and buyout clauses (~12× monthly commission); **permissionless co-marketing** (Notion building templates for Airbnb/Amazon/Tesla to ride their brand — no contract needed); App Store distribution (Grammarly 0→10M).
+
+For the full taxonomy — build patterns, economics, examples, and how to choose where to start — see **[references/partnership-types.md](references/partnership-types.md)**. (Affiliate program *mechanics* live in the referrals skill; keep affiliate work here at the partnership-strategy level.)
 
 ---
 

--- a/skills/co-marketing/evals/evals.json
+++ b/skills/co-marketing/evals/evals.json
@@ -79,6 +79,20 @@
         "Does not attempt full co-marketing strategy"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're a SaaS scheduling tool. We keep hearing 'you should do partnerships' but I don't even know what kinds exist. What are our options and where should we start?",
+      "expected_output": "Should lay out the five partnership types from the partnership-types taxonomy: integrations, reseller programs, affiliate programs, co-marketing, and app store/marketplace — not just joint content. Should note co-marketing is only one of the five. Should reference the flagship proof that partner programs are meaningful (e.g., HubSpot's ~$100M ARR / ~40% of revenue / 3,400+ partners; mature programs ~28% of revenue and 2x growth). Should give concrete moves per type: integrations built native vs via Zapier vs API-first vs embedded, Calendly's staged ladder (calendar to sales stack to marketing stack), 83% of enterprise citing integrations as a decision factor; reseller economics (20-40% of LTV plus 2-3x in services); affiliate power law (20% of affiliates drive 80% of revenue) and buyout clauses (~12x monthly commission); permissionless co-marketing (Notion building templates for Airbnb/Amazon/Tesla to ride their brand); app store distribution (Grammarly 0 to 10M, platforms taking 15-30% as effective CAC). For a scheduling tool specifically, should recommend starting with integrations (retention/expansion, marketplace discovery) given the calendar/CRM workflow. Should point to references/partnership-types.md for the full taxonomy, and note affiliate mechanics live in the referrals skill.",
+      "assertions": [
+        "Lists all five partnership types",
+        "Notes co-marketing is one of five, not the whole picture",
+        "Cites the HubSpot / partner-program flagship stat",
+        "Gives concrete moves for multiple types (integration ladder, affiliate power law, permissionless co-marketing)",
+        "Recommends a starting type appropriate to a scheduling tool (integrations)",
+        "Points to the partnership-types reference"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/co-marketing/references/partnership-types.md
+++ b/skills/co-marketing/references/partnership-types.md
@@ -1,0 +1,100 @@
+# Partnership Types
+
+Adapted from Corey Haines's *Founding Marketing*, Ch. 11 — "Partnerships tap into existing audiences." The fastest way to reach customers is through companies that already have their attention.
+
+**Flagship proof:** HubSpot's partner program = **$100M ARR, ~40% of revenue, 3,400+ partners.** Mature partner programs average **~28% of revenue and 2× the growth** of companies without them.
+
+Co-marketing (in the SKILL.md) is one of five partnership types. Use this reference to place a given partnership in the right category and pick the right play. The types stack — most companies run several at once as the program matures.
+
+| Type | What it is | Primary payoff |
+|------|-----------|----------------|
+| **Integrations** | Your product connects to another's | Retention, expansion, marketplace discovery |
+| **Reseller** | Partners sell your product for you | Distribution + services revenue |
+| **Affiliate** | Promoters earn commission on referrals | Low-risk, pay-for-performance reach |
+| **Co-marketing** | Joint content/campaigns with a peer | Borrowed audience, brand halo |
+| **App Store / Marketplace** | List inside a platform's ecosystem | Built-in distribution, effective CAC |
+
+---
+
+## 1. Integrations
+
+Integrations are the foundation — they make you sticky, unlock expansion, and earn a spot in the partner's marketplace.
+
+**Four ways to build:**
+- **Native** — you build and maintain a direct connection. Best UX, highest cost.
+- **Platform via Zapier/Make** — ride an iPaaS to cover the long tail without building each one.
+- **API-first** — expose a clean public API and let partners build toward you.
+- **Embedded** — your product runs inside theirs (widget, SDK, iframe).
+
+**Calendly's staged integration ladder** — build integrations in order of buyer intent:
+1. **Calendar** (Google/Outlook) — table stakes, required to function.
+2. **Sales stack** (CRM, dialers, Salesforce/HubSpot) — where revenue teams live.
+3. **Marketing stack** (forms, ESP, automation) — top-of-funnel capture.
+
+Each rung deepens the account and widens who inside the company depends on you.
+
+**Marketplace strategy + ASO.** Getting listed isn't enough — apps compete for placement. Treat a marketplace like an app store: optimize the listing (title, keywords, screenshots, reviews, category) the same way you'd do App Store Optimization. Shopify App Store and Salesforce AppExchange are discovery engines; ranking well there is a channel, not an afterthought.
+
+**Why it matters:** **83% of enterprise buyers cite integrations as a purchase-decision factor.** Missing an integration a prospect needs can lose the deal outright.
+
+---
+
+## 2. Reseller programs
+
+Turn other companies into a sales force. Partners resell your product and layer their own services on top.
+
+**Economics:** resellers typically earn **20–40% of LTV** on the software, plus **2–3× that amount in services** (implementation, training, retainers) they sell around it. The services margin is what makes the partner care.
+
+**HubSpot's agency playbook (Peter Caputa).** HubSpot turned marketing agencies into resellers by making the agency's own business better: give them a product to sell, certifications to differentiate on, and a co-selling motion. Agencies became a durable, compounding distribution channel — the engine behind the $100M ARR partner program.
+
+**Partner enablement is the work.** A reseller program lives or dies on enablement: onboarding, certification, sales collateral, deal registration, co-selling support, and a partner portal. Signing partners is easy; getting them to actually sell requires you to train and equip them.
+
+---
+
+## 3. Affiliate programs
+
+Pay-for-performance reach. Affiliates promote you and earn commission on conversions — low downside, since you pay only on results.
+
+**Proof points:**
+- **ConvertKit + Pat Flynn** — a single trusted creator can become a top-of-funnel channel on their own.
+- **Demio** — **50% commissions** to make the program worth a promoter's real effort.
+- **Cometly** — **$251K in a single launch day**, driven by one top affiliate plus **Rewardful** for tracking and payouts.
+
+**The 20/80 affiliate power law.** ~20% of affiliates drive ~80% of revenue. Don't spread effort evenly across a long tail — **identify super-promoters and invest disproportionately** in them (higher rates, custom assets, early access, direct relationship).
+
+**Buyout clauses.** For a super-promoter you want to lock in (or eventually replace with owned channel), a buyout clause lets you pay out future commissions as a lump sum — commonly **~12× the monthly commission**. It caps long-term liability and gives the affiliate a clean exit.
+
+> Affiliate mechanics — commission structures, cookie windows, fraud, tooling (Rewardful/Tolt/PartnerStack) — belong in the **referrals** skill. Keep affiliate work here at the partnership-strategy level: which promoters to recruit, how to tier them, when to buy out.
+
+---
+
+## 4. Co-marketing
+
+Joint campaigns with a non-competing peer who shares your audience. Covered in depth in the main SKILL.md (campaign types, partner scoring, agreements). Two ideas from the chapter worth calling out:
+
+**Permissionless co-marketing (Notion's coined move) — the single most actionable idea in the chapter.** You don't need a signed partnership to ride a bigger brand. Notion built and published templates *for* Airbnb, Amazon, and Tesla — no permission, no contract — capturing search demand and brand halo from companies far larger than itself. **Build assets around brands your audience already loves; let the association do the work.**
+
+**Content ecosystems.** Gong earned reach by showing up consistently on **SaaStr** (the audience it wanted, hosted by someone else) rather than only building its own. Pair with the lowest-friction swaps — **newsletter swaps** and cross-promotion — where each side keeps its own leads and simply exposes the other to its audience.
+
+---
+
+## 5. App Store / Marketplace
+
+List your product inside a platform's ecosystem and inherit its distribution.
+
+- **Grammarly's Chrome Web Store extension** took it from **0 to 10M users** — the store *was* the acquisition channel.
+- Platforms take **15–30% of revenue**. Treat that cut as **effective CAC**: you're buying distribution instead of running ads.
+- **Go all-in on one platform when it maps to your ICP.** Arrows built its entire GTM around **HubSpot** — deep integration, AppExchange presence, co-selling — rather than spreading thin across many ecosystems.
+
+**When to choose this:** if a single platform owns your buyer's daily workflow, being *inside* it beats trying to pull users out to your own site.
+
+---
+
+## Choosing where to start
+
+- **Retention/expansion problem** → Integrations first (and the marketplace listing that comes with them).
+- **Need distribution without headcount** → Affiliate (fast, pay-on-results) or Reseller (slower, higher-touch, services upside).
+- **Have content but no reach** → Co-marketing, starting with permissionless assets and newsletter swaps.
+- **A platform owns your buyer's workflow** → App Store / Marketplace, all-in.
+
+Programs compound: integrations create marketplace presence, marketplace presence attracts resellers, resellers and affiliates create the case studies that fuel co-marketing.


### PR DESCRIPTION
## What

Adds a **partnership-type taxonomy** to the `co-marketing` skill, sourced from Corey Haines's *Founding Marketing*, Ch. 11 ("Partnerships tap into existing audiences"). The skill was strong on partner identification/scoring/campaign types but missing the taxonomy of partnership *types* — this fills that gap.

## Changes

- **New** `skills/co-marketing/references/partnership-types.md` — the **five partnership types**:
  1. **Integrations** — native / Zapier / API-first / embedded; Calendly's staged ladder (calendar → sales → marketing); marketplace ASO (Shopify / AppExchange); "83% of enterprise cite integrations as a decision factor."
  2. **Reseller** — 20–40% of LTV + 2–3× in services; HubSpot's agency playbook (Peter Caputa); enablement.
  3. **Affiliate** — ConvertKit/Pat Flynn, Demio (50%), **Cometly ($251K launch day via a top affiliate + Rewardful)**, **buyout clauses (~12× monthly commission)**, the **20/80 power law**. Kept at strategy level; mechanics deferred to `referrals`.
  4. **Co-marketing** — **permissionless co-marketing** (Notion's coined move: templates for Airbnb/Amazon/Tesla), Gong-on-SaaStr, newsletter swaps.
  5. **App Store / Marketplace** — Grammarly Chrome (0→10M), platforms taking 15–30% as effective CAC, Arrows all-in on HubSpot.
  - Leads with the flagship: HubSpot's partner program = **$100M ARR, ~40% of revenue, 3,400+ partners**; mature programs ≈ 28% of revenue + 2× growth.
- **SKILL.md** — new "Partnership Types" section (summary table + standout moves) routing to the reference; version 2.0.0 → **2.0.1**.
- **evals.json** — new eval **id 7** (taxonomy request from a scheduling tool).
- **VERSIONS.md** — co-marketing row → 2.0.1 (2026-08-23).

## Validation

- `bash validate-skills.sh` → all 49 skills pass.
- `evals.json` valid JSON; SKILL.md 310 lines (<500); description unchanged (430 chars).

## Notes / risks

- The affiliate buyout-clause and power-law detail may also touch the `referrals` skill — a **separate PR** handles referrals. Affiliate coverage here is intentionally partnership-strategy level only.
- No changes to `plugin.json` / `marketplace.json`. Suggested repo-release bump when batched — a `z` (patch) release with the changelog bullet:
  - Added partnership-type taxonomy (5 types) to co-marketing via references/partnership-types.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
