### PR TITLE
feat: free-tools case benchmarks + common pitfalls (Founding Marketing ch.8)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -23,7 +23,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
-| free-tools | 2.0.0 | 2026-05-05 |
+| free-tools | 2.0.1 | 2026-08-23 |
 | image | 2.0.1 | 2026-05-18 |
 | influencer-marketing | 1.1.0 | 2026-08-19 |
 | launch | 2.0.1 | 2026-06-16 |

--- a/skills/free-tools/SKILL.md
+++ b/skills/free-tools/SKILL.md
@@ -2,7 +2,7 @@
 name: free-tools
 description: When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions "engineering as marketing," "free tool," "marketing tool," "calculator," "generator," "interactive tool," "lead gen tool," "build a tool for leads," "free resource," "ROI calculator," "grader tool," "audit tool," "should I build a free tool," or "tools for lead gen." Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Free Tool Strategy (Engineering as Marketing)
@@ -25,6 +25,8 @@ Before designing a tool strategy, understand:
 ---
 
 ## Core Principles
+
+**"Your product is my marketing opportunity."** Bezos said "your margin is my opportunity." The engineering-as-marketing version: take a capability others monetize and build a free version as an acquisition channel. Unsplash gave away the stock photos Getty sold — and Getty acquired it. See [references/tool-benchmarks.md](references/tool-benchmarks.md) for named cases and conversion numbers.
 
 ### 1. Solve a Real Problem
 - Tool must provide genuine value
@@ -58,6 +60,8 @@ Before designing a tool strategy, understand:
 | Interactive | Tutorials, playgrounds, quizzes | Learning/understanding |
 
 **For detailed tool types and examples**: See [references/tool-types.md](references/tool-types.md)
+
+**For named case benchmarks (Unsplash, HubSpot Website Grader, Moz, Buffer, Shopify) with real conversion numbers**: See [references/tool-benchmarks.md](references/tool-benchmarks.md)
 
 ---
 
@@ -169,6 +173,13 @@ Rate each factor 1-5:
 4. What's the timeline and budget?
 
 ---
+
+## Common Pitfalls
+
+- **Over-engineering** — Shipping a bloated tool when the winning cases were tiny (Unsplash: 3 hrs; Website Grader: 2 engineers, 2 weeks). Scope to the one job.
+- **Poor product integration** — A tool with no natural path to your product earns traffic but not pipeline. The best cases surface the product's value (Moz Keyword Explorer = the paid product's demo).
+- **Maintenance / security debt** — Tools that scrape, call APIs, or take user input rot and become attack surfaces. Budget for upkeep before you build.
+- **Vanity metrics** — Visitors and usage feel good but don't pay. Track leads, qualification rate, and trial/signup conversion — the numbers the case library reports.
 
 ## Related Skills
 

--- a/skills/free-tools/evals/evals.json
+++ b/skills/free-tools/evals/evals.json
@@ -85,6 +85,19 @@
         "Does not attempt full page CRO using free tool strategy patterns"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're deciding whether a free tool is worth building for our SaaS. What kind of results do free tools actually get, and what usually goes wrong?",
+      "expected_output": "Should reference the named case benchmarks (e.g. Crew/Unsplash 3 hrs to 11M monthly visitors and Getty acquisition, HubSpot Website Grader 250K leads / $6M, Moz Keyword Explorer 40% trial conversion / CAC down 65%, Buffer Salary Calculator 1.5M visitors / 12% signup, Shopify Hatchful 25% trial conversion) to set realistic expectations. Should invoke the 'your product is my marketing opportunity' framing. Should surface the common pitfalls: over-engineering, poor product integration, maintenance/security debt, and vanity metrics. Should tie expectations to tool type (analyzers convert/qualify leads, calculators drive reach, generators feed onboarding). Should recommend tracking leads and conversion rather than vanity metrics.",
+      "assertions": [
+        "Cites named case benchmarks with real numbers",
+        "Invokes 'your product is my marketing opportunity' framing",
+        "Lists the common pitfalls (over-engineering, poor product integration, maintenance/security debt, vanity metrics)",
+        "Connects expected results to tool type",
+        "Recommends tracking leads/conversion over vanity metrics"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/free-tools/references/tool-benchmarks.md
+++ b/skills/free-tools/references/tool-benchmarks.md
@@ -1,0 +1,35 @@
+# Free Tool Case Benchmarks
+
+Real free tools and the numbers they produced. Use these to set expectations, justify the build, and pattern-match your concept against what actually worked.
+
+## Framing: "Your product is my marketing opportunity"
+
+Bezos's line was **"your margin is my opportunity"** — where a competitor monetizes something, undercut it. The engineering-as-marketing version is **"your product is my marketing opportunity."** Take a capability others sell, build a simple free version, and turn it into an acquisition channel. Unsplash gave away the stock photos that Getty charged for — and Getty ended up acquiring it.
+
+## Case Library
+
+| Tool | Company | Build cost | Result |
+|------|---------|-----------|--------|
+| Unsplash | Crew | 3 hrs, leftover redesign photos | 11M monthly visitors; acquired by Getty |
+| Website Grader | HubSpot | 2 engineers, 2 weeks | 250K leads, 98% auto-qualification, $6M revenue |
+| Forecasting | Baremetrics | — | 35% trial conversion |
+| Headline Analyzer | CoSchedule | — | ~20% of users convert to subscribers |
+| Keyword Explorer | Moz | — | 40% trial conversion, CAC down 65% |
+| Salary Calculator | Buffer | — | 1.5M visitors, 12% signup rate |
+| Hatchful | Shopify | — | 25% trial conversion |
+
+## What each case teaches
+
+- **Crew → Unsplash** — The anchor case. A near-zero-cost byproduct (leftover photos from a redesign, ~3 hrs to ship) became a top-of-funnel giant. Give away what others charge for; the reach compounds.
+- **HubSpot Website Grader** — Small build (2 engineers, 2 weeks), enormous return. Proof that an analyzer/grader can double as a lead engine *and* a qualification engine — 98% of leads auto-qualified because the tool's inputs revealed fit.
+- **Baremetrics Forecasting** — A tool adjacent to the core product (revenue analytics) that converts trials at 35% because using it makes the paid product's value obvious.
+- **CoSchedule Headline Analyzer** — Repeat-use analyzer with a low-friction path to subscription (~20%). High recurring usage keeps the brand in front of the audience.
+- **Moz Keyword Explorer** — A free surface of the paid product itself: 40% trial conversion and a 65% drop in CAC because the tool *is* the demo.
+- **Buffer Salary Calculator** — Not adjacent to the product at all, but massively shareable: 1.5M visitors, 12% signup. Pure reach + brand play that still converts.
+- **Shopify Hatchful** — A generator (logo maker) that feeds the core product's onboarding, converting trials at 25%.
+
+## How to use these benchmarks
+
+- **Set expectations**: Analyzer/grader tools tend to convert visitors to leads well and qualify them; calculators skew toward reach and share-worthiness; generators feed onboarding.
+- **Justify the build**: Compare your expected lead value × volume against these ratios before committing engineering time.
+- **Pattern-match**: Find the case closest to your concept (adjacent-to-product vs pure-reach) and borrow its gating and distribution approach.


### PR DESCRIPTION
## Summary

Enriches the **free-tools** skill (subtitle: "Engineering as Marketing") with the two things it lacked, adapted from Corey Haines's *Founding Marketing*, chapter 8. Does not duplicate existing content (core principles, tool-type taxonomy, gating, SEO/link-building).

- **Named case benchmarks** — new `references/tool-benchmarks.md` with a case-library table and per-case teardown: Crew → Unsplash (3 hrs → 11M/mo → Getty acquisition), HubSpot Website Grader (2 engineers, 2 wks → 250K leads, 98% auto-qualification, $6M), Baremetrics Forecasting (35% trial conv), CoSchedule Headline Analyzer (~20% → subscribers), Moz Keyword Explorer (40% trial conv, CAC −65%), Buffer Salary Calculator (1.5M visitors, 12% signup), Shopify Hatchful (25% trial conv).
- **Framing** — Bezos's "your margin is my opportunity" → **"your product is my marketing opportunity"** added to Core Principles and the benchmarks file.
- **Common Pitfalls** section in SKILL.md — over-engineering, poor product integration, maintenance/security debt, vanity metrics.
- Wired the new reference into SKILL.md routing (Core Principles + Tool Types Overview).
- New eval (id 7) covering benchmarks + pitfalls.

## Version

- `free-tools` metadata.version: 2.0.0 → **2.0.1** (patch)
- VERSIONS.md row updated to 2.0.1 / 2026-08-23

Suggested Recent Changes bullet (not added here):
- **free-tools 2.0.1** — Added named case benchmarks (Unsplash, HubSpot, Moz, Buffer, Shopify), "your product is my marketing opportunity" framing, and a Common Pitfalls list.

## Validation

- `bash validate-skills.sh` → all 49 skills valid
- evals.json valid JSON (7 evals)
- SKILL.md 190 lines (<500)
- description untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)