### PR TITLE
feat: initial pricing, 8 pricing models, and price-change rollout method (pricing)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -38,7 +38,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
-| pricing | 2.1.0 | 2026-07-27 |
+| pricing | 2.1.1 | 2026-08-23 |
 | product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |

--- a/skills/pricing/SKILL.md
+++ b/skills/pricing/SKILL.md
@@ -2,7 +2,7 @@
 name: pricing
 description: "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' 'should I offer a free plan,' 'pricing page teardown,' 'pricing page audit,' 'is my pricing page AI-readable,' or 'can AI read my pricing.' Use this whenever someone is figuring out what to charge, how to structure their plans, or wants to audit a pricing page (for humans and for the AI agents that shortlist tools). For in-app upgrade screens, see paywalls. For offer construction (bonuses, guarantees, value framing, naming) on services/courses/coaching/high-ticket B2B, see offers."
 metadata:
-  version: 2.1.0
+  version: 2.1.1
 ---
 
 # Pricing Strategy
@@ -65,6 +65,40 @@ Price should be based on value delivered, not cost to serve:
 
 **Key insight:** Price between the next best alternative and perceived value.
 
+**Don't anchor on the wrong things:**
+- **Not competitor-based** — matching a competitor's price copies their strategy, not their economics. It's a data point, not a target.
+- **Not cost-based** — cost is a floor, never the basis. Value + differentiation set the price.
+
+---
+
+## Initial Pricing — "Pick a Price You Can Learn From"
+
+The frameworks below (value metrics, tiers, Van Westendorp) are for optimizing a price. **On day one you don't have a price to optimize — you have a bet to place.** The goal of your first price is *learning*, not precision. Pick a number, ship it, and let real buyers tell you if it's wrong.
+
+### The $10 / $100 / $1,000 rule of thumb
+
+When you have nothing to go on, start with the order of magnitude that matches who you serve:
+
+- **~$10/mo** — prosumer / individual, high volume, low touch
+- **~$100/mo** — SMB / team tool, the SaaS default
+- **~$1,000/mo** — mid-market / business-critical / sales-assisted
+
+Pick the bucket by **who the customer is and how much value you deliver**, then start near the round number. You can move within the bucket fast once you have signal.
+
+### Avoid the $9 trap
+
+Resist the urge to price ultra-low (e.g. **$9/mo**) to reduce friction. Ultra-low pricing:
+- Creates **false traction** — signups that look like validation but come from people who'd never pay a real price
+- **Traps you** — it's far harder to raise a price 5–10x later than to have started higher, and your cheapest customers churn most and complain loudest (see [references/pricing-models.md](references/pricing-models.md) on low-price retention)
+
+Round-and-slightly-higher beats clever-and-cheap.
+
+### "Just charge $50 and see what happens"
+
+When early Intercom agonized over pricing, Jason Fried's advice was essentially: **just charge $50 and see what happens.** Stop modeling; get a real signal. If people pay without flinching, raise it. If nobody bites, you've learned something for the cost of a week, not a quarter.
+
+**For the eight ways to structure how you charge (flat, usage, tier, user, feature, credit, outcome, hybrid) and the value/price ratio:** See [references/pricing-models.md](references/pricing-models.md).
+
 ---
 
 ## Value Metrics
@@ -95,6 +129,8 @@ The value metric is what you charge for—it should scale with the value custome
 Ask: "As a customer uses more of [metric], do they get more value?"
 - If yes → good value metric
 - If no → price doesn't align with value
+
+**The value metric picks the pricing model.** Once you know what scales with value, choose how to charge on it — flat, usage, tier, user, feature, credit, outcome, or a hybrid. See [references/pricing-models.md](references/pricing-models.md).
 
 ---
 
@@ -164,6 +200,17 @@ Identifies which features customers value most:
 2. **Delayed increase** — Announce 3-6 months out
 3. **Tied to value** — Raise price but add features
 4. **Plan restructure** — Change plans entirely
+
+### Rollout Methodology
+
+A price change is a rollout, not a switch you flip. Sequence it to de-risk:
+
+1. **Test on new customers first.** Raise the price only for *new* signups and watch conversion. New customers have no anchor and no relationship at stake, so they give you a clean read on whether the market accepts the number — before you touch a single existing account.
+2. **Don't reflexively grandfather forever.** Grandfathering feels kind, but it can leave enormous money on the table. Run the math: a customer paying **$50/mo** who *should* be at **$250/mo** is a **$2,400/yr** gap — and $200/mo you're subsidizing indefinitely across your whole base. Grandfather as a *transition* (a grace period), not a permanent exemption.
+3. **Roll out small, then gradually.** Move **5–10%** of existing customers to the new price first. Watch churn and support volume for a cycle, then expand in staggered waves. A staggered rollout contains the blast radius and gives you an off-ramp if churn spikes.
+4. **Communicate the *why*, months ahead, with a generous offer.** Tell customers why the price is changing (usually: more value shipped) well in advance. Soften it: lock-in-the-old-price-if-you-upgrade-to-annual-now, an extended grace window, or a one-time credit. Advance notice + a generous option converts a resentment moment into a loyalty one.
+
+Expect — and accept — some churn. The customers most likely to leave over a justified increase are usually your least-profitable, highest-support, most price-sensitive accounts.
 
 ---
 

--- a/skills/pricing/evals/evals.json
+++ b/skills/pricing/evals/evals.json
@@ -99,6 +99,21 @@
         "Does not treat this as pure conversion-rate CRO"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "We're launching an AI writing tool for solo creators next week and I genuinely have no idea what to charge on day one. I was going to just do $9/month to get people in the door. What price should I pick and how should I even structure it?",
+      "expected_output": "Should treat this as an INITIAL pricing question, not a price-optimization one — the goal of a first price is learning, not precision ('pick a price you can learn from'). Should apply the $10/$100/$1,000 rule of thumb and place a solo-creator tool near the ~$10 bucket. Should warn against the $9 trap (false traction, hard to raise later, cheapest customers churn most). May cite the Intercom/Jason Fried 'just charge $50 and see what happens' idea — ship a price and get real signal. Should reject competitor-based and cost-based anchoring in favor of value + differentiation. Should recommend a pricing MODEL/structure: for an AI actions-based tool, credit-based or usage-based (or a hybrid) is a natural fit; may reference the 8 models. May mention the ~10:1 value/price ratio and the low-price-hurts-retention counterpoint (when in doubt, price higher).",
+      "assertions": [
+        "Frames the first price as a learning bet, not an optimization",
+        "Applies the $10/$100/$1,000 rule of thumb and buckets the tool appropriately",
+        "Warns against the $9 / ultra-low trap (false traction, hard to raise, low-price churn)",
+        "References 'just charge $50 and see' / getting a real signal (Intercom/Jason Fried)",
+        "Rejects competitor-based and cost-based pricing in favor of value + differentiation",
+        "Recommends a pricing model/structure (e.g. credit-based or usage-based for an AI tool)",
+        "Notes value/price ratio (~10:1) or that low prices hurt retention"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/pricing/references/pricing-models.md
+++ b/skills/pricing/references/pricing-models.md
@@ -1,0 +1,66 @@
+# Pricing Models
+
+The eight core ways to structure *how* you charge. This is distinct from the value metric (what unit you charge on) and the tier structure (how you package). Most real products **combine** two or more of these.
+
+## Contents
+- The 8 Pricing Models
+- Combining Models
+- The Value/Price Ratio
+- The Low-Price Retention Counterpoint
+
+---
+
+## The 8 Pricing Models
+
+| Model | How it works | Best when | Reference |
+|-------|-------------|-----------|-----------|
+| **Flat-rate** | One price, one product, everyone pays the same | Simple product, one persona, you want zero pricing friction | Basecamp |
+| **Usage-based** | Pay for what you consume (metered) | Value scales directly with volume; consumption is variable and easy to meter | Stripe |
+| **Tier-based** | Good-better-best packages at set prices | Distinct segments with different needs and budgets | Kinsta |
+| **User-based** | Price per seat/user | Value grows as more people in the org use it (collaboration) | Notion |
+| **Feature-based** | Price gated by which capabilities are unlocked | Clear feature tiers map to willingness to pay | Intercom |
+| **Credit-based** | Buy a bucket of credits, spend them on actions | Usage is lumpy or bursty; you want prepaid commitment and simple mental accounting | Audible |
+| **Outcome-based** | Pay per result delivered (resolution, task completed) | You can measure and attribute the outcome, and the outcome is what the buyer actually wants | Intercom Fin, Zapier |
+| **Hybrid** | Deliberate mix (e.g. platform fee + usage, or seats + credits) | A single model under- or over-charges different customers | Drift |
+
+### When to reach for each
+
+- **Flat-rate** — reach for it first if you can. It's the easiest to sell, easiest to understand, easiest to forecast. The tradeoff: you leave money on the table with your biggest customers.
+- **Usage-based** — the fairest model when consumption tracks value, but revenue is less predictable and buyers fear a surprise bill. Pair with spend caps or alerts.
+- **Tier-based** — the default for self-serve SaaS. Lets one page serve SMB through mid-market.
+- **User-based** — only if value genuinely rises with headcount. If it doesn't, seats punish adoption (teams share logins to avoid paying).
+- **Feature-based** — powerful for segmentation, but don't gate the feature that delivers your core value; gate the ones that separate casual from serious users.
+- **Credit-based** — good for AI/actions-based products where each action has a cost. Credits decouple price from a single unit and make prepayment feel natural.
+- **Outcome-based** — the emerging model for AI agents (charge per resolved ticket, per automation run). Highest trust because the buyer only pays when they win — but only viable when the outcome is measurable and clearly attributable to you.
+- **Hybrid** — where most mature products end up. A base platform fee for predictability plus a usage/outcome component for upside.
+
+---
+
+## Combining Models
+
+These aren't mutually exclusive. Common combinations:
+
+- **Tiers + per-user** — seats within each package (most B2B SaaS)
+- **Platform fee + usage** — predictable base, variable upside (Twilio-style)
+- **Seats + credits** — pay per person, then top up credits for heavy actions
+- **Feature tiers + outcome** — unlock capabilities by tier, charge per result on top
+
+Pick the primary model from the value metric, then layer a second only if a single model clearly mis-prices a real segment.
+
+---
+
+## The Value/Price Ratio
+
+Aim for roughly a **10:1 value-to-price ratio** (Ryan Kulp): the customer should perceive about **10x more value than they pay**. This is the buffer that makes the purchase feel obvious rather than negotiated, and it leaves headroom to raise prices later as you add value.
+
+If you can't articulate 10x value, the problem is usually the offer or the positioning, not the price point.
+
+---
+
+## The Low-Price Retention Counterpoint
+
+Charging too little is not the safe choice. **Low prices hurt retention** (Patrick Campbell / ProfitWell data, echoed by operators like Josh Pigford of SpyFu and Tyler Tringas): under-priced customers churn *more*, not less, because a low price signals low value and attracts the least-committed, most price-sensitive buyers.
+
+Related: the **discount-asker signal** — customers who negotiate for a discount tend to churn at roughly **2x** the rate of full-price customers. Discounting to close a deal often buys a customer who leaves anyway.
+
+**Implication:** when in doubt, price higher. It's easier to grandfather a price down than to claw one up, and a higher price selects for better-fit, longer-retained customers.


### PR DESCRIPTION
Enriches the **pricing** skill with the initial-pricing / model-catalog / rollout-method material from Corey Haines's *Founding Marketing* (chs. 15–16, the pricing-rollout half). The skill previously jumped straight to sophisticated frameworks with nothing for "I'm launching — what do I charge day one?"

## What changed

**SKILL.md**
- New **"Initial Pricing — Pick a Price You Can Learn From"** section: first price is a learning bet, not an optimization; the **$10 / $100 / $1,000/mo rule of thumb**; the **anti-$9 warning** (false traction, traps you, cheapest churn most); the **Intercom / Jason Fried "just charge $50 and see what happens"** story.
- Value-Based Pricing now explicitly rejects **competitor-based** and **cost-based** anchoring (value + differentiation instead).
- **Price Increase → Rollout Methodology** subsection: test on **new customers first**; the anti-grandfathering **$50→$250 = $2,400/yr** math (grandfather as a transition, not forever); **5–10%** small-scale then staggered waves; communicate the **why**, months ahead, with a generous offer.
- Routing wired to the new reference from both the value-metric and initial-pricing sections.

**references/pricing-models.md (new)**
- The **8 pricing models** — flat (Basecamp), usage (Stripe), tier (Kinsta), user (Notion), feature (Intercom), **credit (Audible)**, **outcome (Intercom Fin, Zapier)**, **hybrid (Drift)** — each with when-to-use + reference company; note that models combine.
- The **~10:1 value/price ratio** (Ryan Kulp) and the **low-price-hurts-retention** counterpoint (Tringas/SpyFu, incl. the ~2× discount-asker churn signal).

**evals.json** — new eval (id 8): launch-day pricing for an AI writing tool, covering learning-price framing, the $10/$100/$1,000 rule, the $9 trap, "just charge $50," value-not-competitor/cost, and model selection.

**Versioning** — pricing `2.1.0 → 2.1.1`; VERSIONS.md row updated (2026-08-23). plugin.json/marketplace.json untouched.

Suggested repo-release catch-up bullet:
- `z` bump — pricing 2.1.1: initial "learning price" philosophy, 8-model catalog reference, and price-change rollout methodology.

## Checks
- `bash validate-skills.sh` → all 49 skills pass
- evals.json valid JSON
- SKILL.md 295 lines (<500); description unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
