### PR TITLE
feat: content-strategy — distribution spine + execution layer (Founding Marketing ch6 + ch14)

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -16,7 +16,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | community-marketing | 2.0.0 | 2026-05-05 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |
 | competitors | 2.0.1 | 2026-07-09 |
-| content-strategy | 2.1.0 | 2026-08-19 |
+| content-strategy | 2.2.0 | 2026-08-23 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
 | cro | 2.0.0 | 2026-05-05 |

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: content-strategy
 description: When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions "content strategy," "what should I write about," "content ideas," "blog strategy," "topic clusters," "content planning," "editorial calendar," "content marketing," "content roadmap," "what content should I create," "blog topics," "content pillars," or "I don't know what to write." Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social.
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Content Strategy
@@ -38,6 +38,12 @@ Gather this context (ask if not provided):
 - What content gaps exist in your market?
 
 ---
+
+## Treat Content Like a Product
+
+Every piece is its own launch. Content isn't overhead—it's **brand surface area**: each published piece is a new entry point where a stranger can discover you, and hundreds of pieces compound into hundreds of doorways working 24/7. Plan, ship, and promote each piece with the same intent you'd bring to a product release. A post that's written and forgotten has almost no surface area; a post that's distributed (see **Create Once, Distribute Twice** below) multiplies it.
+
+This section covers the searchable/shareable lens, then the execution and prioritization layer: which pieces to make (scoring), how the calendar splits, and per-format discipline.
 
 ## Searchable vs Shareable
 
@@ -331,6 +337,55 @@ Score each idea on four factors:
 | Topic A | 8 | 9 | 7 | 6 | 8.0 |
 | Topic B | 6 | 7 | 9 | 8 | 7.1 |
 
+Score 1-10 per factor, multiply by the weight, sum for the total. Rank the list; make the top-scoring pieces first.
+
+---
+
+## Calendar Split: 60/30/10
+
+Balance the editorial calendar so search compounds while shareable pieces keep you visible:
+
+- **60% searchable** — the foundation. Demand you can capture predictably (use-case content, hub/spoke, how-tos).
+- **30% shareable** — thought leadership, original data, opinion. Creates demand and earns links/mentions.
+- **10% experimental** — new formats, channels, or bets. Cheap insurance against a stale mix.
+
+This is a starting ratio, not a rule. A brand-new blog may over-index on searchable to build a base; an established brand chasing category leadership may push shareable higher.
+
+---
+
+## Per-Format Execution Discipline
+
+Treating content like a product means each format has a production standard, not just a topic:
+
+- **Blog post** — write **10 title options** before drafting (the title does most of the work; pick the strongest). Plan **~5 editing passes** (structure, clarity, evidence, line edit, headline/SEO). For the writing itself, see **copywriting**.
+- **Long-form guide** — the flagship of a pillar. Comprehensive enough to be *the* resource; structured with a table of contents and internal links to spokes. Build the hub before the spokes.
+- **Video** — script the hook first; front-load the payoff. Repurpose into short-form clips at creation time (see **social**).
+- **Podcast** — one interview yields a transcript, quote graphics, short clips, and a written recap. Design the episode knowing it will be atomized.
+- **Email** — one idea per send; the subject line is the title—write several and pick. For sequences and lifecycle, see **emails**.
+
+---
+
+## Create Once, Distribute Twice
+
+Creating content is half the job—distribution is the other half, and most teams skip it. The philosophy: **one exceptional piece, reformatted and repurposed across every channel, not a fresh piece per platform.** Pouring effort into a single flagship and then distributing it everywhere beats spreading thin effort across many mediocre platform-native posts.
+
+Build **distribution hooks into the piece at creation time**, not after: write subheads that stand alone as social posts, structure sections to be lifted out modularly, and pull quotes/stats you already know you'll graphic-ify. A well-designed guide is a distribution kit in disguise.
+
+**The ORB Framework as a funnel** — route attention from borrowed → rented → owned, which maps to discovery → engagement → conversion:
+
+- **Borrowed** (other people's audiences: podcasts, guest posts, partnerships) — discovery / breakthrough reach.
+- **Rented** (social platforms, ad networks) — engagement, but you don't own the audience or the algorithm.
+- **Owned** (email list, blog, community) — conversion and the only durable asset. Everything upstream should funnel here.
+
+ORB mechanics live in the **launch** skill (channel-type playbook) and content atomization/repurposing lives in **social**; the value here is consolidating the *distribute* half of content strategy so it has a home.
+
+**Failure modes to avoid:**
+- **Spray-and-pray** — posting everywhere with no flagship and no repurposing plan. Effort scatters, nothing compounds.
+- **Platform dependency** — building on rented land. Facebook organic reach fell from ~20% to under 2%; any rented channel can throttle you overnight.
+- **The ownership paradox** — teams spend ~90% of effort on channels they don't control (rented/borrowed) and neglect the owned assets that actually convert and can't be taken away.
+
+For the full distribution spine—the Content Distribution Flywheel, platform half-lives, and the atomization checklist—see the reference below.
+
 ---
 
 ## Output Format
@@ -367,6 +422,7 @@ Visual or structured representation of how content interconnects.
 
 ## References
 
+- **[Content Distribution Spine](references/content-distribution.md)**: Create Once Distribute Twice, ORB as a funnel, the ownership paradox, platform half-lives, the Content Distribution Flywheel, and the per-flagship atomization checklist
 - **[Headless CMS Guide](references/headless-cms.md)**: CMS selection, content modeling for marketing, editorial workflows, platform comparison (Sanity, Contentful, Strapi)
 
 ---
@@ -379,4 +435,5 @@ Visual or structured representation of how content interconnects.
 - **programmatic-seo**: For scaled content generation
 - **site-architecture**: For page hierarchy, navigation design, and URL structure
 - **emails**: For email-based content
-- **social**: For social media content
+- **social**: For social media content, content atomization, and repurposing execution
+- **launch**: For the ORB channel-type playbook and launch-day distribution

--- a/skills/content-strategy/evals/evals.json
+++ b/skills/content-strategy/evals/evals.json
@@ -97,6 +97,20 @@
         "Notes the other formats are judged by different jobs rather than calling them worthless"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "We publish one good blog post a week but nobody reads it — we just post the link once on Twitter and LinkedIn and move on. How should we think about getting our content actually seen, and how should we balance what we produce?",
+      "expected_output": "Should reframe content as brand surface area and each piece as its own launch — creating is only half the job, distribution is the other half. Should introduce 'Create Once, Distribute Twice': one flagship piece repurposed/atomized across channels rather than a single link-drop, with distribution hooks (standalone subheads, modular sections, pull quotes) designed in at creation time. Should diagnose the failure modes at play — spray-and-pray / posting once with no repurposing, and the risk of platform dependency and the ownership paradox (over-investing in rented channels vs owned). Should present the ORB framework as a discovery->engagement->conversion funnel (borrowed -> rented -> owned) routing attention back to owned assets, and reference the launch skill (ORB playbook) and social skill (atomization execution) rather than re-deriving them. Should recommend a calendar balance (60% searchable / 30% shareable / 10% experimental) as a starting ratio. May reference the Content Distribution Flywheel and per-format execution discipline (e.g., 10 titles, ~5 editing passes for a blog post).",
+      "assertions": [
+        "Reframes content as brand surface area / each piece as its own launch and names distribution as the missing half",
+        "Introduces Create Once, Distribute Twice with atomization and creation-time distribution hooks",
+        "Names failure modes: spray-and-pray, platform dependency, ownership paradox",
+        "Presents ORB (borrowed/rented/owned) as a discovery-to-conversion funnel routing back to owned, cross-linking launch and social",
+        "Recommends the 60/30/10 calendar split as a starting ratio",
+        "May reference the Content Distribution Flywheel or per-format execution discipline"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/content-strategy/references/content-distribution.md
+++ b/skills/content-strategy/references/content-distribution.md
@@ -1,0 +1,83 @@
+# Content Distribution Spine
+
+The "distribute" half of content strategy. Creating a great piece is table stakes; the leverage is in getting it seen. This reference expands the **Create Once, Distribute Twice** section of the skill.
+
+Cross-links: ORB channel-type playbook lives in **launch**; atomization/repurposing workflows (podcast → clips, blog → thread) live in **social**. This file consolidates the strategy that ties them together—don't re-derive ORB from scratch here.
+
+## Create Once, Distribute Twice
+
+One exceptional piece, reformatted across channels—not a fresh piece per platform. The math is simple: a flagship piece plus ten repurposed cuts reaches far more people than eleven mediocre native posts, at a fraction of the effort.
+
+The discipline is **designing the piece to be distributed**:
+- Write subheads that read as standalone social posts.
+- Structure sections modularly so they can be lifted out and stand alone.
+- Pre-identify the pull quotes, stats, and frames you'll turn into graphics or short clips.
+- Know the atomized outputs before you write, so the source piece contains them.
+
+Treat the flagship as the master; every channel gets a cut derived from it.
+
+## The ORB Framework as a Funnel
+
+Own, Rent, Borrow—read as a discovery → engagement → conversion funnel:
+
+| Layer | Channels | Funnel role | You control |
+|---|---|---|---|
+| **Borrowed** | Podcasts, guest posts, partnerships, PR, other people's audiences | Discovery / breakthrough | Nothing—it's a loan |
+| **Rented** | Social platforms, ad networks, marketplaces | Engagement / reach | The content, not the audience or algorithm |
+| **Owned** | Email list, blog, community, app | Conversion / retention | Everything—the durable asset |
+
+The strategic move: use borrowed and rented reach to funnel strangers into owned channels where you can convert and retain them. Borrowed and rented are rented land; owned is the only asset you keep.
+
+## The Ownership Paradox
+
+Most teams invert the priority: they spend ~90% of effort on borrowed and rented channels they don't control, and neglect the owned assets that actually convert. The paradox is that the channels getting the least attention (email, blog, community) are the ones that compound and can't be revoked. Rebalance toward owned as the destination for all upstream effort.
+
+## Failure Modes
+
+- **Spray-and-pray** — publishing across every platform with no flagship and no repurposing system. Effort scatters; nothing compounds; each post starts from zero.
+- **Platform dependency** — building your audience on rented land. Facebook organic reach collapsed from ~20% to under 2% as the platform monetized. Any rented channel can throttle, deprioritize, or de-platform you with no recourse. The lesson isn't "avoid rented"—it's "never let rented be the endpoint."
+
+## Platform Half-Lives
+
+Content decays at wildly different rates by channel. Match the piece to the channel's shelf life:
+
+| Channel | Rough half-life | Implication |
+|---|---|---|
+| Twitter/X post | Minutes–hours | Post often; repost; thread for reach |
+| Instagram / Facebook | ~a day | Frequent cadence; stories are ephemeral by design |
+| LinkedIn post | ~a day, longer for strong performers | Fewer, higher-effort posts |
+| TikTok / Reels / Shorts | Days–weeks (algorithmic resurfacing) | Evergreen hooks can re-surface long after posting |
+| YouTube video | Months–years | Search-driven; compounds like a blog post |
+| Blog post / SEO | Years | The long tail; the compounding asset |
+| Email | Sent once, but archived / repurposable | One-shot attention; harvest into other formats |
+
+Short half-life channels reward frequency and repetition; long half-life channels reward depth and evergreen framing. Owned, long-half-life formats (blog, YouTube, email archive) are where distribution effort compounds.
+
+## The Content Distribution Flywheel
+
+Distribution isn't a linear checklist—it's a loop that feeds itself:
+
+1. **Create** one exceptional flagship piece (guide, video, podcast, original research), with distribution hooks built in.
+2. **Atomize** it into channel-native cuts—clips, threads, carousels, quote graphics, email, subhead-posts.
+3. **Distribute** across owned → rented → borrowed, routing everything back to owned.
+4. **Engage** with the responses; capture the questions, objections, and reactions.
+5. **Feed back** — the engagement surfaces the next flagship topic (what resonated, what got asked), and top-performing atoms signal what to make more of.
+
+Each turn of the loop lowers the cost of the next piece (you learn what lands) and grows the owned audience that amplifies it. The flywheel is why consistent distributors pull away from one-off publishers over time.
+
+## Atomization Checklist (per flagship)
+
+For each major piece, produce (see **social** for the platform-native execution):
+- [ ] 3–5 standalone social posts from the subheads/key points
+- [ ] 1 thread (Twitter/X) or carousel (LinkedIn/Instagram) of the core argument
+- [ ] 2–4 short-form video clips (if source is video/podcast)
+- [ ] 1–2 quote or stat graphics
+- [ ] 1 email to the owned list linking the flagship
+- [ ] Repost/reshare schedule across the piece's half-life (don't post once and move on)
+
+## Related
+
+- **launch** — ORB channel-type playbook and launch-day distribution
+- **social** — atomization/repurposing workflows and platform-native execution
+- **emails** — the owned channel that converts distributed attention
+- **ai-seo** — making owned content citable by LLMs (another distribution surface)


### PR DESCRIPTION
## What

Enriches the **content-strategy** skill with the two things it lacked, adapted from Corey Haines's *Founding Marketing* chapters 6 and 14. Does not duplicate the existing searchable/shareable taxonomy or content-type sections.

### (A) Execution + prioritization layer (ch6)
- **"Treat content like a product / brand surface area"** thesis — every piece is its own launch; content multiplies your brand's entry points.
- **60/30/10 calendar split** (searchable / shareable / experimental) as a starting ratio.
- **Per-format execution discipline** — blog (10 titles, ~5 editing passes), long-form guide, video, podcast, email.
- Clarifies the existing **40/30/20/10 scoring template** (Customer Impact / Content-Market Fit / Search / Resources), which the skill already had.

### (B) Distribution spine (ch14) — consolidating the "distribute" half
- **"Create Once, Distribute Twice"** philosophy — one exceptional piece, reformatted across channels.
- **ORB as a funnel** — borrowed → rented → owned mapped to discovery → engagement → conversion.
- **Distribution hooks designed in at creation time** — subhead-posts, modular sections, pre-picked pull quotes.
- **Content Distribution Flywheel** + **platform half-lives** + per-flagship **atomization checklist** (in new reference).
- **Failure modes** — spray-and-pray, platform dependency (FB organic ~20%→<2%), the ownership paradox.
- Cross-links **launch** (ORB channel-type playbook) and **social** (atomization execution) rather than re-deriving ORB.

## Files
- `skills/content-strategy/SKILL.md` — new "Treat Content Like a Product", "Calendar Split", "Per-Format Execution Discipline", and "Create Once, Distribute Twice" sections; routing + related-skills links. 439 lines.
- `skills/content-strategy/references/content-distribution.md` — new reference for the full distribution spine.
- `skills/content-strategy/evals/evals.json` — new eval (id 8).
- `VERSIONS.md` — content-strategy 2.1.0 → 2.2.0, dated 2026-08-23.

## Checks
- `bash validate-skills.sh` → all 49 skills valid.
- evals.json valid JSON, ids 1–8.
- SKILL.md 439 lines (<500). Description untouched.

## Suggested Recent Changes bullet
- **content-strategy** (2.1.0 → 2.2.0): added the ch6 execution/prioritization layer ("treat content like a product / brand surface area" thesis, 60/30/10 calendar split, per-format discipline) and the ch14 distribution spine ("Create Once, Distribute Twice", ORB-as-funnel, creation-time distribution hooks, Content Distribution Flywheel, failure modes incl. the ownership paradox) via new `references/content-distribution.md`; cross-links launch + social. New eval (id 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)