### PR TITLE
feat(offers): SaaS offers reference — discount trap + four worked examples

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -33,7 +33,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
-| offers | 1.0.0 | 2026-06-16 |
+| offers | 1.0.1 | 2026-08-23 |
 | onboarding | 2.0.0 | 2026-05-05 |
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |

--- a/skills/offers/SKILL.md
+++ b/skills/offers/SKILL.md
@@ -2,7 +2,7 @@
 name: offers
 description: "When the user wants to design, construct, or improve an offer — the thing they actually sell — including value framing, bonus stacking, guarantee design, scarcity/urgency, naming, and payment structure. Also use when the user mentions 'offer,' 'offer design,' 'build an offer,' 'grand slam offer,' 'irresistible offer,' 'value stack,' 'bonus stack,' 'guarantee,' 'risk reversal,' 'money-back guarantee,' 'scarcity,' 'urgency,' 'high-ticket offer,' 'productize a service,' 'naming an offer,' 'payment plan,' 'down-sell,' 'upsell offer,' or 'why isn't my offer converting.' Best for services, agencies, courses, coaching, info products, high-ticket B2B, and direct-response. If you run pure self-serve SaaS, read pricing first — tiers and packaging do more work there. For price level itself (tiers, freemium, value metric), see pricing. For the page that presents the offer, see copywriting. For the launch moment, see launch. For sales collateral, see sales-enablement."
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Offer Design
@@ -96,6 +96,7 @@ Most weak offers fail on bonuses (none), guarantees (none or wrong type), or sca
 | [bonus-stacking.md](references/bonus-stacking.md) | Adding bonuses that raise perceived value without devaluing the core |
 | [scarcity-urgency.md](references/scarcity-urgency.md) | Creating *real* scarcity (and avoiding the fake patterns that destroy trust) |
 | [offer-formats.md](references/offer-formats.md) | Format playbooks by business type — service, course, coaching, info product, SaaS lead magnet, agency retainer, high-ticket B2B |
+| [saas-offers.md](references/saas-offers.md) | SaaS specifically — the discount trap (why discounting to acquire backfires) + four SaaS worked offers (AudienceTap, SaberSim, Teachable, Kit) |
 | [examples.md](references/examples.md) | Anonymized worked examples — before/after for each business type |
 
 ---
@@ -122,6 +123,7 @@ Some offer patterns work but cost more than they're worth:
 - **Over-promising guarantees** — "double your revenue or refund + $1,000." Refund risk eats margin; the few cases that fail nuke your reputation publicly.
 - **Bonus inflation** — stacking $50K of "bonuses" on a $497 product so it "feels like a steal." Sophisticated buyers see this. Treat bonuses as additive, not exaggerated.
 - **Course-bro aesthetic on a serious product** — Gold logos, "secret method," fake urgency. Pattern-matches to scam. Wrong room.
+- **Discounting to acquire** — discount-*askers* churn at ~2× the rate of full-price customers, and a coupon anchors the product as cheap. Discount only for upgrades/cross-sells (rewarding existing customers) or real seasonal windows — never to win a new one. Raise value with an offer instead. See [saas-offers.md](references/saas-offers.md).
 
 The repo voice: opinionated, but honest. Building offers well doesn't mean building offers loud.
 

--- a/skills/offers/evals/evals.json
+++ b/skills/offers/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "offers",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Our B2B SaaS trial-to-paid conversion is stuck. Our plan is to run a 50% off first 3 months coupon to push more people to convert. It's a $99/month email-tool competitor and the biggest thing prospects say is they're scared to migrate their list and automations off their current provider. Is the discount the right move?",
+      "expected_output": "Should push back on discounting to acquire and cite that discount-askers churn at roughly 2x the rate of full-price customers, that a coupon anchors the product as cheap, and attracts price-shoppers over value-buyers. Should state the rule: discount only for upgrades/cross-sells or real seasonal windows, never to acquire a new customer. Should reframe 'offers > discounts' — raise value instead of cutting price. Should diagnose that the real objection is switching cost / migration risk, not price, so a discount does nothing about it. Should recommend a real offer that reverses that risk — e.g. a done-for-you 'Painless Switch' style migration offer with a switching-cost guarantee (migration live/verified in N days or it's free) and a bonus that removes the secondary fear (deliverability/re-warm). May reference the value equation (lower effort/sacrifice and raise perceived likelihood rather than lower price). Should tie back to real, honest scarcity (capacity/queue) rather than a fake timer.",
+      "assertions": [
+        "Advises against discounting to acquire new customers",
+        "Cites discount-askers churn at ~2x full-price customers",
+        "States discount only for upgrades/cross-sells or seasonal moments",
+        "Frames offers as beating discounts (raise value, not cut price)",
+        "Identifies migration/switching cost as the real objection, not price",
+        "Recommends a done-for-you migration offer with a switching-cost guarantee",
+        "Suggests a bonus or risk-reversal that removes the real fear",
+        "Uses real scarcity (capacity/queue) rather than a fake timer"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/offers/references/saas-offers.md
+++ b/skills/offers/references/saas-offers.md
@@ -1,0 +1,116 @@
+# SaaS Offers — the discount trap + worked examples
+
+The rest of the offers library skews services, courses, and coaching. This reference covers the SaaS case specifically: why discounting is the wrong acquisition lever, and four worked offers that stack risk-reversal, bonuses, and scarcity for a software business.
+
+Read this alongside [offer-formats.md](offer-formats.md#self-serve-saas). For price level and tier structure, the `pricing` skill still does the heavier lifting — this covers the *offer* wrapped around the price.
+
+---
+
+## The discount trap
+
+The instinct when a SaaS isn't converting is to cut the price — a launch coupon, a "50% off first 3 months," a permanent lower tier. It's the most-reached-for lever and one of the worst.
+
+**Offers beat discounts.** A discount lowers the price. An offer raises the value — a guarantee, a done-for-you migration, a bonus that removes the switching cost. Same net price to the buyer, but one trains them to expect cheap and the other trains them to expect valuable.
+
+### The data
+
+**Discount-*askers* churn at roughly 2× the rate of full-price customers.** The buyer who negotiated their way in is signaling something: price was the reason they bought, not value. When a cheaper option appears — or when the renewal hits full price — they leave. You bought a customer who was never yours.
+
+This compounds. Discounting to acquire also:
+
+- **Anchors the product as cheap** — hard to raise later without churn spikes
+- **Attracts the wrong ICP** — price-shoppers, not value-buyers
+- **Trains the market to wait** — buyers learn there's always a sale coming, so they never pay full
+- Sits next to **trial fatigue and discount fatigue** — the same buyer who's seen a hundred "50% off" banners no longer feels urgency from yours
+
+### The rule
+
+**Never discount to acquire.** Discount only in two moments, where the mechanics actually work for you:
+
+| When | Why it works |
+|------|--------------|
+| **Upgrades / cross-sells** | The customer already values the product. A discount to move up a tier or add a product rewards commitment instead of buying a stranger. |
+| **Seasonal moments** | Black Friday, year-end, an annual-plan push — a real, time-bound, everyone-gets-it window. Not a permanent price cut wearing a costume. |
+
+Everything else is an **offer**, not a discount. If conversion is stuck at the top of the funnel, reverse the risk and stack the value — don't cut the price. See the four examples below.
+
+---
+
+## Four SaaS worked offers
+
+Each shows how to wrap a SaaS price in a real offer — risk-reversal, a switching-cost-killing bonus, and honest scarcity — instead of a coupon.
+
+### 1. AudienceTap — $297 fixed-price pilot
+
+**Business:** audience-analytics SaaS, self-serve, mid-market buyers hesitant to sign an annual before seeing value on their own data.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$297 fixed-price 30-day pilot** — full product, run against the buyer's real audience, not a demo dataset |
+| **Risk reversal** | "If the pilot doesn't surface an insight your team acts on, the $297 is refunded — and it credits toward annual if you convert." |
+| **Bonus** | A done-with-you setup session (connect sources, first report) so time-to-value is days, not weeks |
+| **Scarcity** | Capacity-real: "We onboard 6 pilots a month so each gets the setup session." Not a fake counter. |
+
+**Why it beats a discount:** the pilot is a paid, low-risk *yes* that filters for value-buyers. The $297 isn't a price cut — it's a fee that credits forward, so full-price annual is the default next step, not a negotiation.
+
+### 2. SaberSim — $497 bundle
+
+**Business:** sports-analytics/optimizer SaaS. Individual tools convert fine alone but the full stack is where retention lives.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$497 bundle** of the optimizer + sync + data feed — the tools that only pay off together |
+| **Risk reversal** | 14-day "run it on a real slate" guarantee — use it live, full refund if it doesn't beat the buyer's current workflow |
+| **Bonus** | Strategy walkthroughs + a starter template library so the bundle produces a result on day one |
+| **Scarcity** | Seasonal: bundle priced for the **start of the season**; after kickoff it unbundles to full à-la-carte |
+
+**Why it beats a discount:** the bundle raises perceived value (three tools, one decision) rather than lowering price on one. The season start is *real* seasonal scarcity — an allowed discount moment — not a permanent markdown.
+
+### 3. Teachable — $1,997 accelerator
+
+**Business:** course-platform SaaS. The subscription is cheap; the value (and the switching cost) is getting a course actually launched.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$1,997 "Launch Accelerator"** — the platform plan **plus** a structured 6-week program to ship the buyer's first course |
+| **Risk reversal** | Outcome guarantee: "Publish your course in 6 weeks or we work with you free until you do." Tied to a completion condition. |
+| **Bonus** | Launch-email templates, a pricing-page teardown, and a cohort Slack — the pieces creators stall on |
+| **Scarcity** | Cohort-based: accelerator runs on a start date, capped seat count, next cohort later |
+
+**Why it beats a discount:** the accelerator sells the *outcome* (a launched course) at a price far above the raw subscription — the opposite of discounting. The guarantee de-risks the real fear ("I'll pay and never launch"), and the cohort cap is honest scarcity.
+
+### 4. Kit — "Painless Switch" $997 migration offer
+
+**Business:** email-platform SaaS. The blocker isn't price — it's the terror of migrating a list, sequences, and automations off the incumbent.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$997 "Painless Switch"** — done-for-you migration of list, forms, sequences, and automations |
+| **Risk reversal** | "If your migration isn't live and verified in 14 days, it's free." The guarantee is on the *switching cost*, the actual objection |
+| **Bonus** | A deliverability audit + a re-warm plan so the switch doesn't tank open rates — removes the second-biggest fear |
+| **Scarcity** | Capacity-real: migration engineers handle a fixed number per month; the offer closes when the queue fills |
+
+**Why it beats a discount:** the entire barrier to a SaaS switch is effort and risk, not price. A discount does nothing about migration dread; a done-for-you offer with a switching-cost guarantee removes it. The buyer pays *more* up front and churns *less*, because they're a value-buyer who committed.
+
+---
+
+## The pattern across all four
+
+| Offer | Price | Risk reversal is on… | Scarcity type |
+|-------|-------|----------------------|---------------|
+| AudienceTap pilot | $297 | Whether it surfaces an actionable insight | Capacity (setup sessions) |
+| SaberSim bundle | $497 | Whether it beats the current workflow | Seasonal (season start) |
+| Teachable accelerator | $1,997 | Whether the course actually launches | Cohort (start date + cap) |
+| Kit Painless Switch | $997 | Whether migration is live in 14 days | Capacity (engineer queue) |
+
+Notice what's *not* here: a coupon, a "% off," a slashed sticker price. Every one raises value and reverses the real risk — and the scarcity is either capacity, cohort, or a genuine seasonal window, never a fake timer.
+
+**The SaaS takeaway:** when conversion is stuck, your instinct will be to discount. Build the offer instead. Discount only to reward existing customers (upgrades, cross-sells) or in a real seasonal window — never to acquire a stranger you'll watch churn at 2×.


### PR DESCRIPTION
## What

Enriches the **offers** skill with the SaaS half of *Founding Marketing* ch. 15 — the two things it was missing. Does not touch the existing value-equation / five-elements content.

Adds `skills/offers/references/saas-offers.md`:

1. **The discount trap** — discount-*askers* churn at ~**2×** the rate of full-price customers; a coupon anchors the product as cheap and attracts price-shoppers. Rule: **never discount to acquire** — only for **upgrades/cross-sells** (reward existing customers) or **real seasonal windows**. "Offers > discounts": raise value, don't cut price (trial/discount fatigue).
2. **Four SaaS worked offers** (the skill's existing examples skewed services/courses), each stacking risk-reversal + bonus + honest scarcity:
   - **AudienceTap** — $297 fixed-price pilot (credits to annual)
   - **SaberSim** — $497 season-start bundle
   - **Teachable** — $1,997 launch accelerator (outcome guarantee, cohort)
   - **Kit** — "Painless Switch" $997 done-for-you migration offer

Wires SKILL.md routing (reference-library row + a discount-trap bullet in "When NOT to Use"), adds `evals/evals.json` (id 1), bumps offers **1.0.0 → 1.0.1**, updates the VERSIONS.md row (2026-08-23).

## Validation

- `bash validate-skills.sh` → all 49 skills pass
- `evals.json` parses (valid JSON)
- SKILL.md = 155 lines (< 500)
- Description field untouched (still < 1024)

## Suggested Recent Changes bullet

- offers 1.0.1 — new `saas-offers.md` reference: the discount trap (discount-askers churn ~2×) + four SaaS worked offers (AudienceTap, SaberSim, Teachable, Kit)

Source: Corey Haines, *Founding Marketing*, ch. 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
