### PR TITLE
feat: marketing-plan investing north-star + 70/20/10 & plateau alerts

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -31,7 +31,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
 | marketing-loops | 1.2.0 | 2026-07-10 |
-| marketing-plan | 1.1.0 | 2026-05-29 |
+| marketing-plan | 1.1.1 | 2026-08-23 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
 | onboarding | 2.0.0 | 2026-05-05 |

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: marketing-plan
 description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and an embedded 17-section current-state audit rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For positioning and ICP context before planning, see product-marketing. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
+metadata:
+  version: 1.1.1
 ---
 
 # Marketing Plan
@@ -92,6 +94,32 @@ Full primer in `references/aarrr-framework.md`. Quick rule:
 
 Brand and content are **cross-cutting**, not their own AARRR stage — they serve every stage.
 
+## Marketing as investing — the north-star framing
+
+AARRR gives the plan its *structure*. This gives it its *spine*. Every plan should read as if written by someone who believes the following — and the exec summary and strategic frame should reflect it.
+
+Adapted from *Founding Marketing* by Corey Haines (Ch. 1).
+
+- **Marketing is like investing.** Treat the plan as a **compounding portfolio**, not a campaign calendar. Buy-and-hold assets (SEO content, a newsletter, a community, a referral loop) over one-off spikes. Diversify — no single channel carries the plan. Time in market beats timing the market.
+- **No silver bullets, a hundred golden pellets.** There is no one move that fixes growth. The plan wins by stacking many small compounding assets. Be suspicious of any recommendation that promises to be *the* thing.
+- **One asset, many returns.** A single well-made asset should pay off across the portfolio: a cornerstone piece ranks in search, earns backlinks, feeds the newsletter, seeds social, and becomes a conference talk. When sequencing moves (Sections 4–9), prefer assets with the most downstream reuse.
+- **Audition, not an auction.** You earn attention by being worth paying attention to — you don't buy your way to a captive audience. Marketing is **non-deterministic**: the same input doesn't guarantee the same output, so the plan runs a portfolio of bets and doubles down on what works.
+- **Hope is not a strategy.** Every move in the plan names its mechanism and its leading indicator. "Post more and hope it works" is not a line item. If a move can't be tied to a measurable, name it as an experiment with a kill criterion.
+
+### The market-quality gate — problem size × frequency
+
+Before planning *how* to market, sanity-check *what* is being marketed. Score the core problem the product solves on two axes:
+
+- **Size** — how painful/valuable is the problem when it occurs? (small → large)
+- **Frequency** — how often does the customer feel it? (rare → constant)
+
+|  | **Low frequency** | **High frequency** |
+|---|---|---|
+| **Large problem** | Winnable but expensive to keep top-of-mind (long sales cycles, retargeting-heavy) | **Best quadrant — build here.** Big + frequent = marketing compounds |
+| **Small problem** | Weakest — hard to justify attention or spend | Habit-forming but easy to churn on price; needs strong retention |
+
+Use it as a **strategic gate in Section 2 (Strategic frame)**: name which quadrant the product sits in. Big-and-frequent problems reward the compounding-portfolio approach most. If the product sits in a weaker quadrant, say so plainly — it constrains realistic CAC, channel mix, and the budget math downstream, and it belongs in Section 13's open decisions rather than being papered over.
+
 ## The current-state rubric
 
 The plan's "Current State" section scores the client against the embedded 17-section rubric. Full rubric in `references/current-state-rubric.md` — it's the source of truth, not a derivative of any external skill.
@@ -145,6 +173,8 @@ Pitch decks show hockey sticks. Real growth is a series of S-curves with plateau
 - **Phase identification** — $0–10K ARR (grueling), $10K–100K (treacherous middle), $100K–1M (acceleration). Section 3 names the current phase; Section 10 sequences the next.
 - **Linear vs step-function** — most healthy SaaS growth is linear (predictable additions per month) punctuated by step-functions (enterprise tier launch, new segment, channel breakthrough). The plan should describe both honestly — not promise exponential.
 - **S-curve layering** — Channel × Product × Market. Start the next S-curve while the current one is still growing. Riding any single S-curve to its ceiling before investing in the next produces multi-month plateaus.
+- **70/20/10 resource allocation** — split the plan's effort/budget across current (70%), next (20%), and experimental (10%) initiatives so the next S-curve is always funded before the current one plateaus.
+- **Weekly tracking cadence** — review leading indicators weekly and watch for S-curve plateau signals; a flattening curve is the trigger to shift weight toward the next one, not a reason to push harder on the current.
 
 ## Team and agency model
 

--- a/skills/marketing-plan/evals/evals.json
+++ b/skills/marketing-plan/evals/evals.json
@@ -91,6 +91,22 @@
         "Does not silently produce a stripped-down plan"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "A founder wants a plan but keeps asking 'what's the one channel that will make us blow up?' They also want a defensible way to split the budget so they don't starve future growth, and a way to know when a channel is running out of steam. Frame the strategic thinking for the plan.",
+      "expected_output": "Should push back on silver-bullet thinking with the marketing-as-investing framing — a compounding portfolio, 'no silver bullets, a hundred golden pellets,' one asset that ranks + earns backlinks + feeds the newsletter + becomes a talk, audition not an auction, hope is not a strategy. Should apply the problem size x frequency market-quality gate to sanity-check whether the product is even in a build-big-and-frequent quadrant. Should introduce the 70/20/10 resource-allocation rule (current / next / experimental) so future growth stays funded. Should introduce a weekly tracking cadence with plateau-indicator alerts (flattening week-over-week additions, rising CAC, effort up / output flat) that trigger shifting weight to the next S-curve. Should tie these into Section 2 (Strategic frame), Section 10 (12-month outlook), and Section 13 (Measurement).",
+      "assertions": [
+        "Rejects silver-bullet framing using marketing-as-investing / compounding portfolio",
+        "Uses the 'no silver bullets, a hundred golden pellets' and 'audition, not an auction' framing",
+        "Invokes 'hope is not a strategy' — every move has a mechanism and leading indicator",
+        "Applies the problem size x frequency market-quality gate",
+        "Introduces the 70/20/10 resource-allocation rule (current / next / experimental)",
+        "Introduces a weekly tracking cadence with plateau-indicator alerts",
+        "Ties plateau alerts to shifting weight toward the next S-curve",
+        "Maps the framing to Section 2, Section 10, and Section 13"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/marketing-plan/references/growth-patterns.md
+++ b/skills/marketing-plan/references/growth-patterns.md
@@ -110,6 +110,47 @@ The real magic: while SEO is maturing, you're using paid for quick wins. As thos
 
 This is the operational thesis behind the AARRR mapping (Sections 4–8) and the 12-month outlook (Section 10): each section is a curve, and the plan sequences them so the next curve is ramping while the current one is still growing.
 
+## The 70/20/10 resource-allocation rule
+
+Layering S-curves only works if the next curve is funded *before* the current one plateaus. The 70/20/10 rule is the budgeting discipline that guarantees it. Split marketing effort and spend across three buckets:
+
+| Bucket | Share | What it covers |
+|---|---|---|
+| **Current** | **70%** | The initiatives already working — the channels, content, and campaigns driving today's growth. Protect and optimize. |
+| **Next** | **20%** | The S-curve you're deliberately building — the channel/product/market bet that becomes the *current* 70% in 2–4 quarters. |
+| **Experimental** | **10%** | Unproven bets and small tests. Most fail; the ones that work graduate into the 20%, then the 70%. |
+
+Why it matters for the plan:
+
+- It operationalizes "start the next S-curve before the current one plateaus" — the 20% + 10% *is* the next curve, funded on purpose rather than scrambled for after a plateau hits.
+- It maps cleanly onto the **10–20% experimental budget buffer** in `budget-planning.md` — the experimental layer is the 10% here.
+- It gives Section 11 (Ops stack) and Section 10 (12-month outlook) a defensible allocation logic instead of dumping the whole budget into what's currently working.
+
+**In the plan:** Section 10 (12-month outlook) names what sits in each bucket now, and what's expected to graduate. Section 11 (Ops stack) shows the 70/20/10 split across the AARRR stages. Adjust the ratio by phase — Phase 1 companies (still hunting for any channel that works) may run closer to 40/30/30; Phase 3 companies with a proven engine can run 80/15/5.
+
+## Weekly tracking cadence and plateau alerts
+
+S-curve plateaus are the single most important thing to catch early — the whole point of layering curves is to shift weight to the next one *before* the current plateau bites. That requires a review rhythm, not an annual look-back.
+
+### The cadence
+
+- **Weekly** — review the leading indicators for each active S-curve (new signups per channel, content velocity, activation rate, MRR added). Weekly is frequent enough to spot a curve flattening while there's still time to act.
+- **Monthly** — roll the weeklies up; confirm which bucket (70/20/10) each initiative belongs in and whether anything should graduate or be cut.
+- **Quarterly** — the plan itself adjusts (re-sequence Section 10, reallocate the budget).
+
+### Plateau-indicator alerts
+
+Watch for these signals that a curve is topping out — each is a trigger to shift weight toward the next curve, not to push harder on the current one:
+
+- **Week-over-week additions flattening** — the channel is adding the same absolute numbers it did last month despite equal or greater effort (declining marginal return).
+- **Rising CAC on a formerly cheap channel** — paying more for the same result is the classic plateau tell.
+- **Engagement/activation softening at the top of the funnel** — the audience for this channel/message is saturating.
+- **Effort up, output flat** — the team is working harder to hold the line rather than to grow it.
+
+When two or more fire on the same curve, that's the trigger to accelerate the **20% "next" bucket** — the plateau is the moment between two S-curves, and it should already have a successor ramping.
+
+**In the plan:** Section 13 (Measurement) names the weekly leading indicators per S-curve and the specific plateau thresholds that trigger the next move. This turns "watch for plateaus" from a platitude into an operational alert.
+
 ## The 3-3-2-2-2 VC growth path
 
 For companies that have crossed $1M ARR and raised institutional capital, the VC benchmark is:
@@ -137,8 +178,9 @@ For non-VC-backed (bootstrapped, founder-funded, profit-focused) companies, this
 | **4 (Acquisition)** | Current channels + their position on the S-curve (early / mature / plateauing). Next channel investment with rationale. |
 | **5–8 (AARRR)** | Each section names the binding constraint at the current phase. For Phase 2 companies, Activation is usually the leverage point. For Phase 3, Retention + Referral compound the existing growth. |
 | **9 (90-day roadmap)** | Linear-pattern moves dominate (predictable additions). Step-function setups (the build-up to a launch, an enterprise tier, a new market segment) live here. |
-| **10 (12-month outlook)** | Sequence channel S-curves, product S-curves, market S-curves. If VC-backed Series A+, anchor against 3-3-2-2-2. If not, name the linear or step-function targets. |
-| **13 (Measurement)** | The north-star metric reflects the current phase (Phase 1 is usually pure new-signup; Phase 3 is usually expansion ARR or NRR). |
+| **10 (12-month outlook)** | Sequence channel S-curves, product S-curves, market S-curves. Apply the 70/20/10 split (current / next / experimental) so the next curve is funded before the current one plateaus. If VC-backed Series A+, anchor against 3-3-2-2-2. If not, name the linear or step-function targets. |
+| **11 (Ops stack)** | Show the 70/20/10 allocation across the AARRR stages — what share protects what's working vs. builds the next curve vs. experiments. |
+| **13 (Measurement)** | The north-star metric reflects the current phase (Phase 1 is usually pure new-signup; Phase 3 is usually expansion ARR or NRR). Name the weekly leading indicators per S-curve and the plateau thresholds that trigger the next move. |
 
 ## Operational guidance for the planner
 


### PR DESCRIPTION
## What

Enriches the **marketing-plan** skill with two frameworks from *Founding Marketing* (Corey Haines), chapters 1 and 17 — giving the operationally-strong plan skill a strategic spine. Only the `marketing-plan` skill and its VERSIONS row are touched.

### From Ch. 1 — "Marketing as investing" north-star (new SKILL.md section)
- **Compounding portfolio** framing: "no silver bullets, a hundred golden pellets"; one asset that ranks + earns backlinks + feeds the newsletter + becomes a talk.
- **Marketing is like investing** (buy-and-hold, diversified); **audition, not an auction**; **hope is not a strategy** (every move names a mechanism + leading indicator).
- **Problem size × frequency market-quality matrix** as a strategic gate in Section 2 (build big + frequent).

### From Ch. 17 — the two gaps not already in `growth-patterns.md`
- **70/20/10 resource-allocation rule** (current / next / experimental) — keeps the next S-curve funded before the current one plateaus; maps to the existing 10–20% experimental buffer.
- **Weekly tracking cadence with plateau-indicator alerts** — flattening week-over-week additions, rising CAC, effort-up/output-flat trigger shifting weight to the next curve.

Deliberately does **not** duplicate the S-curves, budget methods, or 3-3-2-2-2 rule already excerpted from this book in `growth-patterns.md` / `budget-planning.md`.

## Changes
- `skills/marketing-plan/SKILL.md` — new "Marketing as investing" section + market-quality gate; two bullets routing 70/20/10 + plateau cadence; `metadata.version` added (1.1.1). 300 lines (<500). Description unchanged (949 chars).
- `skills/marketing-plan/references/growth-patterns.md` — new 70/20/10 and weekly-cadence/plateau-alerts sections; updated "how this informs the plan" table (Sections 10, 11, 13).
- `skills/marketing-plan/evals/evals.json` — new eval id 7 (silver-bullet pushback + 70/20/10 + plateau alerts). Valid JSON, 7 evals.
- `VERSIONS.md` — marketing-plan row 1.1.0 → 1.1.1 (2026-08-23).

## Validation
- `bash validate-skills.sh` → all 49 skills valid.
- evals.json parses; ids 1–7 contiguous.

## Suggested Recent Changes bullet (not added to VERSIONS.md body)
- Enriched `marketing-plan` — added the *Founding Marketing* Ch. 1 "marketing as investing" north-star (compounding portfolio, audition-not-auction, hope-is-not-a-strategy, problem size × frequency market-quality gate) and Ch. 17's 70/20/10 resource-allocation rule + weekly plateau-alert tracking cadence.

## Suggested repo release bump
z-level (existing-skill update) in `plugin.json`/`marketplace.json` — intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
