### PR TITLE
fix: add clarity & message-market-fit tools to copywriting (Founding Marketing ch.3)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,7 +18,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | competitors | 2.0.1 | 2026-07-09 |
 | content-strategy | 2.1.0 | 2026-08-19 |
 | copy-editing | 2.0.0 | 2026-05-05 |
-| copywriting | 2.0.1 | 2026-06-16 |
+| copywriting | 2.0.2 | 2026-08-23 |
 | cro | 2.0.0 | 2026-05-05 |
 | customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -2,7 +2,7 @@
 name: copywriting
 description: When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says "write copy for," "improve this copy," "rewrite this page," "marketing copy," "headline help," "CTA copy," "value proposition," "tagline," "subheadline," "hero section copy," "above the fold," "this copy is weak," "make this more compelling," or "help me describe my product." Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see emails. For popup copy, see popups. For editing existing copy, see copy-editing. For the offer underneath the copy (bonuses, guarantees, value framing), see offers.
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 # Copywriting
@@ -41,7 +41,9 @@ Gather this context (ask if not provided):
 ## Copywriting Principles
 
 ### Clarity Over Cleverness
-If you have to choose between clear and creative, choose clear.
+If you have to choose between clear and creative, choose clear. Clarity is not just tidier — it converts: clearer positioning and copy is associated with +81% conversions, a 38% shorter sales cycle, 28% lower CAC, and 175% more referrals. When a reader has to decode your line, you've lost them.
+
+**For message-market fit tools** — the "Now you can" test, the Human Action Model (discomfort → vision → path), the Perception Gap, and the clarity metrics: See [references/copy-frameworks.md](references/copy-frameworks.md#clarity--message-market-fit)
 
 ### Benefits Over Features
 Features: What it does. Benefits: What that means for the customer.
@@ -119,6 +121,8 @@ Puns and wit make copy memorable—but only if it fits the brand and doesn't und
 - "{Question highlighting main pain point}"
 
 **For comprehensive headline formulas**: See [references/copy-frameworks.md](references/copy-frameworks.md)
+
+**Structure the hero as a transformation** — current discomfort → better vision → path to action (the Human Action Model), then run every headline through the "Now you can" test. See [references/copy-frameworks.md](references/copy-frameworks.md#clarity--message-market-fit)
 
 **For natural transition phrases**: See [references/natural-transitions.md](references/natural-transitions.md)
 

--- a/skills/copywriting/evals/evals.json
+++ b/skills/copywriting/evals/evals.json
@@ -106,6 +106,21 @@
         "Result is specific, clear, and jargon-free"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Write above-the-fold copy for a calendar scheduling tool. Our differentiator is that the recipient gets to overlay their own calendar on the invite, so picking a time feels fair to both people instead of one-sided. Same product needs to work for indie founders AND for enterprise ops teams.",
+      "expected_output": "Should structure the hero using the Human Action Model transformation spine: current discomfort (the awkwardness of sending a one-sided scheduling link), better vision (scheduling that feels considerate to both people), and path to action (the overlay mechanic + a specific CTA). Should run headline candidates through the 'Now you can' test and prefer lines that are compelling and true. Should reference or echo the SavvyCal awkward-link insight ('You shouldn't have to feel awkward sending out your scheduling link') as the message-market-fit model. Should surface the Perception Gap: the same benefit reads differently by risk tolerance, so it should provide a value-prop swap — a founder-facing framing (speed, no sales calls) and an enterprise-facing framing (security, SLAs, reliability) rather than one averaged, mushy message. Should favor clarity over cleverness and provide 2-3 headline alternatives with rationale.",
+      "assertions": [
+        "Structures the hero as discomfort -> vision -> path (Human Action Model)",
+        "Applies the 'Now you can' test to headline candidates",
+        "References the SavvyCal awkward-link message-market-fit insight",
+        "Surfaces the Perception Gap between segments",
+        "Provides a value-prop swap: founder framing vs enterprise framing",
+        "Favors clarity over cleverness",
+        "Provides 2-3 headline alternatives with rationale"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/copywriting/references/copy-frameworks.md
+++ b/skills/copywriting/references/copy-frameworks.md
@@ -7,6 +7,7 @@ Headline formulas, page section types, and structural templates.
 - Landing Page Section Types (core sections, supporting sections)
 - Page Structure Templates (feature-heavy page, varied engaging page, compact landing page, enterprise/B2B landing page, product launch page)
 - Section Writing Tips (problem section, benefits section, how it works section, testimonial selection)
+- Clarity & Message-Market Fit (the "Now you can" test, Human Action Model, the Perception Gap, the SavvyCal case, clarity metrics)
 
 ## Headline Formulas
 
@@ -342,3 +343,91 @@ Avoid testimonials that just say:
 - "Great product!"
 - "Love it!"
 - "Easy to use!"
+
+---
+
+## Clarity & Message-Market Fit
+
+Headline formulas give you the shape of a line. These tools tell you whether the line is actually *working* — whether it's clear, whether it maps to how the reader already thinks, and whether it lands with the right person. Positioning is the prologue to your novel: it sets up everything that follows. Get it clear and the rest of the page writes itself.
+
+### The "Now you can" Test
+
+A fast gut-check for any headline or benefit line. Mentally prefix it with **"Now you can…"**. If the result is both **compelling** and **true**, the line is doing its job. If it reads as vague, obvious, or a stretch, rewrite it.
+
+The test works because "Now you can…" forces the copy into the reader's world — it has to name a concrete new ability they didn't have before. Feature-speak and buzzwords collapse under it.
+
+| Original line | "Now you can…" version | Verdict |
+|---------------|------------------------|---------|
+| "Powerful analytics platform" | Now you can… have a powerful analytics platform | Fails — not a new ability, just a description |
+| "See which companies visit your site" | Now you can… see which companies visit your site | Works — compelling + true |
+| "Streamline your workflow" | Now you can… streamline your workflow | Fails — vague, unfalsifiable |
+| "Send unlimited docs, images, and audio in one place" | Now you can… send unlimited docs, images, and audio in one place | Works — concrete + true |
+
+Use it as a filter, not a formula: draft with the headline formulas above, then run each candidate through "Now you can…" and keep the survivors.
+
+### The Human Action Model (landing-page narrative spine)
+
+Ludwig von Mises' Human Action Model explains *why* anyone acts: a person acts only when three things line up. Every above-the-fold that converts follows the same three-beat spine:
+
+1. **Current discomfort** — the felt problem, named in the reader's own words. They have to recognize their situation ("that's exactly me").
+2. **Better vision** — a clearly imagined, more satisfying state. What life looks like once the discomfort is gone.
+3. **Path to action** — the belief that *this specific step* closes the gap between the two. The product is the bridge, and the CTA is how they cross it.
+
+Miss any beat and the reader stalls. No discomfort = no reason to move. No vision = no destination. No path = no reason to believe *you're* the way there.
+
+**Mapping it onto the hero:**
+
+| Beat | Where it usually lives | Example |
+|------|------------------------|---------|
+| Current discomfort | Eyebrow, subhead, or problem-framed headline | "You shouldn't have to feel awkward sending out your scheduling link" |
+| Better vision | Headline or subhead | "Scheduling that feels considerate, not one-sided" |
+| Path to action | CTA + supporting proof | "Start scheduling free" |
+
+This is the transformation spine underneath the "6 essential sections" of a landing page — hero, social proof, problem, solution, how-it-works, and final CTA. The hero states the transformation; the rest of the page substantiates each beat.
+
+### The Perception Gap
+
+The same benefit can read as a **selling point to one segment and a red flag to another**. The gap is between what *you* think you're saying and what a given reader hears through their own risk tolerance.
+
+The fix isn't softer copy — it's **matching the value prop to the reader's risk tolerance**. Segment first, then swap the framing.
+
+| Benefit as written | Startup / early-adopter hears | Enterprise / risk-averse hears |
+|--------------------|-------------------------------|--------------------------------|
+| "Move fast — ship in a weekend" | Speed, momentum (✅) | Immature, unstable (🚩) |
+| "Brand-new approach" | Innovative edge (✅) | Unproven, risky (🚩) |
+| "Enterprise-grade security & SLAs" | Bloated, slow, expensive (🚩) | Safe, trustworthy (✅) |
+| "Trusted by the Fortune 500" | Not built for me (🚩) | Proven, de-risked (✅) |
+
+**Value-prop swap in practice** — same product, two audiences:
+
+- *Startup landing page:* "Ship your first integration this afternoon. No sales calls, no procurement." 
+- *Enterprise landing page:* "SOC 2 Type II, 99.99% uptime SLA, and a named implementation lead. Roll out with confidence."
+
+When a page has to serve both, don't average them into mush — segment the traffic (separate pages, or a persona split) and let each read its own version of the truth.
+
+### Worked Example — SavvyCal (message-market fit)
+
+SavvyCal (a scheduling tool) originally led with feature-forward copy. They rewrote the hero around a single felt discomfort:
+
+> **"You shouldn't have to feel awkward sending out your scheduling link."**
+
+That one line **roughly tripled (3×) conversions**. It works because it hits all three beats of the Human Action Model at once:
+
+- **Discomfort:** the small social awkwardness of "here's my link, pick a time" — named exactly as users feel it.
+- **Vision:** scheduling that feels considerate to *both* people.
+- **Path:** SavvyCal's overlay-your-calendar mechanic is the bridge, so the CTA feels like the obvious next step.
+
+The lesson: message-market fit beats feature lists. The winning line wasn't cleverer — it named a real feeling the reader hadn't heard a scheduling tool acknowledge before. Run your own hero through "Now you can…" and the Human Action Model to find that line.
+
+### Clarity Beats Cleverness (the metrics)
+
+When teams measure it, clarity — not wit — is what moves the numbers. Clearer positioning and copy is associated with:
+
+- **+81% conversions**
+- **−38% sales cycle** (shorter time to close)
+- **−28% CAC** (lower customer acquisition cost)
+- **+175% referrals**
+
+The mechanism: clear copy lets the *right* buyer self-qualify fast and the wrong one bounce early, so every downstream metric improves. Clever copy that requires decoding does the opposite — it adds a comprehension tax at the exact moment attention is scarcest.
+
+**Practical rule:** if a reader has to pause to figure out what you mean, you've already lost. When forced to choose between a clever line and a clear one, ship the clear one — then use the tests above ("Now you can…", the Human Action Model, the Perception Gap) to make the clear line compelling too.


### PR DESCRIPTION
## Summary

Enriches the **copywriting** skill with the clarity and message-market-fit techniques from chapter 3 of Corey Haines's *Founding Marketing*. The chapter's headline formulas already live in `references/copy-frameworks.md`, so those are deliberately skipped — this PR adds only the confirmed-absent techniques.

New **Clarity & Message-Market Fit** section in `references/copy-frameworks.md`:

- **The "Now you can" test** — a headline/benefit gut-check: prefix a line with "Now you can…"; keep it only if the result is compelling *and* true. Includes a pass/fail table.
- **The Human Action Model** (von Mises) — the landing-page narrative spine **current discomfort → better vision → path to action**, mapped onto the hero/above-the-fold.
- **The Perception Gap** — the same benefit reads as a selling point to one segment and a red flag to another; fix by matching the value prop to risk tolerance, with startup-vs-enterprise value-prop swaps.
- **The SavvyCal case** — "You shouldn't have to feel awkward sending out your scheduling link" → ~3× conversions, worked through all three Human Action Model beats.
- **Clarity beats cleverness metrics** — +81% conversions, −38% sales cycle, −28% CAC, +175% referrals, plus the mechanism and a practical rule.

`SKILL.md` routes to the new section from **Clarity Over Cleverness** and the **Above the Fold** guidance. New eval (id 8) exercises the Human Action Model spine, the "Now you can" test, the SavvyCal insight, and a Perception-Gap value-prop swap.

## Versioning

- copywriting `metadata.version` 2.0.1 → 2.0.2 (patch)
- `VERSIONS.md` copywriting row → 2.0.2 / 2026-08-23

Per instructions, `plugin.json` / `marketplace.json` are untouched and no Recent Changes block was added. Suggested repo-release bullet to add on the next catch-up:

> - **copywriting** (2.0.1 → 2.0.2): new "Clarity & Message-Market Fit" section in `references/copy-frameworks.md` distilled from *Founding Marketing* ch. 3 — the "Now you can" test, the Human Action Model landing-page spine (discomfort → vision → path), the Perception Gap with startup/enterprise value-prop swaps, the SavvyCal awkward-link case (3× conversions), and the clarity metrics (+81% conv, −38% cycle, −28% CAC, +175% referrals). SKILL.md routes to it from Clarity Over Cleverness and Above the Fold. New eval (id 8).

## Checks

- [x] `bash validate-skills.sh` → all 49 skills valid
- [x] `evals.json` valid JSON, new eval = next id (8)
- [x] `SKILL.md` 256 lines (< 500)
- [x] description untouched (still within 1024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
