### PR TITLE
feat: add product-embedded virality to referrals skill

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -43,7 +43,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
 | public-relations | 1.1.0 | 2026-08-19 |
-| referrals | 2.0.0 | 2026-05-05 |
+| referrals | 2.1.0 | 2026-08-23 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |
 | schema | 2.0.0 | 2026-05-05 |

--- a/skills/referrals/SKILL.md
+++ b/skills/referrals/SKILL.md
@@ -2,7 +2,7 @@
 name: referrals
 description: "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch."
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Referral & Affiliate Programs
@@ -35,6 +35,20 @@ Gather this context (ask if not provided):
 ### 4. Resources
 - Tools/platforms you use or consider?
 - Budget for referral incentives?
+
+---
+
+## Should You Engineer Virality First?
+
+Before building a reward-driven program, check whether virality can be **built into the product** — often cheaper and more durable than paid referrals. But **don't force virality where it doesn't naturally fit.**
+
+Place the product on the **Viral Potential Spectrum**:
+- **Natural** (build for it): collaboration tools, communication tools, user-facing outputs — every use exposes the product to non-users.
+- **Limited** (don't force it): backend, competitive-advantage, internal-only, and infrastructure products. Invest in referral programs, content, and partnerships instead.
+
+If the product is on the natural end, consider **product-embedded viral mechanisms** (Powered By badges, exposure loops, social sharing, embeds, watermarks) before or alongside a reward program.
+
+**For the spectrum diagnostic, the 7 viral mechanisms, value-presentation and timing best practices, and affiliate power-law mechanics**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 
@@ -99,7 +113,11 @@ Trigger Moment → Share Action → Convert Referred → Reward → (Loop)
 
 **Tiered rewards**: Gamifies referral process, increases engagement
 
+**Present the reward with the bigger-*feeling* number** — "lead with the larger number" (say "$10 off," not "40% off," on a low-priced product). Reward at the **aha moment or milestone**, not signup. Reduce friction: one-click share, pre-written messages.
+
 **For examples and incentive sizing**: See [references/program-examples.md](references/program-examples.md)
+
+**For product-embedded virality, value-presentation rules, and affiliate power-law mechanics**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 
@@ -219,6 +237,8 @@ They get [their reward] too.
 ## Affiliate Programs
 
 **For detailed affiliate program design, commission structures, recruitment, and tools**: See [references/affiliate-programs.md](references/affiliate-programs.md)
+
+**For affiliate power-law mechanics (buyout clauses ~12× monthly commission, the 20/80 super-promoter rule, launch-affiliate tactics)**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 

--- a/skills/referrals/evals/evals.json
+++ b/skills/referrals/evals/evals.json
@@ -84,6 +84,20 @@
         "Provides specific referral email copy or template"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We build a collaborative design tool. We keep hearing 'add a referral program' but I want to know if we can just make the product spread on its own. What are our options?",
+      "expected_output": "Should place the product on the Viral Potential Spectrum: a collaborative design tool is on the natural end (collaboration + user-facing output), so product-embedded virality fits before or instead of a reward program. Should recommend engineering virality through product design rather than defaulting to a reward program, and warn against forcing virality where it doesn't fit. Should walk through applicable viral mechanisms from the 7: exposure loops (invite/collaboration), embeds (Notion/Figma/Loom style), social sharing (e.g. a #MadeWith hashtag), and Powered By / watermark badges on free-tier output. Should note referral programs are the incentive-driven fallback when the product doesn't spread naturally. Should reference viral-mechanisms.md.",
+      "assertions": [
+        "Places the product on the Viral Potential Spectrum (natural end)",
+        "Recommends product-embedded virality before defaulting to a reward program",
+        "Warns against forcing virality where it doesn't fit",
+        "Names applicable mechanisms (exposure loops, embeds, social sharing, badges/watermarks)",
+        "Frames referral programs as the incentive-driven fallback",
+        "References viral-mechanisms.md"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/referrals/references/viral-mechanisms.md
+++ b/skills/referrals/references/viral-mechanisms.md
@@ -1,0 +1,102 @@
+# Viral Mechanisms
+
+Virality can be **engineered through product design**, not just bought with reward programs. But don't force it — decide *whether* virality fits your product before building anything.
+
+## Contents
+- Viral Potential Spectrum (the diagnostic)
+- The 7 Viral Mechanisms
+- Referral Best Practices (presentation, timing, friction)
+- Affiliate Mechanics (buyout clauses, the 20/80 power law, launch tactics)
+
+---
+
+## Viral Potential Spectrum
+
+Before engineering virality, place your product on the spectrum. **Don't force virality where it doesn't naturally fit.**
+
+**Natural viral potential (build for it):**
+- **Collaboration tools** — value grows when you invite others (docs, whiteboards, project management)
+- **Communication tools** — you can't use them alone (email, scheduling, messaging)
+- **User-facing outputs** — every use produces something others see (design, video, forms, links)
+
+**Limited viral potential (don't force it):**
+- **Backend / infrastructure** — invisible to end users
+- **Competitive-advantage tools** — users *hide* that they use them (their edge)
+- **Internal-only tools** — never leave the org
+- **Infrastructure** — plumbing no one talks about
+
+If you're on the limited end, invest in referral programs, content, and partnerships instead of embedding viral loops that won't fire.
+
+---
+
+## The 7 Viral Mechanisms
+
+Most are **non-incentive** — the loop is built into the product, not paid for.
+
+### 1. "Powered By" Badges
+A small attributed badge on user-facing output ("Powered by [Product]"). Every page/form/widget a customer ships becomes an ad. Often free-tier only (paid tier removes it).
+
+### 2. Exposure Loops
+The product's normal use exposes it to non-users.
+- **Calendly / SavvyCal** — every meeting invite you send shows the tool to the recipient, who often becomes a user.
+- **Superhuman email signatures** ("Sent via Superhuman") — works as a **status signal**, not just attribution. The signature signaled early-adopter status, so recipients *wanted* it. Exposure loops are strongest when using the product confers status.
+
+### 3. Social Sharing
+Make output natively shareable with a branded hook.
+- **#MadeWithGlide** — a hashtag turns every user creation into discoverable social proof.
+- One-tap "share to X/LinkedIn" on any milestone, result, or artifact.
+
+### 4. Embed Options
+Let users embed their content elsewhere; the embed carries your brand and a link back.
+- **Notion, Figma, Loom** — embedded docs, designs, and videos spread the product to every viewer on every host site.
+
+### 5. Watermarks / Mandatory Badges
+Like "Powered By" but harder to remove — baked into the output itself.
+- **OpusClips** watermark on generated clips.
+- **"Made in Webflow"** badge on free-plan sites.
+Free tier carries the mark; paid tier removes it. The free users become the distribution.
+
+### 6. Referral Programs
+Explicit incentives for referring. Covered in detail in [program-examples.md](program-examples.md) and below. The one *incentive-driven* mechanism on this list — use it when the product itself doesn't naturally spread.
+
+### 7. Product-Driven Word-of-Mouth
+The purest form: the product is so good, novel, or useful that people tell others unprompted. Not a mechanism you bolt on — it's earned through the product experience. Engineering the other six makes this easier to trigger.
+
+---
+
+## Referral Best Practices
+
+Detail beyond the core referral loop (trigger → share → convert → reward).
+
+### Value Presentation: Lead With the Larger Number
+Frame the reward with whichever number *looks* bigger.
+- On a $25 product, say **"$10 off"** — not "40% off."
+- On a $500 product, say **"20% off"** — not "$100 off" if the percentage frames better... but usually the absolute dollar figure wins for smaller prices.
+- Rule of thumb: **under ~$100, lead with the dollar amount; over ~$100, test the percentage.** Always pick the bigger-*feeling* number.
+
+### Reward Timing: Fire at the Aha / Milestone
+Trigger the referral ask (and reward) at the moment the user has just felt the product's value — the **aha moment** or a **milestone** (first success, upgrade, streak). Motivation to share peaks right after value is experienced, not at signup.
+
+### Double-Sided Rewards
+Both referrer and referred get value. Higher conversion than single-sided, and gives the referrer a generous, non-selfish reason to share ("here's $10 for you too").
+
+### Friction Reduction
+Every extra step kills share rate.
+- **One-click sharing** — pre-generated link, no form.
+- **Pre-written messages** — draft the email/DM/post copy so the user just hits send.
+- In-product placement at the trigger moment, not buried in settings.
+
+---
+
+## Affiliate Mechanics
+
+Detail deferred from the partnerships side — for building an affiliate motion into a referral/partner strategy.
+
+### Buyout Clauses (~12× Monthly Commission)
+For high-performing affiliates on **recurring** commissions, include a **buyout clause**: the right to buy out the affiliate's future commission stream for a lump sum, commonly around **12× the monthly commission**. Protects margin on a customer the affiliate referred once but earns on forever, and gives the affiliate an attractive cash-out.
+
+### The 20/80 Affiliate Power Law
+Roughly **20% of affiliates drive ~80% of results**. Don't spread effort evenly across a long tail of dormant sign-ups. **Identify super-promoters and invest in them** — higher tiers, custom assets, co-marketing, direct relationship, early access. Recruiting 1,000 passive affiliates is worth less than activating 10 great ones.
+
+### Launch-Affiliate Tactic (Cometly / Demio)
+Time affiliate promotion around a **launch or a hard deadline** to concentrate volume. Cometly drove **$251K on a single launch day** by mobilizing affiliates simultaneously; Demio ran launch-window affiliate pushes. The mechanic: give affiliates a shared date, shared assets, and a reason for their audience to act *now* (bonus, cohort, closing offer) so promotion stacks instead of trickling.


### PR DESCRIPTION
## Summary

Enriches the **referrals** skill (previously reward/program-driven only) with **product-embedded virality** and affiliate power-law mechanics, adapted from Corey Haines's *Founding Marketing* (ch. 10, bit of 11).

Adds `references/viral-mechanisms.md`:
- **Viral Potential Spectrum** diagnostic — natural (collaboration/comms/user-facing) vs limited (backend/competitive-advantage/internal/infra). Decide *whether* to engineer virality first; "don't force virality where it doesn't naturally fit."
- **7 viral mechanisms** — Powered By badges, exposure loops (Calendly/SavvyCal; Superhuman signatures as status signals), social sharing (#MadeWithGlide), embeds (Notion/Figma/Loom), watermarks/mandatory badges (OpusClips, "Made in Webflow"), referral programs, product-driven word-of-mouth.
- **Referral best practices** not already in the skill — "lead with the larger number," reward at aha/milestone, double-sided, one-click + pre-written friction reduction.
- **Affiliate mechanics** — buyout clauses (~12× monthly commission), the 20/80 affiliate power law (invest in super-promoters), Cometly/Demio launch-affiliate tactic.

Wired into SKILL.md routing: new "Should You Engineer Virality First?" section, plus pointers in the incentive and affiliate sections. Added eval #7 (collaborative-tool product-embedded virality). Did not duplicate existing reward-program / Dropbox-Uber / K-factor content.

## Changes
- `skills/referrals/references/viral-mechanisms.md` (new)
- `skills/referrals/SKILL.md` — routing + virality-spectrum section; version 2.0.0 → 2.1.0 (277 lines, <500)
- `skills/referrals/evals/evals.json` — new eval id 7 (valid JSON)
- `VERSIONS.md` — referrals row → 2.1.0 (2026-08-23)

## Validation
- `bash validate-skills.sh` → all skills valid (referrals passes)
- evals.json parses; SKILL.md description untouched

## Suggested Recent Changes bullet (for a later catch-up)
- **referrals** 2.0.0 → 2.1.0 — added product-embedded virality (Viral Potential Spectrum + 7 viral mechanisms), referral value-presentation/timing best practices, and affiliate power-law mechanics (buyout clauses, 20/80 super-promoters, launch-affiliate tactic). Adapted from *Founding Marketing* ch. 10–11. New eval #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
