### PR TITLE
feat: add SLC readiness gate to launch skill

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -26,7 +26,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
 | influencer-marketing | 1.1.0 | 2026-08-19 |
-| launch | 2.0.1 | 2026-06-16 |
+| launch | 2.0.2 | 2026-08-23 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -2,7 +2,7 @@
 name: launch
 description: "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas. For the offer being launched (bonuses, guarantees, scarcity, naming), see offers."
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 # Launch Strategy
@@ -99,6 +99,34 @@ Tap into someone else's audience to shortcut the hardest part—getting noticed.
 Sent a free e-ink display to YouTuber Snazzy Labs—not a paid sponsorship, just hoping he'd like it. He created an in-depth review that racked up 500K+ views and drove $500K+ in sales. They also set up an affiliate program for ongoing promotion.
 
 Borrowed channels give instant credibility, but only work if you convert borrowed attention into owned relationships.
+
+---
+
+## Readiness Gate: Are You Ready to Launch?
+
+Run this **before** the phased mechanics. Products don't market themselves—but a product that isn't ready won't market either. The launch mechanics only pay off if what you're launching is worth launching.
+
+Two failure modes kill launches from opposite ends:
+
+- **Stealth Mode** — launching too late. "Procrastination in a fancy suit." You keep polishing in private, waiting for the product to be perfect. It never ships, and nobody learns you exist.
+- **"Just One More Feature"** — never launching. Every proposed launch date gets pushed for one more thing. The scope creeps forever; the launch never comes.
+
+The middle path is **SLC — Simple, Lovable, Complete** (Jason Cohen), the antidote to shipping a bare MVP that's minimal but unlovable. Don't launch a stub nobody wants; don't wait for a bloated everything-app. A launchable v1 is:
+
+- **Simple** — it does *one* thing. Not many things poorly. One clear job, done well.
+- **Lovable** — people *want* to use it, not just tolerate it. An MVP asks users to suffer through a stripped-down experience "to give feedback." SLC gives them something they'd choose. If nobody would be sad to lose it, it isn't lovable yet.
+- **Complete** — it's a *whole* experience for that one thing, not a stub with obvious holes. Complete at its chosen scope, not a teaser of a bigger promise.
+
+**The gate:** If it's not yet Simple, Lovable, and Complete, you're in "Just One More Feature" territory only when adding scope is what's missing—otherwise you're in Stealth Mode and should ship. Cut scope until one thing is lovable and complete, then launch that. SLC gives you a real launch now instead of a perfect launch never.
+
+**Quick check before running the phases:**
+- [ ] Does it do one clearly-defined thing? (Simple)
+- [ ] Would a target user *choose* to use it, not just endure it? (Lovable)
+- [ ] Is that one thing a whole experience, with no glaring stubs? (Complete)
+- [ ] Are you polishing past this bar? → Stop. You're in Stealth Mode. Ship.
+- [ ] Are you still adding new things to the scope? → Stop. You're in "Just One More Feature." Cut back to SLC.
+
+Pass the gate, then run the phases below.
 
 ---
 

--- a/skills/launch/evals/evals.json
+++ b/skills/launch/evals/evals.json
@@ -86,6 +86,21 @@
         "May provide some launch-related tactical ideas"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We've been building our product in private for 8 months and keep pushing the launch date because there's always one more feature we want to add first. How do we know when we're actually ready to launch?",
+      "expected_output": "Should apply the Readiness Gate before jumping to launch mechanics. Should name the two failure modes: Stealth Mode (launching too late, 'procrastination in a fancy suit') and 'Just One More Feature' (never launching), and identify that this user is exhibiting both. Should introduce SLC (Simple, Lovable, Complete) by Jason Cohen as the middle path and the alternative to a bare MVP. Should explain each: Simple (does one thing), Lovable (users want to use it, not just tolerate it), Complete (a whole experience, not a stub). Should advise cutting scope to reach SLC on one thing rather than adding more features, and to ship once the gate is passed. Should not just dump the five-phase mechanics without addressing readiness first.",
+      "assertions": [
+        "Applies the readiness gate before launch mechanics",
+        "Names Stealth Mode and 'Just One More Feature' failure modes",
+        "Diagnoses the user as stuck in these failure modes",
+        "Introduces SLC (Simple, Lovable, Complete) as the middle path vs a bare MVP",
+        "Explains Simple, Lovable, and Complete distinctly",
+        "Advises cutting scope to reach SLC rather than adding features",
+        "Recommends shipping once the gate is passed"
+      ],
+      "files": []
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a pre-launch **readiness gate** to the `launch` skill, drawn from *Founding Marketing* ch.1. The chapter's launch mechanics (ORB, Five-Stage Launch, Feature Announcement Matrix, Product Hunt) were already productized in this skill — the missing piece was the "are you ready to launch?" check that should run *before* those mechanics.

The gate uses Jason Cohen's **SLC — Simple, Lovable, Complete** as the alternative to a bare MVP, tied to the two chapter failure modes:
- **Stealth Mode** — launching too late ("procrastination in a fancy suit")
- **"Just One More Feature"** — never launching

SLC is the middle path: don't ship a minimal-but-unlovable stub, don't wait for a bloated everything-app. A launchable v1 is Simple (does one thing), Lovable (people want to use it, not tolerate it), and Complete (a whole experience, not a stub).

## Changes
- `skills/launch/SKILL.md` — new **Readiness Gate** section placed before the Five-Phase Launch Approach; bump `metadata.version` 2.0.1 → 2.0.2
- `skills/launch/evals/evals.json` — new eval (id 7): user stuck pushing launch for "one more feature" for 8 months, expects the gate + SLC + both failure modes
- `VERSIONS.md` — launch row 2.0.1 → 2.0.2 (2026-08-23)

## Validation
- `bash validate-skills.sh` → all 49 skills valid
- `evals.json` valid JSON
- SKILL.md 381 lines (<500)
- No duplication of existing launch mechanics; description untouched

## Suggested changelog bullet (VERSIONS.md Recent Changes)
- Bumped `launch` (2.0.1 → 2.0.2): added a pre-launch **Readiness Gate** section (before the five-phase mechanics) based on Jason Cohen's **SLC — Simple, Lovable, Complete** as the alternative to a bare MVP, tied to the two *Founding Marketing* ch.1 failure modes — **Stealth Mode** (launching too late) and **"Just One More Feature"** (never launching) — with a quick pre-launch checklist and a matching eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
