### PR TITLE
Add community-models reference to community-marketing

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -13,7 +13,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | churn-prevention | 2.0.0 | 2026-05-05 |
 | co-marketing | 2.0.0 | 2026-05-05 |
 | cold-email | 2.0.0 | 2026-05-05 |
-| community-marketing | 2.0.0 | 2026-05-05 |
+| community-marketing | 2.0.1 | 2026-08-23 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |
 | competitors | 2.0.1 | 2026-07-09 |
 | content-strategy | 2.1.0 | 2026-08-19 |

--- a/skills/community-marketing/SKILL.md
+++ b/skills/community-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: community-marketing
 description: "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \"build a community,\" \"community strategy,\" \"Discord community,\" \"Slack community,\" \"community-led growth,\" \"brand advocates,\" \"user community,\" \"forum strategy,\" \"community engagement,\" \"grow our community,\" \"ambassador program,\" \"community flywheel.\""
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Community Marketing
@@ -95,6 +95,18 @@ Design for the flywheel from day one. Every decision should ask: *Does this acce
 2. **Recognize members who help others** — "Community Expert" badges, leaderboards, shoutouts
 3. **Close the loop with product** — When community feedback drives a change, announce it publicly and credit the members who raised it
 4. **Monitor sentiment weekly** — Look for patterns in complaints or confusion before they become churn signals
+
+---
+
+## Community Models & Scaling Phases
+
+Before picking tactics, pick the **shape** of the community and match your effort to its stage. See **`references/community-models.md`** for:
+
+- **The 5 community models** — Support-Driven (GreenPal), Product-Development (Ydata), Education/Enablement (LiveAgent), Founder-Led (Bento, Postaga) — each with a "best when…" fit test tied to a primary goal.
+- **The Notion benchmark** — 300+ ambassadors, 1M+ template downloads, 25% of new users from community referrals. The north star for community-led growth at scale.
+- **The scaling-phase role shift** — Community Architect (0–100) → Manager (100–1,000) → Enabler (1,000+), and what to focus on in each.
+
+Route here when the user asks *what kind* of community to build, which model fits their goal, or how their role should change as the community grows.
 
 ---
 

--- a/skills/community-marketing/evals/evals.json
+++ b/skills/community-marketing/evals/evals.json
@@ -84,6 +84,20 @@
         "Notes peer support must feel valued, not used"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're a technical dev-tool startup, still tiny. Our users are opinionated engineers and their feedback basically drives our roadmap. What kind of community should we build, and how will running it change as we grow?",
+      "expected_output": "Should route to references/community-models.md. Should recommend the Product-Development model as the best fit — technical, opinionated users whose feedback shapes the roadmap; cite Ydata's Slack driving GitHub stars and product feedback as the real case. Should note that because they're still tiny, it will start Founder-Led (Bento/Postaga) with the founder showing up personally before systems can carry it. Should lay out the scaling-phase role shift: Community Architect at 0–100 (lay the foundation, do things that don't scale, know members by name, set culture), Community Manager at 100–1,000 (build systems and governance — rituals, moderation, onboarding), Community Enabler at 1,000+ (stand up ambassador programs and sub-communities so members run it). May reference Notion's benchmark (300+ ambassadors, 1M+ template downloads, 25% of new users from community referrals) as the north star for what community-led growth can become at scale. Should match effort to stage rather than running a small community like a large one.",
+      "assertions": [
+        "Routes to references/community-models.md",
+        "Recommends Product-Development model with Ydata case",
+        "Notes it starts Founder-Led while tiny",
+        "Describes the architect -> manager -> enabler role shift with member ranges",
+        "May cite the Notion ambassador benchmark",
+        "Emphasizes matching effort to stage"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/community-marketing/references/community-models.md
+++ b/skills/community-marketing/references/community-models.md
@@ -1,0 +1,63 @@
+# Community Models & Scaling Phases
+
+The named model taxonomy, the flagship benchmark, and how the community-owner role changes as the community grows. Pair this with the goal playbooks and health metrics in `SKILL.md` — this file adds the *shape* of the community, not the tactics.
+
+Source: Corey Haines, *Founding Marketing*, Ch. 12 — "Community connects customers with each other." The thesis: don't just sell software, create a movement. Community is an **audience-first** play — indirect, "deposits in a relationship bank account" — built on **community-led systems** and **recognition/rewards**.
+
+---
+
+## The 5 Community Models
+
+Pick the model that matches the primary business goal. Most communities lean on one and borrow from others. Each has a "best when…" fit test and a real case.
+
+### 1. Support-Driven
+
+- **Best when…** support volume is high, questions are repeatable, and peers can answer each other faster than your team can. Goal: **support deflection**.
+- The community exists so members resolve each other's problems, cutting ticket load while raising satisfaction.
+- **Case — GreenPal:** ran a Facebook group where users and vendors helped each other, deflecting support away from the team.
+
+### 2. Product-Development
+
+- **Best when…** your users are technical or opinionated and their feedback directly shapes the roadmap. Goal: **feedback + build-in-public momentum**.
+- The community is a feedback engine: feature requests, bug reports, and public traction all flow through it.
+- **Case — Ydata:** ran a Slack community that drove **GitHub stars and product feedback**, turning members into co-builders.
+
+### 3. Education / Enablement
+
+- **Best when…** the product has a learning curve and activation/retention hinge on members getting good at it. Goal: **churn reduction**.
+- The community teaches members to succeed with the product; competence lowers churn.
+- **Case — LiveAgent:** used community education/enablement to **reduce churn** by helping customers get more capable.
+
+### 4. Founder-Led
+
+- **Best when…** you're early-stage, the founder's voice is the brand, and personal presence is the fastest way to build trust. Goal: **direct relationships + word-of-mouth**.
+- The founder shows up personally — answering, hosting, setting culture — before systems can carry it.
+- **Cases — Bento** (Discord) and **Postaga:** founders led their communities directly.
+
+> The fifth "model" in practice is the blend: a community usually starts **Founder-Led**, then specializes toward Support-Driven, Product-Development, or Education as it scales.
+
+---
+
+## Flagship Benchmark: Notion's Ambassador Program
+
+The reference point for community-led growth at scale:
+
+- **300+ ambassadors**
+- **1M+ template downloads**
+- **25% of new users come from community referrals**
+
+Use these as the "what great looks like" north star when sizing an ambassador program's potential — not as day-one targets. (For building the program itself, see the ambassador playbook in `SKILL.md`.)
+
+---
+
+## Scaling-Phase Role Shift
+
+The community owner's job changes at each stage. Match your effort to the phase — running a 1,000-member community like a 50-member one (or vice versa) is the most common failure.
+
+| Phase | Members | Role | Focus |
+|-------|---------|------|-------|
+| Foundation | 0–100 | **Community Architect** | Lay the foundation and build relationships — do things that don't scale, know members by name, set the culture. |
+| Systems | 100–1,000 | **Community Manager** | Build systems and governance — rituals, moderation, onboarding paths, clear norms so activity survives without you touching every thread. |
+| Scale | 1,000+ | **Community Enabler** | Enable others — stand up ambassador programs and sub-communities so members and leaders run it. You architect the leverage, not the conversations. |
+
+**The shift in one line:** architect the *room* → manage the *systems* → enable the *people*. Each phase hands off the previous phase's manual work to structure and to members.


### PR DESCRIPTION
Adapts *Founding Marketing* Ch. 12 into the `community-marketing` skill, adding the community-shape guidance the skill was missing (it already covered the flywheel, launch-from-zero, ambassador/power-user playbooks, platform selection, and health metrics).

## What is new
- **`references/community-models.md`**:
  - **5 named community models** with a "best when…" fit test + real case each: Support-Driven (GreenPal — support deflection), Product-Development (Ydata — GitHub stars/feedback), Education/Enablement (LiveAgent — churn reduction), Founder-Led (Bento, Postaga — direct relationships).
  - **Notion ambassador benchmark**: 300+ ambassadors, 1M+ template downloads, 25% of new users from community referrals.
  - **Scaling-phase role shift**: Community Architect (0–100) → Manager (100–1,000) → Enabler (1,000+), with per-phase focus (foundation/relationships → systems/governance → ambassador programs & sub-communities).
- Wired into `SKILL.md` routing via a new "Community Models & Scaling Phases" section.
- New eval **#7** covering model selection + the role shift.
- Version bump `2.0.0 → 2.0.1`; VERSIONS.md row updated (2026-08-23).

No overlap with existing flywheel / ambassador-program / power-user content.

## Validation
- `bash validate-skills.sh` → all 49 skills valid.
- `evals.json` valid JSON.
- SKILL.md 175 lines (<500).

## Suggested Recent Changes bullet (for a later repo-release catch-up)
- Enriched **`community-marketing`** with a `community-models.md` reference: the 5 named community models (Support-Driven/Product-Development/Education/Founder-Led) with fit tests + real cases, the Notion ambassador benchmark, and the architect→manager→enabler scaling-phase role shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
