### PR TITLE
feat: add story-angle taxonomy to public-relations

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -42,7 +42,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
-| public-relations | 1.1.0 | 2026-08-19 |
+| public-relations | 1.1.1 | 2026-08-23 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |

--- a/skills/public-relations/SKILL.md
+++ b/skills/public-relations/SKILL.md
@@ -2,7 +2,7 @@
 name: public-relations
 description: "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get featured,' 'media list,' 'media kit,' 'press kit,' 'newsjacking,' 'news hijack,' 'HARO,' 'Qwoted,' 'Featured,' 'Help A Reporter,' 'reporter request,' 'tech press,' 'TechCrunch,' 'earned media,' 'thought leadership placement,' 'op-ed,' 'guest article,' 'press contacts,' 'podcast prep,' 'going on a podcast,' 'podcast guest,' 'prep me for this podcast,' or 'how do I get press.' Use this for earned media work — finding journalists, pitching stories, newsjacking, prepping podcast appearances, and responding to press requests. For startup/SaaS/AI directory submissions, see directory-submissions. For product launches, see launch. For social-media engagement, see social. For cold-email outreach to prospects, see cold-email."
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 # Public Relations & Earned Media
@@ -22,7 +22,8 @@ PR is not a substitute for distribution. It's a multiplier for it.
 
 - **Earned media doesn't drive direct conversions.** A TechCrunch hit will not give you 1,000 paying customers. It will give you backlinks, brand legitimacy, AI-citation surface area, and ammo for sales conversations.
 - **Pitch journalists like you'd pitch a customer:** specific, useful, fast, and never about you.
-- **The story is not your product. The story is the trend, the data, the conflict, or the human.** Your product is the evidence.
+- **The story is not your product. The story is the trend, the data, the conflict, or the human.** Your product is the evidence. Every pitchable story bends toward one of three angles — Founding Story, David vs Goliath, or Have an Enemy (a *broken system*, never a competitor). See [references/story-angles.md](references/story-angles.md).
+- **Chase press for the compound effect, not the traffic bump.** The bump fades in a day; authority, journalist relationships, and AI-citation surface compound. Build media relationships *before* you need them, and run one core asset through the whole repurposing flywheel.
 - **Speed beats polish on reactive PR.** A B+ pitch in the first hour of a story beats an A+ pitch on day three.
 
 ### When PR is worth it
@@ -49,6 +50,8 @@ Four modes. Most teams over-index on one. Run at least three.
 | **Proactive (pitching)** | Build a media list, pitch original stories | High | 2–8 weeks |
 | **Inbound (press requests)** | Respond to journalist queries on HARO/Qwoted/Featured | Low | Days to weeks |
 | **Owned (press page + media kit)** | Make it easy for journalists to find you | One-time setup | N/A |
+
+**For the story angle taxonomy (Founding Story / David vs Goliath / Have an Enemy), data stories, media relationship-building, and the PR repurposing flywheel** — see [references/story-angles.md](references/story-angles.md)
 
 **For the reactive newsjacking workflow** — see [references/newsjacking.md](references/newsjacking.md)
 
@@ -125,6 +128,9 @@ Go to [journalist-pitching.md](references/journalist-pitching.md), use the disco
 
 ### "What's worth pitching this week?"
 Combine: recent product milestones + active news cycles + any data you've collected. Score each potential story by the quality bar above.
+
+### "What's my story angle?" / "How do I get press with no news?"
+Go to [story-angles.md](references/story-angles.md). Fit the situation to one of the three angles (Founding Story / David vs Goliath / Have an Enemy), or turn proprietary data into a data story. Remember: a milestone alone isn't a story — milestone *with narrative* is.
 
 ### "Respond to this HARO query"
 Go to [press-platforms.md](references/press-platforms.md), use the response template, keep it under 200 words.

--- a/skills/public-relations/evals/evals.json
+++ b/skills/public-relations/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "public-relations",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're a tiny 2-person SaaS competing against Notion in the docs space. We don't have any funding news or a big milestone. How do we get press coverage?",
+      "expected_output": "Should route to references/story-angles.md. Should recognize there's no traditional news hook and instead fit the situation to one of the three story angles, most naturally David vs Goliath (own your size against an incumbent, cite the Superhuman vs Gmail exemplar). Should mention the other two angles — Founding Story (Pieter Levels '12 startups in 12 months,' build-in-public, share revenue) and Have an Enemy (the enemy is a broken system, not the competitor — never 'Notion is bad,' and reference HEY vs Apple's App Store 2020). Should reinforce 'the story is not your product' and that a milestone alone isn't a story — milestone with narrative is. Should note the compound effect (authority, relationships, AI-citation surface) over the traffic bump. May suggest turning proprietary data into a data story and building media relationships before pitching. Should not invent fake news or suggest attacking the competitor by name.",
+      "assertions": [
+        "Routes to references/story-angles.md",
+        "Identifies David vs Goliath as the fitting angle with the Superhuman vs Gmail exemplar",
+        "Names all three angles (Founding Story, David vs Goliath, Have an Enemy)",
+        "Clarifies the enemy is a broken system, not a named competitor (HEY vs Apple App Store 2020)",
+        "Cites Pieter Levels '12 startups in 12 months' for Founding Story",
+        "Reinforces 'the story is not your product'",
+        "Notes milestone-with-narrative and/or the compound effect over the traffic bump",
+        "Does not fabricate news or suggest smearing the competitor by name"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/public-relations/references/story-angles.md
+++ b/skills/public-relations/references/story-angles.md
@@ -1,0 +1,87 @@
+# Story Angles — What Earns Press
+
+Distilled from Corey Haines's *Founding Marketing*, ch. 5. Chase press for the **compound effect** — authority, journalist relationships, AI-citation surface — not the traffic bump. The bump fades in a day; the backlinks, the relationships, and the citable record don't.
+
+**The story is not your product.** Journalists write about trends, data, conflict, and humans. Your product is the evidence, never the headline. If the pitch is "we built a thing," there's no story. If the pitch is "here's a shift happening and we're proof of it," there is.
+
+## Contents
+- The three story angles
+- Newsworthy moments (data stories)
+- Build media relationships before you need them
+- The PR flywheel (repurposing map)
+
+---
+
+## The Three Story Angles
+
+Every earned-media story worth pitching bends toward one of three shapes. Pick the one that fits your moment — don't force all three.
+
+### 1. Founding Story
+
+The origin, the build, the numbers-in-public. Works because people follow *people*, and a founder with skin in the game is quotable in a way a product never is.
+
+- **When to use:** you're early, you have a sharp personal reason you exist, and you're willing to build in public and share real revenue.
+- **Exemplar:** Pieter Levels' "12 startups in 12 months" — shipping in the open, posting MRR screenshots, letting the challenge itself be the story. The build *was* the coverage.
+- **How to run it:** share the arc (why you started, what you've learned, where the numbers are now), not the feature list. Revenue transparency is the hook most founders are too scared to use.
+
+### 2. David vs Goliath
+
+Own your size. Being small against an incumbent is an advantage in the story, not a liability — you're the underdog readers root for.
+
+- **When to use:** there's a giant in your category and you do one thing dramatically better than they do.
+- **Exemplar:** Superhuman vs Gmail — a tiny team reframing "we're small" into "we're the fast, obsessive alternative to the default everyone tolerates."
+- **How to run it:** name the Goliath, name the one thing you beat them at, and let the size gap do the emotional work. Don't hide that you're small — lead with it.
+
+### 3. Have an Enemy
+
+Give the reader something to be against. The enemy is a **broken system**, not a competitor. Attacking a rival looks petty; attacking a genuinely broken status quo looks principled — and journalists cover principled fights.
+
+- **When to use:** there's a systemic wrong in your space you can credibly stand against, and you're willing to take a real position.
+- **Exemplar:** HEY vs Apple's App Store (2020) — the fight wasn't "Basecamp vs Apple the company," it was against App Store rules founders saw as broken. It became a press cycle *and* a policy conversation.
+- **How to run it:** define the broken system precisely, stake a clear position, and make sure you're actually willing to be quoted taking that stance. A half-hearted enemy reads as a marketing stunt.
+
+**Guardrail:** the enemy must be a system or a norm — never a named competitor. "Company X is bad" is a smear; "this way of doing things is broken" is a movement.
+
+---
+
+## Newsworthy Moments: Data Stories
+
+Beyond the three angles, the most reliably pitchable moment is a **data story** — proprietary numbers no one else has, packaged as an industry benchmark. Journalists can build a whole piece around a stat; you get the citation.
+
+- **Exemplars:** Stripe's *State of New User* / annual data reports; Intercom's benchmark reports. Each turns internal data into an annual, citable, must-cover event.
+- **Why it works:** it's original, it's quotable, and it positions you as the source-of-record for your category's numbers. It also compounds in AI answers — benchmark stats get lifted and re-cited for years.
+- **How to run it:** find the one number in your data that surprises, wrap it in methodology, and package it as a standalone one-pager (not your homepage). See [journalist-pitching.md](journalist-pitching.md) → the "Data story" template.
+
+**Milestone reminder:** a milestone alone ("we hit $1M ARR") isn't a story — milestone *with narrative* is. Attach the number to a shift, a lesson, or a David-vs-Goliath frame.
+
+---
+
+## Build Media Relationships Before You Need Them
+
+Cold-pitching a journalist the day you have news is the hard way. The founders who get covered built the relationship months earlier. It's a ladder — climb it before you need the favor.
+
+1. **Follow their beat.** Read their last 5 articles. Know what they cover and what they're tired of covering. (See the discovery checklist in [journalist-pitching.md](journalist-pitching.md).)
+2. **Add value with no ask.** Reply to their work with a genuinely useful data point or correction. Share their pieces. Answer a question they post on X. Give before you take.
+3. **Be a reliable source.** When they need a quote fast, be the person who responds in 20 minutes with a clean, quotable line — even when there's nothing in it for you. Reliability is what turns a contact into a relationship.
+
+Do this for a handful of journalists on your beat and, when you finally have a real story, you're pitching a relationship, not a stranger.
+
+---
+
+## The PR Flywheel (Repurposing Map)
+
+One core asset feeds every other channel. Don't create five things — create one exceptional thing and reformat it five ways. Each format extends the reach of the same idea and gives journalists more of a public trail to find.
+
+```
+Core asset (data report / strong POV / founding story)
+    │
+    ├─→ Thread (X / LinkedIn) — the hook, teased publicly
+    ├─→ Article (your blog) — the full argument, the destination
+    ├─→ Guest post (someone else's audience) — borrow reach
+    ├─→ Podcast appearance — the spoken, citable version
+    └─→ Video — the durable, AI-crawled version
+```
+
+- **Sequence matters less than coverage.** Publish the article as the owned home base, tease it as a thread, pitch the guest post and podcast off the same idea, cut the video from the recording.
+- **Every format strengthens the next pitch.** A journalist who can find your thread, article, and podcast on a topic sees a voice in the space — not an opportunist. This is the public trail that makes newsjacking land (see [newsjacking.md](newsjacking.md) → The Public Trail).
+- **The asset is the flywheel's fuel.** One strong data story or POV can run this loop for weeks. Weak assets stall it immediately.


### PR DESCRIPTION
## What

Adds a named **story-angle taxonomy** to the `public-relations` skill — the one gap in an otherwise complete skill (it already covered the PR mix, pitch quality bar, press page/media kit, and AI-citation measurement, but had no guidance on *what makes a story pitchable* when a founder has no news).

Source: Corey Haines's *Founding Marketing*, ch. 5 ("Leverage press coverage"), adapted into the skill's terse voice.

### New reference: `references/story-angles.md`
- **The three story angles**, each with a when-to-use + exemplar:
  - **Founding Story** — Pieter Levels' "12 startups in 12 months," build-in-public, share revenue
  - **David vs Goliath** — "own your size," Superhuman vs Gmail
  - **Have an Enemy** — the enemy is a *broken system*, never a competitor; HEY vs Apple's App Store (2020)
- **Data stories** as a newsworthy-moment type (Stripe *State of New User*, Intercom benchmarks) + the milestone-with-narrative reminder
- **"Build media relationships before you need them"** ladder (follow beats → add value → be a reliable source)
- **The PR flywheel / repurposing map**: one core asset → thread → article → guest post → podcast → video
- Reinforces "the story is not your product" and the compound-effect framing (authority / relationships / AI-citation surface over the traffic bump)

### SKILL.md wiring
- Reference pointer in the PR Mix section
- Two Core Philosophy bullets (three angles + compound effect)
- New "What's my story angle? / How do I get press with no news?" common workflow
- `metadata.version` 1.1.0 → 1.1.1

### Evals
- First eval for this skill (`evals/evals.json`, id 1): a no-news David-vs-Goliath scenario checking angle selection and the broken-system guardrail

## Validation
- `bash validate-skills.sh` → all 49 skills pass
- `evals.json` valid JSON
- SKILL.md 142 lines (<500); description unchanged at 1010 chars (<1024)

## Suggested VERSIONS.md release bullet
- **public-relations** (1.1.0 → 1.1.1): new `references/story-angles.md` — the three earned-media story angles from *Founding Marketing* ch.5 (Founding Story / David vs Goliath / Have an Enemy, enemy = broken system not competitor), each with when-to-use + exemplar (Pieter Levels, Superhuman vs Gmail, HEY vs Apple App Store 2020); plus data stories as a newsworthy-moment type, the "build media relationships before you need them" ladder, and the one-asset PR repurposing flywheel (thread → article → guest post → podcast → video). SKILL.md adds routing, "the story is not your product"/compound-effect framing, and a "what's my story angle?" workflow. First eval (id 1) covers angle selection.

Scope: only the `public-relations` skill + its VERSIONS row. plugin.json/marketplace.json untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)