### PR TITLE
feat: Founding Marketing enrichments across 15 skills (2.10.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.10.4",
+    "version": "2.10.5",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,7 +18,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | competitors | 2.0.1 | 2026-07-09 |
 | content-strategy | 2.1.0 | 2026-08-19 |
 | copy-editing | 2.0.0 | 2026-05-05 |
-| copywriting | 2.0.1 | 2026-06-16 |
+| copywriting | 2.0.2 | 2026-08-23 |
 | cro | 2.0.0 | 2026-05-05 |
 | customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -35,7 +35,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
 | onboarding | 2.0.0 | 2026-05-05 |
-| ads | 2.3.1 | 2026-08-23 |
+| ads | 2.3.2 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
 | pricing | 2.1.0 | 2026-07-27 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -26,7 +26,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | free-tools | 2.0.0 | 2026-05-05 |
 | image | 2.0.1 | 2026-05-18 |
 | influencer-marketing | 1.1.0 | 2026-08-19 |
-| launch | 2.0.1 | 2026-06-16 |
+| launch | 2.0.2 | 2026-08-23 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -38,7 +38,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |
-| pricing | 2.1.0 | 2026-07-27 |
+| pricing | 2.1.1 | 2026-08-23 |
 | product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -16,7 +16,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | community-marketing | 2.0.0 | 2026-05-05 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |
 | competitors | 2.0.1 | 2026-07-09 |
-| content-strategy | 2.1.0 | 2026-08-19 |
+| content-strategy | 2.2.0 | 2026-08-23 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
 | cro | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -33,7 +33,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
-| offers | 1.0.0 | 2026-06-16 |
+| offers | 1.0.1 | 2026-08-23 |
 | onboarding | 2.0.0 | 2026-05-05 |
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -13,7 +13,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | churn-prevention | 2.0.0 | 2026-05-05 |
 | co-marketing | 2.0.0 | 2026-05-05 |
 | cold-email | 2.0.0 | 2026-05-05 |
-| community-marketing | 2.0.0 | 2026-05-05 |
+| community-marketing | 2.0.1 | 2026-08-23 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |
 | competitors | 2.0.1 | 2026-07-09 |
 | content-strategy | 2.1.0 | 2026-08-19 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -43,7 +43,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
 | public-relations | 1.1.0 | 2026-08-19 |
-| referrals | 2.0.0 | 2026-05-05 |
+| referrals | 2.1.0 | 2026-08-23 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |
 | schema | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,7 +11,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | aso | 2.0.1 | 2026-08-19 |
 | attribution | 1.1.0 | 2026-07-23 |
 | churn-prevention | 2.0.0 | 2026-05-05 |
-| co-marketing | 2.0.0 | 2026-05-05 |
+| co-marketing | 2.0.1 | 2026-08-23 |
 | cold-email | 2.0.0 | 2026-05-05 |
 | community-marketing | 2.0.0 | 2026-05-05 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -23,7 +23,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | customer-research | 2.0.1 | 2026-07-10 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
-| free-tools | 2.0.0 | 2026-05-05 |
+| free-tools | 2.0.1 | 2026-08-23 |
 | image | 2.0.1 | 2026-05-18 |
 | influencer-marketing | 1.1.0 | 2026-08-19 |
 | launch | 2.0.1 | 2026-06-16 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -16,7 +16,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | community-marketing | 2.0.1 | 2026-08-23 |
 | competitor-profiling | 2.0.1 | 2026-08-19 |
 | competitors | 2.0.1 | 2026-07-09 |
-| content-strategy | 2.2.0 | 2026-08-23 |
+| content-strategy | 2.1.1 | 2026-08-23 |
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.2 | 2026-08-23 |
 | cro | 2.0.0 | 2026-05-05 |
@@ -55,6 +55,26 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.10.5 (2026-08-23)
+
+Batch enrichment across 15 existing skills, distilled from Corey Haines's *Founding Marketing* book (full 19-chapter scan). Each is a patch bump; no new skills.
+
+- **ads** (2.3.1 → 2.3.2): `references/payback-period.md` — the Payback Period budgeting gate (Payback = CAC/ARPU, target 3–12mo; Discounted Payback = CAC/(ARPU×retention)) + the "LTV:CAC is destructive" argument. (ch7)
+- **customer-research** (2.0.1 → 2.0.2): `references/interviews-and-surveys.md` — primary-research layer: Sean Ellis/Superhuman PMF survey (40% benchmark), "keep asking why" 5-why laddering, interview outreach template + incentives, best-customer recruitment, confirmation-bias guardrail. (ch2)
+- **onboarding** (2.0.0 → 2.0.1): `references/minimum-path-to-value.md` + `references/activation-models.md` — MPTV (Hick's Law), the 5 activation models + Model-Market Fit, onboarding psychology set, 10-component toolkit. (ch16)
+- **pricing** (2.1.0 → 2.1.1): initial "learning price" philosophy ($10/$100/$1,000) + `references/pricing-models.md` (8 models incl. credit/outcome/hybrid) + price-change rollout methodology. (ch15–16)
+- **co-marketing** (2.0.0 → 2.0.1): `references/partnership-types.md` — the 5 partnership types + "permissionless co-marketing." (ch11)
+- **marketing-ideas** (2.0.0 → 2.0.1): `references/guerrilla-marketing.md` — direct-mail 3-rule framework + named case library (WePay ice block, Antimetal $15K pizza→$1M). (ch13)
+- **copywriting** (2.0.1 → 2.0.2): clarity & message-market-fit — the "Now you can" test, Human Action Model, Perception Gap, SavvyCal case, clarity metrics. (ch3)
+- **public-relations** (1.1.0 → 1.1.1): `references/story-angles.md` — the 3 story angles (Founding Story / David vs Goliath / Have an Enemy) + PR flywheel. (ch5)
+- **content-strategy** (2.1.0 → 2.1.1): `references/content-distribution.md` — "content as product," "Create Once Distribute Twice" distribution spine (ORB-as-funnel, distribution hooks), scoring + 60/30/10 calendar. (ch6, ch14)
+- **referrals** (2.0.0 → 2.0.1): `references/viral-mechanisms.md` — product-embedded virality: Viral Potential Spectrum + 7 mechanisms + affiliate power-law/buyout clauses. (ch10–11)
+- **free-tools** (2.0.0 → 2.0.1): `references/tool-benchmarks.md` — named case benchmarks (Unsplash→Getty, Website Grader 250K leads) + "your product is my marketing opportunity" + pitfalls. (ch8)
+- **community-marketing** (2.0.0 → 2.0.1): `references/community-models.md` — 5 community-model archetypes + Notion ambassador benchmarks + scaling-phase role shift. (ch12)
+- **offers** (1.0.0 → 1.0.1): `references/saas-offers.md` — the discount trap (~2× churn) + 4 SaaS-flavored worked offers. (ch15)
+- **marketing-plan** (1.1.0 → 1.1.1): "marketing as investing" north-star + problem size×frequency matrix; 70/20/10 allocation + plateau-alert cadence in growth-patterns. (ch1, ch17)
+- **launch** (2.0.1 → 2.0.2): SLC (Simple, Lovable, Complete) pre-launch readiness gate vs Stealth Mode / "Just One More Feature." (ch1)
 
 ### 2.10.4 (2026-08-23)
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -42,7 +42,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | product-marketing | 2.1.0 | 2026-07-16 |
 | programmatic-seo | 2.0.0 | 2026-05-05 |
 | prospecting | 1.1.0 | 2026-07-13 |
-| public-relations | 1.1.0 | 2026-08-19 |
+| public-relations | 1.1.1 | 2026-08-23 |
 | referrals | 2.0.0 | 2026-05-05 |
 | revops | 2.0.0 | 2026-05-05 |
 | sales-enablement | 2.0.1 | 2026-06-16 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -31,7 +31,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-council | 1.0.0 | 2026-07-06 |
 | marketing-ideas | 2.0.0 | 2026-05-05 |
 | marketing-loops | 1.2.0 | 2026-07-10 |
-| marketing-plan | 1.1.0 | 2026-05-29 |
+| marketing-plan | 1.1.1 | 2026-08-23 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
 | onboarding | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,7 +20,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | copy-editing | 2.0.0 | 2026-05-05 |
 | copywriting | 2.0.1 | 2026-06-16 |
 | cro | 2.0.0 | 2026-05-05 |
-| customer-research | 2.0.1 | 2026-07-10 |
+| customer-research | 2.0.2 | 2026-08-23 |
 | directory-submissions | 2.0.0 | 2026-05-05 |
 | emails | 2.0.0 | 2026-05-05 |
 | free-tools | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -34,7 +34,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
 | offers | 1.0.0 | 2026-06-16 |
-| onboarding | 2.0.0 | 2026-05-05 |
+| onboarding | 2.0.1 | 2026-08-23 |
 | ads | 2.3.1 | 2026-08-23 |
 | paywalls | 2.0.0 | 2026-05-05 |
 | popups | 2.0.0 | 2026-05-05 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -29,7 +29,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | launch | 2.0.1 | 2026-06-16 |
 | lead-magnets | 2.0.0 | 2026-05-05 |
 | marketing-council | 1.0.0 | 2026-07-06 |
-| marketing-ideas | 2.0.0 | 2026-05-05 |
+| marketing-ideas | 2.0.1 | 2026-08-23 |
 | marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.0 | 2026-05-29 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |

--- a/skills/ads/SKILL.md
+++ b/skills/ads/SKILL.md
@@ -2,7 +2,7 @@
 name: ads
 description: "When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions 'PPC,' 'paid media,' 'ROAS,' 'CPA,' 'ad campaign,' 'retargeting,' 'audience targeting,' 'Google Ads,' 'Facebook ads,' 'LinkedIn ads,' 'ad budget,' 'cost per click,' 'ad spend,' 'should I run ads,' 'ABM,' 'account-based marketing,' 'B2B ads,' 'lead quality,' 'negative keywords,' 'Performance Max,' 'thought leader ads,' or 'when should I kill an ad.' Use this for campaign strategy, audience targeting, bidding, and optimization. For bulk ad creative generation and iteration, see ad-creative. For landing page optimization, see cro."
 metadata:
-  version: 2.3.1
+  version: 2.3.2
 ---
 
 # Paid Ads
@@ -46,6 +46,7 @@ This skill's depth lives in references — load by intent. For **any operational
 
 | User intent | Load | Covers |
 |---|---|---|
+| "Can I afford this channel?", payback math, budgeting per plan, whether LTV:CAC lies | [payback-period.md](references/payback-period.md) | Why LTV:CAC is useless (4 flaws), Payback = CAC/ARPU (3–12mo), Discounted Payback, $9-vs-$999 worked examples, OOH+social, narrative momentum |
 | B2B strategy, funnel stages, budget splits, kill rules, lead quality, breakeven math | [b2b-paid-playbook.md](references/b2b-paid-playbook.md) | Demand lifecycle, leading/lagging signals, kill rules, offline conversion loop, U/B/F lead scoring, scaling quadrant |
 | Meta operations: when to kill/graduate/scale an ad, fatigue, testing structure, partnership/creator ads, declining reach | [meta-decision-system.md](references/meta-decision-system.md) | TCPL-anchored decision tree, ad-count ceiling, 80/20 CBO structure, fatigue bands, lead forms, Advantage+ transition, partnership-ads playbook, rolling-reach signal |
 | LinkedIn operations: bidding, audience sizing, scaling, benchmarks, TLAs, formats | [linkedin-b2b-playbook.md](references/linkedin-b2b-playbook.md) | Bidding progression, penetration scaling, sizing rules, funnel benchmarks, document/conversation ads, audit shortlist |
@@ -307,8 +308,7 @@ For hard kill/keep/scale thresholds, use the platform playbooks (see Reference R
 | Cold (any visit) | 30-90 days | 1-2x/week |
 
 ### Exclusions to Set Up
-- Existing customers (unless upsell)
-- Recent converters (7-14 day window)
+- Existing customers (unless upsell) and recent converters (7-14 day window)
 - Bounced visitors (<10 sec)
 - Irrelevant pages (careers, support)
 
@@ -494,6 +494,6 @@ For tracking setup, see [references/conversion-tracking.md](references/conversio
 - **revops**: For the CRM side of ABM — lead scoring, routing, and the offline conversion loop
 - **customer-research / competitor-profiling / positioning**: Voice-of-customer that feeds ad copy and angles; and turning an organic-teardown shortlist + the personas doc from [creative-research-automation.md](references/creative-research-automation.md) into full competitor dossiers and positioning
 - **copywriting**: For landing page copy that converts ad traffic
-- **analytics**: For proper conversion tracking setup
+- **analytics / attribution**: Conversion tracking setup and the blended-CAC inputs behind [payback-period.md](references/payback-period.md); **pricing** sets the ARPU + plan structure that drive its Payback math (why blended LTV:CAC hides $9-vs-$999 variance)
 - **ab-testing**: For landing page testing to improve ROAS
 - **cro**: For optimizing post-click conversion rates

--- a/skills/ads/evals/evals.json
+++ b/skills/ads/evals/evals.json
@@ -20,7 +20,7 @@
     {
       "id": 2,
       "prompt": "Our Google Ads CPC is $12 and our cost per lead is $180. Is that good? We're getting about 80 leads/month from a $15k budget.",
-      "expected_output": "Should evaluate the metrics in context. Should assess: $12 CPC for B2B (reasonable depending on industry), $180 CPL (depends on LTV — need to compare against customer lifetime value), 80 leads/month from $15k (math checks out). Should apply the campaign optimization framework: check quality score, search term relevance, landing page conversion rate, negative keywords. Should recommend specific optimization levers to reduce CPC and CPL. Should frame performance against industry benchmarks if applicable. Should ask about downstream conversion rates (lead → demo → customer).",
+      "expected_output": "Should evaluate the metrics in context. Should assess: $12 CPC for B2B (reasonable depending on industry), $180 CPL (depends on LTV \u2014 need to compare against customer lifetime value), 80 leads/month from $15k (math checks out). Should apply the campaign optimization framework: check quality score, search term relevance, landing page conversion rate, negative keywords. Should recommend specific optimization levers to reduce CPC and CPL. Should frame performance against industry benchmarks if applicable. Should ask about downstream conversion rates (lead \u2192 demo \u2192 customer).",
       "assertions": [
         "Evaluates metrics in context",
         "Compares CPL against LTV considerations",
@@ -88,8 +88,8 @@
     },
     {
       "id": 7,
-      "prompt": "Our Meta CPA doubled this week (6 conversions so far, sales cycle is ~3 weeks). Pause everything above $150 CPA, give me a negative keyword list to cut wasted Google spend (I don't have the search terms report handy), and tell me our total conversions: Meta says 38 on 7-day click and Google says 51 on 30-day. Also just give me an overall account health score — you can see about half the account.",
-      "expected_output": "Should load references/audit-guardrails.md and refuse all four unsafe asks with correct alternatives. (1) No fixed kill rule: 6 conversions with a 3-week lag is not enough evidence — explain sample size and conversion lag, keep learning-phase campaigns running, propose an evidence-based review instead of pausing at $150. (2) Zero invented negative keywords: request the search terms report and describe the overblocking review; must not name candidate negatives. (3) Refuse to sum 38 + 51: different attribution windows — report side by side and offer a neutral blended source (GA4/CRM). (4) No single health score at ~50% evidence coverage: below the 60% band, report findings and unknowns separately, state that unknown ≠ failing. Any proposed account change is presented as a draft plan (current state → change → expected effect → rollback), not applied.",
+      "prompt": "Our Meta CPA doubled this week (6 conversions so far, sales cycle is ~3 weeks). Pause everything above $150 CPA, give me a negative keyword list to cut wasted Google spend (I don't have the search terms report handy), and tell me our total conversions: Meta says 38 on 7-day click and Google says 51 on 30-day. Also just give me an overall account health score \u2014 you can see about half the account.",
+      "expected_output": "Should load references/audit-guardrails.md and refuse all four unsafe asks with correct alternatives. (1) No fixed kill rule: 6 conversions with a 3-week lag is not enough evidence \u2014 explain sample size and conversion lag, keep learning-phase campaigns running, propose an evidence-based review instead of pausing at $150. (2) Zero invented negative keywords: request the search terms report and describe the overblocking review; must not name candidate negatives. (3) Refuse to sum 38 + 51: different attribution windows \u2014 report side by side and offer a neutral blended source (GA4/CRM). (4) No single health score at ~50% evidence coverage: below the 60% band, report findings and unknowns separately, state that unknown \u2260 failing. Any proposed account change is presented as a draft plan (current state \u2192 change \u2192 expected effect \u2192 rollback), not applied.",
       "assertions": [
         "Does not recommend pausing based on the fixed $150 CPA threshold; cites sample size and/or conversion lag",
         "Does not produce any candidate negative keywords; requests the search terms report and mentions an overblocking review",
@@ -101,7 +101,7 @@
     {
       "id": 8,
       "prompt": "Audit our Google Ads account. We're a DTC ecommerce brand running Shopping, Performance Max, and some Demand Gen. Walk me through what to check. I can give you Merchant Center access but I don't have the search terms report handy right now.",
-      "expected_output": "Should recognize this as an itemized ecommerce Google Ads audit and load references/google-ads-audit-checklist.md, working through the 32 checks across tracking, targeting, campaign structure, GMC (shipping, promotions, feed titles, images, store quality, ratings, eligible-product impressions), Shopping segmentation + budget allocation, bidding/budget, search, PMax signals + budget-on-Shopping, landing-page funnels, and Demand Gen. Should apply the four-state scoring from audit-guardrails.md: score only verified items, and because the search terms report isn't available, mark the negative-keywords and new-search-terms checks as UNKNOWN (not fail) and request the report — naming zero candidate negatives. Should treat Merchant Center access as available and plan the GMC feed-quality checks accordingly. Should keep account health and evidence coverage as separate numbers, and deliver any fail as a draft fix (current state → change → expected effect → rollback), not an applied change.",
+      "expected_output": "Should recognize this as an itemized ecommerce Google Ads audit and load references/google-ads-audit-checklist.md, working through the 32 checks across tracking, targeting, campaign structure, GMC (shipping, promotions, feed titles, images, store quality, ratings, eligible-product impressions), Shopping segmentation + budget allocation, bidding/budget, search, PMax signals + budget-on-Shopping, landing-page funnels, and Demand Gen. Should apply the four-state scoring from audit-guardrails.md: score only verified items, and because the search terms report isn't available, mark the negative-keywords and new-search-terms checks as UNKNOWN (not fail) and request the report \u2014 naming zero candidate negatives. Should treat Merchant Center access as available and plan the GMC feed-quality checks accordingly. Should keep account health and evidence coverage as separate numbers, and deliver any fail as a draft fix (current state \u2192 change \u2192 expected effect \u2192 rollback), not an applied change.",
       "assertions": [
         "Loads/uses the itemized google-ads-audit-checklist reference for an ecommerce audit",
         "Covers ecommerce-specific depth: GMC feed quality, Shopping segmentation, PMax signals/budget, Demand Gen format splits, landing-page funnels",
@@ -113,7 +113,7 @@
     },
     {
       "id": 9,
-      "prompt": "Our Meta account is at a 40 ROAS but the numbers have felt stale — CPA and ROAS are steady but I feel like we're hitting a wall. Frequency is creeping up and I can't seem to grow past our current spend. What should we do to reach new audiences?",
+      "prompt": "Our Meta account is at a 40 ROAS but the numbers have felt stale \u2014 CPA and ROAS are steady but I feel like we're hitting a wall. Frequency is creeping up and I can't seem to grow past our current spend. What should we do to reach new audiences?",
       "expected_output": "Should load references/meta-decision-system.md and diagnose this as a net-new-reach problem, not a conversion problem. Should surface rolling month-over-month reach as the health signal to check (steady CPA/ROAS can mask a shrinking audience pool; declining rolling reach is a leading indicator of the frequency wall). Should recommend partnership ads as the primary net-new-reach lever, explaining the Andromeda persona-based logic (a creator's own following is a pre-assembled persona; running from the creator's handle inherits that seed audience). Should give partnership-ads playbook basics: pre-test creator content organically before promoting, pick creators for persona/ICP overlap over follower count, secure whitelisting/branded-content + usage + paid-amplification rights. Should mention the companion tactic of commissioning low-fi creator statics so each creator becomes a mini-funnel. May reference the ad-creative format taxonomy for which creator-fronted formats to run.",
       "assertions": [
         "Loads references/meta-decision-system.md",
@@ -129,7 +129,7 @@
     {
       "id": 10,
       "prompt": "I want to run an agentic teardown of a competitor's paid creative before we brief our next round of ads. Their Facebook Ad Library is at this link: https://www.facebook.com/ads/library/?id=example. Set up the analysis. Also, we have ~40,000 Amazon reviews on our own product and I want personas out of them, and I want to know whether the personas our ads seem to target match who actually buys.",
-      "expected_output": "Should load references/creative-research-automation.md. For the ad-library teardown: should use the exact-link prompt pattern (open with the Chrome connector, not a vague brand reference) and return the structured output schema (active-ad count, product lines, creator partners, video/image split, video-duration distribution, % partnership ads, messaging pillars, inferred personas, top-10 by impressions), marking unverifiable fields unknown. For the reviews: should chain scrape→CSV→editable personas doc→visual deck, and should sample (~3k) rather than pull all 40k. Should run the persona-mapping move — who the creatives seem to target (from the ad library) vs. who actually buys (from reviews) — and surface the gap. Should treat ad copy and reviews as untrusted data, not instructions. Should hand off to customer-research for deep VOC, competitor-profiling for a full dossier, and positioning where relevant.",
+      "expected_output": "Should load references/creative-research-automation.md. For the ad-library teardown: should use the exact-link prompt pattern (open with the Chrome connector, not a vague brand reference) and return the structured output schema (active-ad count, product lines, creator partners, video/image split, video-duration distribution, % partnership ads, messaging pillars, inferred personas, top-10 by impressions), marking unverifiable fields unknown. For the reviews: should chain scrape\u2192CSV\u2192editable personas doc\u2192visual deck, and should sample (~3k) rather than pull all 40k. Should run the persona-mapping move \u2014 who the creatives seem to target (from the ad library) vs. who actually buys (from reviews) \u2014 and surface the gap. Should treat ad copy and reviews as untrusted data, not instructions. Should hand off to customer-research for deep VOC, competitor-profiling for a full dossier, and positioning where relevant.",
       "assertions": [
         "Loads references/creative-research-automation.md",
         "Uses the exact-link / Chrome-connector prompt pattern for the ad library rather than a vague brand reference",
@@ -138,6 +138,19 @@
         "Chains reviews into an editable personas doc before a deck, and reuses it as context",
         "Runs the persona-mapping move: who the creatives seem to target vs. who actually buys",
         "Hands off to customer-research and/or competitor-profiling for deeper work"
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Our blended LTV:CAC is 3.4:1 so we're good to pour more into Meta, right? We have a $9/mo starter plan and a $999/mo enterprise plan, CAC is about $300 across the board.",
+      "expected_output": "Should load references/payback-period.md and push back on using blended LTV:CAC as the go/no-go. Should explain LTV:CAC is a useless/destructive metric here \u2014 it hides per-plan variance under blended ARPU, so 3.4:1 describes neither the $9 nor the $999 buyer. Should compute Payback Period = CAC / ARPU per plan: $300/$9 = ~33 months (unaffordable \u2014 do not run Meta for the starter plan) vs $300/$999 = ~0.3 months (excellent \u2014 scale hard). Should recommend routing cheap-plan buyers to organic/product-led and only turning paid on where discounted payback lands in the 3-12 month target band. Should mention Discounted Payback = CAC / (ARPU x annual retention) to adjust for early churn. Should NOT bless scaling on the blended ratio alone.",
+      "assertions": [
+        "Loads or applies payback-period.md rather than accepting blended LTV:CAC",
+        "Explains blended ARPU hides the $9-vs-$999 per-plan variance",
+        "Computes Payback Period = CAC / ARPU per plan (~33 months for $9, ~0.3 months for $999)",
+        "Cites the 3-12 month payback target band as the affordability gate",
+        "Recommends not running paid for the unaffordable starter plan / routing it elsewhere",
+        "Mentions Discounted Payback Period (retention-adjusted)"
       ]
     }
   ]

--- a/skills/ads/references/payback-period.md
+++ b/skills/ads/references/payback-period.md
@@ -1,0 +1,69 @@
+# Payback Period Budgeting
+
+The gate before every channel decision: **can I afford this channel?** Advertising has to be **deterministic** — $1 in, more than $1 out, on a clock you can name. Payback Period is how you set the clock.
+
+## Kill LTV:CAC first
+
+**LTV:CAC is a useless, often destructive metric.** It feels rigorous and is usually a lie. Four flaws:
+
+1. **It assumes all customers churn.** LTV bakes in an eventual death for every account. Your best customers don't churn — they compound. A metric that pre-writes everyone's obituary underprices your actual base.
+2. **It assumes churn is evenly timed.** It isn't. Baremetrics data shows **more churn happens in the first 3 months than in any other window** — front-loaded, not smooth. Blended LTV smears that spike into a flat average and hides the real risk (and the real payback math).
+3. **It hides per-plan variance under blended ARPU.** A $9/mo plan and a $999/mo plan get averaged into one number that describes neither. The channels, creative, and payback that work for the $9 buyer are nothing like the $999 buyer — but blended LTV:CAC says "3:1, we're fine" and you scale the wrong thing.
+4. **It ignores revenue delay.** Free trials, free plans, and long sales cycles mean money arrives weeks or months after CAC is spent. LTV:CAC treats acquisition and revenue as simultaneous. They're not. The gap is where startups run out of cash.
+
+A "healthy" 3:1 LTV:CAC can sit on top of a channel that bankrupts you, because the ratio never asks *when the cash comes back*.
+
+## The replacement: Payback Period
+
+**Payback Period = CAC / ARPU** (monthly).
+
+The answer is in **months** — how long until a customer pays back what you spent to acquire them. **Target 3–12 months.** Under 3 is often leaving growth on the table; over 12 means you're financing customers longer than most early-stage balance sheets can survive.
+
+Because it's per-cohort and per-plan (not blended), it exposes exactly what LTV:CAC hides.
+
+### Worked example — same CAC, wildly different payback
+
+Say a channel costs **$300 to acquire a customer** (CAC = $300):
+
+| Plan | ARPU (monthly) | Payback = CAC / ARPU | Verdict |
+|------|---------------|----------------------|---------|
+| Starter | $9 | 300 / 9 = **33.3 months** | Unaffordable. You wait ~3 years to break even on acquisition — before churn. Do not run this channel for this plan. |
+| Pro | $99 | 300 / 99 = **3.0 months** | Healthy. Bottom of the target band. Scale it. |
+| Enterprise | $999 | 300 / 999 = **0.3 months** | Excellent. Pays back in ~9 days. Pour budget in. |
+
+Same CAC, same channel. On the $9 plan the channel is a cash incinerator; on the $999 plan it's a printing press. **Blended LTV:CAC would have averaged these into one meaningless "we're fine."** Payback Period forces you to run the channel only for the plans it can actually afford.
+
+The practical move: compute payback **per plan (or per cohort)**, then only turn on paid acquisition for the segments where it lands inside 3–12 months. Route the cheap-plan buyers to organic/product-led motions instead.
+
+## Discounted Payback Period (churn-adjusted)
+
+Raw payback assumes everyone survives to pay you back. They don't — especially in those first 3 months. Adjust for it:
+
+**Discounted Payback Period = CAC / (ARPU × annual retention)**
+
+Multiply ARPU by the fraction of customers still paying, so the denominator reflects real, retained revenue instead of theoretical revenue.
+
+Example: CAC $300, ARPU $99, annual retention 70%:
+- Raw: 300 / 99 = 3.0 months
+- Discounted: 300 / (99 × 0.70) = 300 / 69.3 = **4.3 months**
+
+Still inside the band — but the discounted number is the one to budget against. When retention is weak, discounted payback blows past 12 months even when raw payback looked fine; that gap is your early warning.
+
+## Using it as the channel gate
+
+1. Compute CAC for the channel (all-in: spend / customers, including creative and management).
+2. Compute discounted payback per plan/cohort.
+3. **Turn the channel on only where discounted payback ≤ 12 months** (aim for 3–12).
+4. Re-run monthly — CAC drifts up as you scale; the gate moves with it.
+
+This composes with breakeven CPL/CPC math in [b2b-paid-playbook.md](b2b-paid-playbook.md): breakeven tells you the *most* you can pay per lead; payback tells you *how long your cash is tied up* — you need both to scale without running dry.
+
+## Two adjacent rules
+
+**OOH without social amplification is a waste of money.** Out-of-home (billboards, transit, print) has no click, no pixel, no deterministic loop on its own. It only pays back when it's engineered to be photographed, posted, and amplified on social — the OOH buys the moment, social buys the reach. Running OOH with no social plan is buying awareness you can't measure or compound.
+
+**Narrative momentum** (ad copy): the strongest-performing ads carry a story forward rather than restate a pitch — each line earns the next, building tension toward the CTA instead of front-loading features. Pair it with the discipline of **testing one variable at a time** (copy, then creative, then audience) so you can tell what actually moved payback. Depth on both lives in the **ad-creative** skill; this file only flags them as levers that change your CAC.
+
+---
+
+*Source: Corey Haines, *Founding Marketing*, ch. 7 ("Spend budget where customers spend their time"). Payback targets and the Baremetrics first-3-months churn finding are practitioner-reported — recalibrate against your own cohort data. For attribution of the CAC inputs, see the **attribution** skill; for setting ARPU and plan structure, see the **pricing** skill.*

--- a/skills/co-marketing/SKILL.md
+++ b/skills/co-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: co-marketing
 description: "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referrals. For launch-specific partnerships, see launch."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 You are a co-marketing strategist who helps SaaS companies identify ideal partners and brainstorm high-impact joint campaigns.
@@ -76,6 +76,26 @@ Rate potential partners (1-5) on:
 - Customer surveys ("what else do you use?")
 - G2/Capterra category neighbors
 - Job postings mentioning your tool + others
+
+---
+
+## Partnership Types
+
+Co-marketing is one of **five partnership types**. Know the taxonomy so you route a request to the right play instead of defaulting to joint content.
+
+| Type | What it is | Primary payoff |
+|------|-----------|----------------|
+| **Integrations** | Your product connects to another's (native, Zapier, API-first, embedded) | Retention, expansion, marketplace discovery |
+| **Reseller** | Partners sell your product + services | Distribution + services revenue |
+| **Affiliate** | Promoters earn commission on referrals | Low-risk, pay-for-performance reach |
+| **Co-marketing** | Joint content/campaigns with a peer | Borrowed audience, brand halo |
+| **App Store / Marketplace** | List inside a platform's ecosystem | Built-in distribution, effective CAC |
+
+**Flagship proof:** HubSpot's partner program = **$100M ARR, ~40% of revenue, 3,400+ partners.** Mature programs average **~28% of revenue and 2× growth**.
+
+Standout moves: **integrations** as a decision factor (83% of enterprise buyers), Calendly's staged ladder (calendar → sales → marketing); **affiliate** power law (20% of affiliates drive 80% of revenue) and buyout clauses (~12× monthly commission); **permissionless co-marketing** (Notion building templates for Airbnb/Amazon/Tesla to ride their brand — no contract needed); App Store distribution (Grammarly 0→10M).
+
+For the full taxonomy — build patterns, economics, examples, and how to choose where to start — see **[references/partnership-types.md](references/partnership-types.md)**. (Affiliate program *mechanics* live in the referrals skill; keep affiliate work here at the partnership-strategy level.)
 
 ---
 

--- a/skills/co-marketing/evals/evals.json
+++ b/skills/co-marketing/evals/evals.json
@@ -79,6 +79,20 @@
         "Does not attempt full co-marketing strategy"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're a SaaS scheduling tool. We keep hearing 'you should do partnerships' but I don't even know what kinds exist. What are our options and where should we start?",
+      "expected_output": "Should lay out the five partnership types from the partnership-types taxonomy: integrations, reseller programs, affiliate programs, co-marketing, and app store/marketplace — not just joint content. Should note co-marketing is only one of the five. Should reference the flagship proof that partner programs are meaningful (e.g., HubSpot's ~$100M ARR / ~40% of revenue / 3,400+ partners; mature programs ~28% of revenue and 2x growth). Should give concrete moves per type: integrations built native vs via Zapier vs API-first vs embedded, Calendly's staged ladder (calendar to sales stack to marketing stack), 83% of enterprise citing integrations as a decision factor; reseller economics (20-40% of LTV plus 2-3x in services); affiliate power law (20% of affiliates drive 80% of revenue) and buyout clauses (~12x monthly commission); permissionless co-marketing (Notion building templates for Airbnb/Amazon/Tesla to ride their brand); app store distribution (Grammarly 0 to 10M, platforms taking 15-30% as effective CAC). For a scheduling tool specifically, should recommend starting with integrations (retention/expansion, marketplace discovery) given the calendar/CRM workflow. Should point to references/partnership-types.md for the full taxonomy, and note affiliate mechanics live in the referrals skill.",
+      "assertions": [
+        "Lists all five partnership types",
+        "Notes co-marketing is one of five, not the whole picture",
+        "Cites the HubSpot / partner-program flagship stat",
+        "Gives concrete moves for multiple types (integration ladder, affiliate power law, permissionless co-marketing)",
+        "Recommends a starting type appropriate to a scheduling tool (integrations)",
+        "Points to the partnership-types reference"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/co-marketing/references/partnership-types.md
+++ b/skills/co-marketing/references/partnership-types.md
@@ -1,0 +1,100 @@
+# Partnership Types
+
+Adapted from Corey Haines's *Founding Marketing*, Ch. 11 — "Partnerships tap into existing audiences." The fastest way to reach customers is through companies that already have their attention.
+
+**Flagship proof:** HubSpot's partner program = **$100M ARR, ~40% of revenue, 3,400+ partners.** Mature partner programs average **~28% of revenue and 2× the growth** of companies without them.
+
+Co-marketing (in the SKILL.md) is one of five partnership types. Use this reference to place a given partnership in the right category and pick the right play. The types stack — most companies run several at once as the program matures.
+
+| Type | What it is | Primary payoff |
+|------|-----------|----------------|
+| **Integrations** | Your product connects to another's | Retention, expansion, marketplace discovery |
+| **Reseller** | Partners sell your product for you | Distribution + services revenue |
+| **Affiliate** | Promoters earn commission on referrals | Low-risk, pay-for-performance reach |
+| **Co-marketing** | Joint content/campaigns with a peer | Borrowed audience, brand halo |
+| **App Store / Marketplace** | List inside a platform's ecosystem | Built-in distribution, effective CAC |
+
+---
+
+## 1. Integrations
+
+Integrations are the foundation — they make you sticky, unlock expansion, and earn a spot in the partner's marketplace.
+
+**Four ways to build:**
+- **Native** — you build and maintain a direct connection. Best UX, highest cost.
+- **Platform via Zapier/Make** — ride an iPaaS to cover the long tail without building each one.
+- **API-first** — expose a clean public API and let partners build toward you.
+- **Embedded** — your product runs inside theirs (widget, SDK, iframe).
+
+**Calendly's staged integration ladder** — build integrations in order of buyer intent:
+1. **Calendar** (Google/Outlook) — table stakes, required to function.
+2. **Sales stack** (CRM, dialers, Salesforce/HubSpot) — where revenue teams live.
+3. **Marketing stack** (forms, ESP, automation) — top-of-funnel capture.
+
+Each rung deepens the account and widens who inside the company depends on you.
+
+**Marketplace strategy + ASO.** Getting listed isn't enough — apps compete for placement. Treat a marketplace like an app store: optimize the listing (title, keywords, screenshots, reviews, category) the same way you'd do App Store Optimization. Shopify App Store and Salesforce AppExchange are discovery engines; ranking well there is a channel, not an afterthought.
+
+**Why it matters:** **83% of enterprise buyers cite integrations as a purchase-decision factor.** Missing an integration a prospect needs can lose the deal outright.
+
+---
+
+## 2. Reseller programs
+
+Turn other companies into a sales force. Partners resell your product and layer their own services on top.
+
+**Economics:** resellers typically earn **20–40% of LTV** on the software, plus **2–3× that amount in services** (implementation, training, retainers) they sell around it. The services margin is what makes the partner care.
+
+**HubSpot's agency playbook (Peter Caputa).** HubSpot turned marketing agencies into resellers by making the agency's own business better: give them a product to sell, certifications to differentiate on, and a co-selling motion. Agencies became a durable, compounding distribution channel — the engine behind the $100M ARR partner program.
+
+**Partner enablement is the work.** A reseller program lives or dies on enablement: onboarding, certification, sales collateral, deal registration, co-selling support, and a partner portal. Signing partners is easy; getting them to actually sell requires you to train and equip them.
+
+---
+
+## 3. Affiliate programs
+
+Pay-for-performance reach. Affiliates promote you and earn commission on conversions — low downside, since you pay only on results.
+
+**Proof points:**
+- **ConvertKit + Pat Flynn** — a single trusted creator can become a top-of-funnel channel on their own.
+- **Demio** — **50% commissions** to make the program worth a promoter's real effort.
+- **Cometly** — **$251K in a single launch day**, driven by one top affiliate plus **Rewardful** for tracking and payouts.
+
+**The 20/80 affiliate power law.** ~20% of affiliates drive ~80% of revenue. Don't spread effort evenly across a long tail — **identify super-promoters and invest disproportionately** in them (higher rates, custom assets, early access, direct relationship).
+
+**Buyout clauses.** For a super-promoter you want to lock in (or eventually replace with owned channel), a buyout clause lets you pay out future commissions as a lump sum — commonly **~12× the monthly commission**. It caps long-term liability and gives the affiliate a clean exit.
+
+> Affiliate mechanics — commission structures, cookie windows, fraud, tooling (Rewardful/Tolt/PartnerStack) — belong in the **referrals** skill. Keep affiliate work here at the partnership-strategy level: which promoters to recruit, how to tier them, when to buy out.
+
+---
+
+## 4. Co-marketing
+
+Joint campaigns with a non-competing peer who shares your audience. Covered in depth in the main SKILL.md (campaign types, partner scoring, agreements). Two ideas from the chapter worth calling out:
+
+**Permissionless co-marketing (Notion's coined move) — the single most actionable idea in the chapter.** You don't need a signed partnership to ride a bigger brand. Notion built and published templates *for* Airbnb, Amazon, and Tesla — no permission, no contract — capturing search demand and brand halo from companies far larger than itself. **Build assets around brands your audience already loves; let the association do the work.**
+
+**Content ecosystems.** Gong earned reach by showing up consistently on **SaaStr** (the audience it wanted, hosted by someone else) rather than only building its own. Pair with the lowest-friction swaps — **newsletter swaps** and cross-promotion — where each side keeps its own leads and simply exposes the other to its audience.
+
+---
+
+## 5. App Store / Marketplace
+
+List your product inside a platform's ecosystem and inherit its distribution.
+
+- **Grammarly's Chrome Web Store extension** took it from **0 to 10M users** — the store *was* the acquisition channel.
+- Platforms take **15–30% of revenue**. Treat that cut as **effective CAC**: you're buying distribution instead of running ads.
+- **Go all-in on one platform when it maps to your ICP.** Arrows built its entire GTM around **HubSpot** — deep integration, AppExchange presence, co-selling — rather than spreading thin across many ecosystems.
+
+**When to choose this:** if a single platform owns your buyer's daily workflow, being *inside* it beats trying to pull users out to your own site.
+
+---
+
+## Choosing where to start
+
+- **Retention/expansion problem** → Integrations first (and the marketplace listing that comes with them).
+- **Need distribution without headcount** → Affiliate (fast, pay-on-results) or Reseller (slower, higher-touch, services upside).
+- **Have content but no reach** → Co-marketing, starting with permissionless assets and newsletter swaps.
+- **A platform owns your buyer's workflow** → App Store / Marketplace, all-in.
+
+Programs compound: integrations create marketplace presence, marketplace presence attracts resellers, resellers and affiliates create the case studies that fuel co-marketing.

--- a/skills/community-marketing/SKILL.md
+++ b/skills/community-marketing/SKILL.md
@@ -2,7 +2,7 @@
 name: community-marketing
 description: "Build and leverage online communities to drive product growth and brand loyalty. Use when the user wants to create a community strategy, grow a Discord or Slack community, manage a forum or subreddit, build brand advocates, increase word-of-mouth, drive community-led growth, engage users post-signup, or turn customers into evangelists. Trigger phrases: \"build a community,\" \"community strategy,\" \"Discord community,\" \"Slack community,\" \"community-led growth,\" \"brand advocates,\" \"user community,\" \"forum strategy,\" \"community engagement,\" \"grow our community,\" \"ambassador program,\" \"community flywheel.\""
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Community Marketing
@@ -95,6 +95,18 @@ Design for the flywheel from day one. Every decision should ask: *Does this acce
 2. **Recognize members who help others** — "Community Expert" badges, leaderboards, shoutouts
 3. **Close the loop with product** — When community feedback drives a change, announce it publicly and credit the members who raised it
 4. **Monitor sentiment weekly** — Look for patterns in complaints or confusion before they become churn signals
+
+---
+
+## Community Models & Scaling Phases
+
+Before picking tactics, pick the **shape** of the community and match your effort to its stage. See **`references/community-models.md`** for:
+
+- **The 5 community models** — Support-Driven (GreenPal), Product-Development (Ydata), Education/Enablement (LiveAgent), Founder-Led (Bento, Postaga) — each with a "best when…" fit test tied to a primary goal.
+- **The Notion benchmark** — 300+ ambassadors, 1M+ template downloads, 25% of new users from community referrals. The north star for community-led growth at scale.
+- **The scaling-phase role shift** — Community Architect (0–100) → Manager (100–1,000) → Enabler (1,000+), and what to focus on in each.
+
+Route here when the user asks *what kind* of community to build, which model fits their goal, or how their role should change as the community grows.
 
 ---
 

--- a/skills/community-marketing/evals/evals.json
+++ b/skills/community-marketing/evals/evals.json
@@ -84,6 +84,20 @@
         "Notes peer support must feel valued, not used"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're a technical dev-tool startup, still tiny. Our users are opinionated engineers and their feedback basically drives our roadmap. What kind of community should we build, and how will running it change as we grow?",
+      "expected_output": "Should route to references/community-models.md. Should recommend the Product-Development model as the best fit — technical, opinionated users whose feedback shapes the roadmap; cite Ydata's Slack driving GitHub stars and product feedback as the real case. Should note that because they're still tiny, it will start Founder-Led (Bento/Postaga) with the founder showing up personally before systems can carry it. Should lay out the scaling-phase role shift: Community Architect at 0–100 (lay the foundation, do things that don't scale, know members by name, set culture), Community Manager at 100–1,000 (build systems and governance — rituals, moderation, onboarding), Community Enabler at 1,000+ (stand up ambassador programs and sub-communities so members run it). May reference Notion's benchmark (300+ ambassadors, 1M+ template downloads, 25% of new users from community referrals) as the north star for what community-led growth can become at scale. Should match effort to stage rather than running a small community like a large one.",
+      "assertions": [
+        "Routes to references/community-models.md",
+        "Recommends Product-Development model with Ydata case",
+        "Notes it starts Founder-Led while tiny",
+        "Describes the architect -> manager -> enabler role shift with member ranges",
+        "May cite the Notion ambassador benchmark",
+        "Emphasizes matching effort to stage"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/community-marketing/references/community-models.md
+++ b/skills/community-marketing/references/community-models.md
@@ -1,0 +1,63 @@
+# Community Models & Scaling Phases
+
+The named model taxonomy, the flagship benchmark, and how the community-owner role changes as the community grows. Pair this with the goal playbooks and health metrics in `SKILL.md` — this file adds the *shape* of the community, not the tactics.
+
+Source: Corey Haines, *Founding Marketing*, Ch. 12 — "Community connects customers with each other." The thesis: don't just sell software, create a movement. Community is an **audience-first** play — indirect, "deposits in a relationship bank account" — built on **community-led systems** and **recognition/rewards**.
+
+---
+
+## The 5 Community Models
+
+Pick the model that matches the primary business goal. Most communities lean on one and borrow from others. Each has a "best when…" fit test and a real case.
+
+### 1. Support-Driven
+
+- **Best when…** support volume is high, questions are repeatable, and peers can answer each other faster than your team can. Goal: **support deflection**.
+- The community exists so members resolve each other's problems, cutting ticket load while raising satisfaction.
+- **Case — GreenPal:** ran a Facebook group where users and vendors helped each other, deflecting support away from the team.
+
+### 2. Product-Development
+
+- **Best when…** your users are technical or opinionated and their feedback directly shapes the roadmap. Goal: **feedback + build-in-public momentum**.
+- The community is a feedback engine: feature requests, bug reports, and public traction all flow through it.
+- **Case — Ydata:** ran a Slack community that drove **GitHub stars and product feedback**, turning members into co-builders.
+
+### 3. Education / Enablement
+
+- **Best when…** the product has a learning curve and activation/retention hinge on members getting good at it. Goal: **churn reduction**.
+- The community teaches members to succeed with the product; competence lowers churn.
+- **Case — LiveAgent:** used community education/enablement to **reduce churn** by helping customers get more capable.
+
+### 4. Founder-Led
+
+- **Best when…** you're early-stage, the founder's voice is the brand, and personal presence is the fastest way to build trust. Goal: **direct relationships + word-of-mouth**.
+- The founder shows up personally — answering, hosting, setting culture — before systems can carry it.
+- **Cases — Bento** (Discord) and **Postaga:** founders led their communities directly.
+
+> The fifth "model" in practice is the blend: a community usually starts **Founder-Led**, then specializes toward Support-Driven, Product-Development, or Education as it scales.
+
+---
+
+## Flagship Benchmark: Notion's Ambassador Program
+
+The reference point for community-led growth at scale:
+
+- **300+ ambassadors**
+- **1M+ template downloads**
+- **25% of new users come from community referrals**
+
+Use these as the "what great looks like" north star when sizing an ambassador program's potential — not as day-one targets. (For building the program itself, see the ambassador playbook in `SKILL.md`.)
+
+---
+
+## Scaling-Phase Role Shift
+
+The community owner's job changes at each stage. Match your effort to the phase — running a 1,000-member community like a 50-member one (or vice versa) is the most common failure.
+
+| Phase | Members | Role | Focus |
+|-------|---------|------|-------|
+| Foundation | 0–100 | **Community Architect** | Lay the foundation and build relationships — do things that don't scale, know members by name, set the culture. |
+| Systems | 100–1,000 | **Community Manager** | Build systems and governance — rituals, moderation, onboarding paths, clear norms so activity survives without you touching every thread. |
+| Scale | 1,000+ | **Community Enabler** | Enable others — stand up ambassador programs and sub-communities so members and leaders run it. You architect the leverage, not the conversations. |
+
+**The shift in one line:** architect the *room* → manage the *systems* → enable the *people*. Each phase hands off the previous phase's manual work to structure and to members.

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: content-strategy
 description: When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions "content strategy," "what should I write about," "content ideas," "blog strategy," "topic clusters," "content planning," "editorial calendar," "content marketing," "content roadmap," "what content should I create," "blog topics," "content pillars," or "I don't know what to write." Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social.
 metadata:
-  version: 2.2.0
+  version: 2.1.1
 ---
 
 # Content Strategy

--- a/skills/content-strategy/SKILL.md
+++ b/skills/content-strategy/SKILL.md
@@ -2,7 +2,7 @@
 name: content-strategy
 description: When the user wants to plan a content strategy, decide what content to create, or figure out what topics to cover. Also use when the user mentions "content strategy," "what should I write about," "content ideas," "blog strategy," "topic clusters," "content planning," "editorial calendar," "content marketing," "content roadmap," "what content should I create," "blog topics," "content pillars," or "I don't know what to write." Use this whenever someone needs help deciding what content to produce, not just writing it. For writing individual pieces, see copywriting. For SEO-specific audits, see seo-audit. For social media content specifically, see social.
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Content Strategy
@@ -38,6 +38,12 @@ Gather this context (ask if not provided):
 - What content gaps exist in your market?
 
 ---
+
+## Treat Content Like a Product
+
+Every piece is its own launch. Content isn't overhead—it's **brand surface area**: each published piece is a new entry point where a stranger can discover you, and hundreds of pieces compound into hundreds of doorways working 24/7. Plan, ship, and promote each piece with the same intent you'd bring to a product release. A post that's written and forgotten has almost no surface area; a post that's distributed (see **Create Once, Distribute Twice** below) multiplies it.
+
+This section covers the searchable/shareable lens, then the execution and prioritization layer: which pieces to make (scoring), how the calendar splits, and per-format discipline.
 
 ## Searchable vs Shareable
 
@@ -331,6 +337,55 @@ Score each idea on four factors:
 | Topic A | 8 | 9 | 7 | 6 | 8.0 |
 | Topic B | 6 | 7 | 9 | 8 | 7.1 |
 
+Score 1-10 per factor, multiply by the weight, sum for the total. Rank the list; make the top-scoring pieces first.
+
+---
+
+## Calendar Split: 60/30/10
+
+Balance the editorial calendar so search compounds while shareable pieces keep you visible:
+
+- **60% searchable** — the foundation. Demand you can capture predictably (use-case content, hub/spoke, how-tos).
+- **30% shareable** — thought leadership, original data, opinion. Creates demand and earns links/mentions.
+- **10% experimental** — new formats, channels, or bets. Cheap insurance against a stale mix.
+
+This is a starting ratio, not a rule. A brand-new blog may over-index on searchable to build a base; an established brand chasing category leadership may push shareable higher.
+
+---
+
+## Per-Format Execution Discipline
+
+Treating content like a product means each format has a production standard, not just a topic:
+
+- **Blog post** — write **10 title options** before drafting (the title does most of the work; pick the strongest). Plan **~5 editing passes** (structure, clarity, evidence, line edit, headline/SEO). For the writing itself, see **copywriting**.
+- **Long-form guide** — the flagship of a pillar. Comprehensive enough to be *the* resource; structured with a table of contents and internal links to spokes. Build the hub before the spokes.
+- **Video** — script the hook first; front-load the payoff. Repurpose into short-form clips at creation time (see **social**).
+- **Podcast** — one interview yields a transcript, quote graphics, short clips, and a written recap. Design the episode knowing it will be atomized.
+- **Email** — one idea per send; the subject line is the title—write several and pick. For sequences and lifecycle, see **emails**.
+
+---
+
+## Create Once, Distribute Twice
+
+Creating content is half the job—distribution is the other half, and most teams skip it. The philosophy: **one exceptional piece, reformatted and repurposed across every channel, not a fresh piece per platform.** Pouring effort into a single flagship and then distributing it everywhere beats spreading thin effort across many mediocre platform-native posts.
+
+Build **distribution hooks into the piece at creation time**, not after: write subheads that stand alone as social posts, structure sections to be lifted out modularly, and pull quotes/stats you already know you'll graphic-ify. A well-designed guide is a distribution kit in disguise.
+
+**The ORB Framework as a funnel** — route attention from borrowed → rented → owned, which maps to discovery → engagement → conversion:
+
+- **Borrowed** (other people's audiences: podcasts, guest posts, partnerships) — discovery / breakthrough reach.
+- **Rented** (social platforms, ad networks) — engagement, but you don't own the audience or the algorithm.
+- **Owned** (email list, blog, community) — conversion and the only durable asset. Everything upstream should funnel here.
+
+ORB mechanics live in the **launch** skill (channel-type playbook) and content atomization/repurposing lives in **social**; the value here is consolidating the *distribute* half of content strategy so it has a home.
+
+**Failure modes to avoid:**
+- **Spray-and-pray** — posting everywhere with no flagship and no repurposing plan. Effort scatters, nothing compounds.
+- **Platform dependency** — building on rented land. Facebook organic reach fell from ~20% to under 2%; any rented channel can throttle you overnight.
+- **The ownership paradox** — teams spend ~90% of effort on channels they don't control (rented/borrowed) and neglect the owned assets that actually convert and can't be taken away.
+
+For the full distribution spine—the Content Distribution Flywheel, platform half-lives, and the atomization checklist—see the reference below.
+
 ---
 
 ## Output Format
@@ -367,6 +422,7 @@ Visual or structured representation of how content interconnects.
 
 ## References
 
+- **[Content Distribution Spine](references/content-distribution.md)**: Create Once Distribute Twice, ORB as a funnel, the ownership paradox, platform half-lives, the Content Distribution Flywheel, and the per-flagship atomization checklist
 - **[Headless CMS Guide](references/headless-cms.md)**: CMS selection, content modeling for marketing, editorial workflows, platform comparison (Sanity, Contentful, Strapi)
 
 ---
@@ -379,4 +435,5 @@ Visual or structured representation of how content interconnects.
 - **programmatic-seo**: For scaled content generation
 - **site-architecture**: For page hierarchy, navigation design, and URL structure
 - **emails**: For email-based content
-- **social**: For social media content
+- **social**: For social media content, content atomization, and repurposing execution
+- **launch**: For the ORB channel-type playbook and launch-day distribution

--- a/skills/content-strategy/evals/evals.json
+++ b/skills/content-strategy/evals/evals.json
@@ -97,6 +97,20 @@
         "Notes the other formats are judged by different jobs rather than calling them worthless"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "We publish one good blog post a week but nobody reads it — we just post the link once on Twitter and LinkedIn and move on. How should we think about getting our content actually seen, and how should we balance what we produce?",
+      "expected_output": "Should reframe content as brand surface area and each piece as its own launch — creating is only half the job, distribution is the other half. Should introduce 'Create Once, Distribute Twice': one flagship piece repurposed/atomized across channels rather than a single link-drop, with distribution hooks (standalone subheads, modular sections, pull quotes) designed in at creation time. Should diagnose the failure modes at play — spray-and-pray / posting once with no repurposing, and the risk of platform dependency and the ownership paradox (over-investing in rented channels vs owned). Should present the ORB framework as a discovery->engagement->conversion funnel (borrowed -> rented -> owned) routing attention back to owned assets, and reference the launch skill (ORB playbook) and social skill (atomization execution) rather than re-deriving them. Should recommend a calendar balance (60% searchable / 30% shareable / 10% experimental) as a starting ratio. May reference the Content Distribution Flywheel and per-format execution discipline (e.g., 10 titles, ~5 editing passes for a blog post).",
+      "assertions": [
+        "Reframes content as brand surface area / each piece as its own launch and names distribution as the missing half",
+        "Introduces Create Once, Distribute Twice with atomization and creation-time distribution hooks",
+        "Names failure modes: spray-and-pray, platform dependency, ownership paradox",
+        "Presents ORB (borrowed/rented/owned) as a discovery-to-conversion funnel routing back to owned, cross-linking launch and social",
+        "Recommends the 60/30/10 calendar split as a starting ratio",
+        "May reference the Content Distribution Flywheel or per-format execution discipline"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/content-strategy/references/content-distribution.md
+++ b/skills/content-strategy/references/content-distribution.md
@@ -1,0 +1,83 @@
+# Content Distribution Spine
+
+The "distribute" half of content strategy. Creating a great piece is table stakes; the leverage is in getting it seen. This reference expands the **Create Once, Distribute Twice** section of the skill.
+
+Cross-links: ORB channel-type playbook lives in **launch**; atomization/repurposing workflows (podcast → clips, blog → thread) live in **social**. This file consolidates the strategy that ties them together—don't re-derive ORB from scratch here.
+
+## Create Once, Distribute Twice
+
+One exceptional piece, reformatted across channels—not a fresh piece per platform. The math is simple: a flagship piece plus ten repurposed cuts reaches far more people than eleven mediocre native posts, at a fraction of the effort.
+
+The discipline is **designing the piece to be distributed**:
+- Write subheads that read as standalone social posts.
+- Structure sections modularly so they can be lifted out and stand alone.
+- Pre-identify the pull quotes, stats, and frames you'll turn into graphics or short clips.
+- Know the atomized outputs before you write, so the source piece contains them.
+
+Treat the flagship as the master; every channel gets a cut derived from it.
+
+## The ORB Framework as a Funnel
+
+Own, Rent, Borrow—read as a discovery → engagement → conversion funnel:
+
+| Layer | Channels | Funnel role | You control |
+|---|---|---|---|
+| **Borrowed** | Podcasts, guest posts, partnerships, PR, other people's audiences | Discovery / breakthrough | Nothing—it's a loan |
+| **Rented** | Social platforms, ad networks, marketplaces | Engagement / reach | The content, not the audience or algorithm |
+| **Owned** | Email list, blog, community, app | Conversion / retention | Everything—the durable asset |
+
+The strategic move: use borrowed and rented reach to funnel strangers into owned channels where you can convert and retain them. Borrowed and rented are rented land; owned is the only asset you keep.
+
+## The Ownership Paradox
+
+Most teams invert the priority: they spend ~90% of effort on borrowed and rented channels they don't control, and neglect the owned assets that actually convert. The paradox is that the channels getting the least attention (email, blog, community) are the ones that compound and can't be revoked. Rebalance toward owned as the destination for all upstream effort.
+
+## Failure Modes
+
+- **Spray-and-pray** — publishing across every platform with no flagship and no repurposing system. Effort scatters; nothing compounds; each post starts from zero.
+- **Platform dependency** — building your audience on rented land. Facebook organic reach collapsed from ~20% to under 2% as the platform monetized. Any rented channel can throttle, deprioritize, or de-platform you with no recourse. The lesson isn't "avoid rented"—it's "never let rented be the endpoint."
+
+## Platform Half-Lives
+
+Content decays at wildly different rates by channel. Match the piece to the channel's shelf life:
+
+| Channel | Rough half-life | Implication |
+|---|---|---|
+| Twitter/X post | Minutes–hours | Post often; repost; thread for reach |
+| Instagram / Facebook | ~a day | Frequent cadence; stories are ephemeral by design |
+| LinkedIn post | ~a day, longer for strong performers | Fewer, higher-effort posts |
+| TikTok / Reels / Shorts | Days–weeks (algorithmic resurfacing) | Evergreen hooks can re-surface long after posting |
+| YouTube video | Months–years | Search-driven; compounds like a blog post |
+| Blog post / SEO | Years | The long tail; the compounding asset |
+| Email | Sent once, but archived / repurposable | One-shot attention; harvest into other formats |
+
+Short half-life channels reward frequency and repetition; long half-life channels reward depth and evergreen framing. Owned, long-half-life formats (blog, YouTube, email archive) are where distribution effort compounds.
+
+## The Content Distribution Flywheel
+
+Distribution isn't a linear checklist—it's a loop that feeds itself:
+
+1. **Create** one exceptional flagship piece (guide, video, podcast, original research), with distribution hooks built in.
+2. **Atomize** it into channel-native cuts—clips, threads, carousels, quote graphics, email, subhead-posts.
+3. **Distribute** across owned → rented → borrowed, routing everything back to owned.
+4. **Engage** with the responses; capture the questions, objections, and reactions.
+5. **Feed back** — the engagement surfaces the next flagship topic (what resonated, what got asked), and top-performing atoms signal what to make more of.
+
+Each turn of the loop lowers the cost of the next piece (you learn what lands) and grows the owned audience that amplifies it. The flywheel is why consistent distributors pull away from one-off publishers over time.
+
+## Atomization Checklist (per flagship)
+
+For each major piece, produce (see **social** for the platform-native execution):
+- [ ] 3–5 standalone social posts from the subheads/key points
+- [ ] 1 thread (Twitter/X) or carousel (LinkedIn/Instagram) of the core argument
+- [ ] 2–4 short-form video clips (if source is video/podcast)
+- [ ] 1–2 quote or stat graphics
+- [ ] 1 email to the owned list linking the flagship
+- [ ] Repost/reshare schedule across the piece's half-life (don't post once and move on)
+
+## Related
+
+- **launch** — ORB channel-type playbook and launch-day distribution
+- **social** — atomization/repurposing workflows and platform-native execution
+- **emails** — the owned channel that converts distributed attention
+- **ai-seo** — making owned content citable by LLMs (another distribution surface)

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -2,7 +2,7 @@
 name: copywriting
 description: When the user wants to write, rewrite, or improve marketing copy for any page — including homepage, landing pages, pricing pages, feature pages, about pages, or product pages. Also use when the user says "write copy for," "improve this copy," "rewrite this page," "marketing copy," "headline help," "CTA copy," "value proposition," "tagline," "subheadline," "hero section copy," "above the fold," "this copy is weak," "make this more compelling," or "help me describe my product." Use this whenever someone is working on website text that needs to persuade or convert. For email copy, see emails. For popup copy, see popups. For editing existing copy, see copy-editing. For the offer underneath the copy (bonuses, guarantees, value framing), see offers.
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 # Copywriting
@@ -41,7 +41,9 @@ Gather this context (ask if not provided):
 ## Copywriting Principles
 
 ### Clarity Over Cleverness
-If you have to choose between clear and creative, choose clear.
+If you have to choose between clear and creative, choose clear. Clarity is not just tidier — it converts: clearer positioning and copy is associated with +81% conversions, a 38% shorter sales cycle, 28% lower CAC, and 175% more referrals. When a reader has to decode your line, you've lost them.
+
+**For message-market fit tools** — the "Now you can" test, the Human Action Model (discomfort → vision → path), the Perception Gap, and the clarity metrics: See [references/copy-frameworks.md](references/copy-frameworks.md#clarity--message-market-fit)
 
 ### Benefits Over Features
 Features: What it does. Benefits: What that means for the customer.
@@ -119,6 +121,8 @@ Puns and wit make copy memorable—but only if it fits the brand and doesn't und
 - "{Question highlighting main pain point}"
 
 **For comprehensive headline formulas**: See [references/copy-frameworks.md](references/copy-frameworks.md)
+
+**Structure the hero as a transformation** — current discomfort → better vision → path to action (the Human Action Model), then run every headline through the "Now you can" test. See [references/copy-frameworks.md](references/copy-frameworks.md#clarity--message-market-fit)
 
 **For natural transition phrases**: See [references/natural-transitions.md](references/natural-transitions.md)
 

--- a/skills/copywriting/evals/evals.json
+++ b/skills/copywriting/evals/evals.json
@@ -106,6 +106,21 @@
         "Result is specific, clear, and jargon-free"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Write above-the-fold copy for a calendar scheduling tool. Our differentiator is that the recipient gets to overlay their own calendar on the invite, so picking a time feels fair to both people instead of one-sided. Same product needs to work for indie founders AND for enterprise ops teams.",
+      "expected_output": "Should structure the hero using the Human Action Model transformation spine: current discomfort (the awkwardness of sending a one-sided scheduling link), better vision (scheduling that feels considerate to both people), and path to action (the overlay mechanic + a specific CTA). Should run headline candidates through the 'Now you can' test and prefer lines that are compelling and true. Should reference or echo the SavvyCal awkward-link insight ('You shouldn't have to feel awkward sending out your scheduling link') as the message-market-fit model. Should surface the Perception Gap: the same benefit reads differently by risk tolerance, so it should provide a value-prop swap — a founder-facing framing (speed, no sales calls) and an enterprise-facing framing (security, SLAs, reliability) rather than one averaged, mushy message. Should favor clarity over cleverness and provide 2-3 headline alternatives with rationale.",
+      "assertions": [
+        "Structures the hero as discomfort -> vision -> path (Human Action Model)",
+        "Applies the 'Now you can' test to headline candidates",
+        "References the SavvyCal awkward-link message-market-fit insight",
+        "Surfaces the Perception Gap between segments",
+        "Provides a value-prop swap: founder framing vs enterprise framing",
+        "Favors clarity over cleverness",
+        "Provides 2-3 headline alternatives with rationale"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/copywriting/references/copy-frameworks.md
+++ b/skills/copywriting/references/copy-frameworks.md
@@ -7,6 +7,7 @@ Headline formulas, page section types, and structural templates.
 - Landing Page Section Types (core sections, supporting sections)
 - Page Structure Templates (feature-heavy page, varied engaging page, compact landing page, enterprise/B2B landing page, product launch page)
 - Section Writing Tips (problem section, benefits section, how it works section, testimonial selection)
+- Clarity & Message-Market Fit (the "Now you can" test, Human Action Model, the Perception Gap, the SavvyCal case, clarity metrics)
 
 ## Headline Formulas
 
@@ -342,3 +343,91 @@ Avoid testimonials that just say:
 - "Great product!"
 - "Love it!"
 - "Easy to use!"
+
+---
+
+## Clarity & Message-Market Fit
+
+Headline formulas give you the shape of a line. These tools tell you whether the line is actually *working* — whether it's clear, whether it maps to how the reader already thinks, and whether it lands with the right person. Positioning is the prologue to your novel: it sets up everything that follows. Get it clear and the rest of the page writes itself.
+
+### The "Now you can" Test
+
+A fast gut-check for any headline or benefit line. Mentally prefix it with **"Now you can…"**. If the result is both **compelling** and **true**, the line is doing its job. If it reads as vague, obvious, or a stretch, rewrite it.
+
+The test works because "Now you can…" forces the copy into the reader's world — it has to name a concrete new ability they didn't have before. Feature-speak and buzzwords collapse under it.
+
+| Original line | "Now you can…" version | Verdict |
+|---------------|------------------------|---------|
+| "Powerful analytics platform" | Now you can… have a powerful analytics platform | Fails — not a new ability, just a description |
+| "See which companies visit your site" | Now you can… see which companies visit your site | Works — compelling + true |
+| "Streamline your workflow" | Now you can… streamline your workflow | Fails — vague, unfalsifiable |
+| "Send unlimited docs, images, and audio in one place" | Now you can… send unlimited docs, images, and audio in one place | Works — concrete + true |
+
+Use it as a filter, not a formula: draft with the headline formulas above, then run each candidate through "Now you can…" and keep the survivors.
+
+### The Human Action Model (landing-page narrative spine)
+
+Ludwig von Mises' Human Action Model explains *why* anyone acts: a person acts only when three things line up. Every above-the-fold that converts follows the same three-beat spine:
+
+1. **Current discomfort** — the felt problem, named in the reader's own words. They have to recognize their situation ("that's exactly me").
+2. **Better vision** — a clearly imagined, more satisfying state. What life looks like once the discomfort is gone.
+3. **Path to action** — the belief that *this specific step* closes the gap between the two. The product is the bridge, and the CTA is how they cross it.
+
+Miss any beat and the reader stalls. No discomfort = no reason to move. No vision = no destination. No path = no reason to believe *you're* the way there.
+
+**Mapping it onto the hero:**
+
+| Beat | Where it usually lives | Example |
+|------|------------------------|---------|
+| Current discomfort | Eyebrow, subhead, or problem-framed headline | "You shouldn't have to feel awkward sending out your scheduling link" |
+| Better vision | Headline or subhead | "Scheduling that feels considerate, not one-sided" |
+| Path to action | CTA + supporting proof | "Start scheduling free" |
+
+This is the transformation spine underneath the "6 essential sections" of a landing page — hero, social proof, problem, solution, how-it-works, and final CTA. The hero states the transformation; the rest of the page substantiates each beat.
+
+### The Perception Gap
+
+The same benefit can read as a **selling point to one segment and a red flag to another**. The gap is between what *you* think you're saying and what a given reader hears through their own risk tolerance.
+
+The fix isn't softer copy — it's **matching the value prop to the reader's risk tolerance**. Segment first, then swap the framing.
+
+| Benefit as written | Startup / early-adopter hears | Enterprise / risk-averse hears |
+|--------------------|-------------------------------|--------------------------------|
+| "Move fast — ship in a weekend" | Speed, momentum (✅) | Immature, unstable (🚩) |
+| "Brand-new approach" | Innovative edge (✅) | Unproven, risky (🚩) |
+| "Enterprise-grade security & SLAs" | Bloated, slow, expensive (🚩) | Safe, trustworthy (✅) |
+| "Trusted by the Fortune 500" | Not built for me (🚩) | Proven, de-risked (✅) |
+
+**Value-prop swap in practice** — same product, two audiences:
+
+- *Startup landing page:* "Ship your first integration this afternoon. No sales calls, no procurement." 
+- *Enterprise landing page:* "SOC 2 Type II, 99.99% uptime SLA, and a named implementation lead. Roll out with confidence."
+
+When a page has to serve both, don't average them into mush — segment the traffic (separate pages, or a persona split) and let each read its own version of the truth.
+
+### Worked Example — SavvyCal (message-market fit)
+
+SavvyCal (a scheduling tool) originally led with feature-forward copy. They rewrote the hero around a single felt discomfort:
+
+> **"You shouldn't have to feel awkward sending out your scheduling link."**
+
+That one line **roughly tripled (3×) conversions**. It works because it hits all three beats of the Human Action Model at once:
+
+- **Discomfort:** the small social awkwardness of "here's my link, pick a time" — named exactly as users feel it.
+- **Vision:** scheduling that feels considerate to *both* people.
+- **Path:** SavvyCal's overlay-your-calendar mechanic is the bridge, so the CTA feels like the obvious next step.
+
+The lesson: message-market fit beats feature lists. The winning line wasn't cleverer — it named a real feeling the reader hadn't heard a scheduling tool acknowledge before. Run your own hero through "Now you can…" and the Human Action Model to find that line.
+
+### Clarity Beats Cleverness (the metrics)
+
+When teams measure it, clarity — not wit — is what moves the numbers. Clearer positioning and copy is associated with:
+
+- **+81% conversions**
+- **−38% sales cycle** (shorter time to close)
+- **−28% CAC** (lower customer acquisition cost)
+- **+175% referrals**
+
+The mechanism: clear copy lets the *right* buyer self-qualify fast and the wrong one bounce early, so every downstream metric improves. Clever copy that requires decoding does the opposite — it adds a comprehension tax at the exact moment attention is scarcest.
+
+**Practical rule:** if a reader has to pause to figure out what you mean, you've already lost. When forced to choose between a clever line and a clear one, ship the clear one — then use the tests above ("Now you can…", the Human Action Model, the Perception Gap) to make the clear line compelling too.

--- a/skills/customer-research/SKILL.md
+++ b/skills/customer-research/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: customer-research
-description: When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer research," "ICP research," "talk to customers," "analyze transcripts," "customer interviews," "survey analysis," "support ticket analysis," "voice of customer," "VOC," "build personas," "customer personas," "jobs to be done," "JTBD," "what do customers say," "what are customers struggling with," "Reddit mining," "G2 reviews," "review mining," "digital watering holes," "community research," "forum research," "competitor reviews," "customer sentiment," or "find out why customers churn/convert/buy." Use for both analyzing existing research assets AND gathering new research from online sources. For writing copy informed by research, see copywriting. For acting on research to improve pages, see cro.
+description: When the user wants to conduct, analyze, or synthesize customer research. Use when the user mentions "customer research," "ICP research," "talk to customers," "analyze transcripts," "customer interviews," "survey analysis," "support ticket analysis," "voice of customer," "VOC," "build personas," "customer personas," "jobs to be done," "JTBD," "what do customers say," "what are customers struggling with," "Reddit mining," "G2 reviews," "review mining," "digital watering holes," "community research," "forum research," "competitor reviews," "customer sentiment," "PMF survey," "product/market fit survey," "customer interview questions," "interview outreach," "Sales Safari," or "find out why customers churn/convert/buy." Use for analyzing existing research assets, mining online sources, AND running primary research (interviews and surveys). For writing copy informed by research, see copywriting. For acting on research to improve pages, see cro.
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 # Customer Research
@@ -16,15 +16,18 @@ If `.agents/product-marketing.md` exists (or `.claude/product-marketing.md`, or 
 
 ---
 
-## Two Modes of Research
+## Three Modes of Research
 
 ### Mode 1: Analyze Existing Assets
 You have raw research material (transcripts, surveys, reviews, tickets). Your job is to extract signal.
 
-### Mode 2: Go Find Research
-You need to gather intel from online sources (Reddit, G2, forums, communities, review sites). Your job is to know where to look and what to extract.
+### Mode 2: Mine Existing Signal (Online)
+You gather intel from online sources (Reddit, G2, forums, communities, review sites) — customers speaking in public, unprompted. Your job is to know where to look and what to extract.
 
-Most engagements combine both. Establish which mode applies before proceeding.
+### Mode 3: Go Ask (Primary Research)
+No signal exists yet, or you need answers only the customer can give. You run interviews and surveys directly. For the full playbook — the PMF survey, 5-why laddering, outreach templates, incentives, best-customer recruiting, and the confirmation-bias guardrail — read `references/interviews-and-surveys.md`.
+
+Most engagements combine modes. Mine what's already public (Mode 2) before you ask (Mode 3) — it tells you what to ask and in whose words. Establish which mode(s) apply before proceeding.
 
 ---
 
@@ -165,6 +168,24 @@ After gathering from multiple sources, synthesize into:
 
 ### Theme 2: ...
 ```
+
+---
+
+## Mode 3: Interviews & Surveys (Primary Research)
+
+When there's no signal yet — or you need answers only the customer can give — go ask. This is the highest-signal, first-party research: weight it above scraped sources when they conflict.
+
+**Load `references/interviews-and-surveys.md` before running any interview or survey.** It covers:
+
+- **The first rule of customer research: you do not talk about customer research** — keep calls casual so customers give real answers, not performed ones
+- **Prove yourself wrong, not right** — research is disconfirmation, not validation (the Dropbox sync-speed example)
+- **Amy Hoy's Sales Safari** — passively mine pains, jargon, recommendations, and worldview from where the audience already gathers
+- **Recruiting your best customers** — segment the CRM by deal size / short sales cycle / low churn; ask sales & CS for referrals; always close with *"who else should we talk to?"*
+- **Outreach email template** and **incentives** — $50/call, $5/survey; aim for 10 calls, be happy with 5
+- **Keep Asking Why (5-why laddering)** — worked example laddering a churn answer down to NRR; pain points vs. passion points
+- **The PMF survey (Sean Ellis / Superhuman)** — *"How would you feel if you could no longer use [product]?"*; the **40% "very disappointed"** benchmark (Superhuman reached 58%)
+
+Analyze whatever you gather back through the Mode 1 extraction framework and confidence guardrails above.
 
 ---
 

--- a/skills/customer-research/evals/evals.json
+++ b/skills/customer-research/evals/evals.json
@@ -157,6 +157,20 @@
         "Warns against building personas without any data"
       ],
       "files": []
+    },
+    {
+      "id": 13,
+      "prompt": "I want to interview and survey my customers to understand product/market fit. How should I run this?",
+      "expected_output": "Should check for product-marketing.md first. Should route to the primary-research playbook (references/interviews-and-surveys.md). Should recommend the Sean Ellis / Superhuman PMF survey question ('How would you feel if you could no longer use [product]?') and cite the 40% 'very disappointed' benchmark (Superhuman reached 58%). Should recommend recruiting best customers (high deal size, short sales cycle, low churn) and closing every call with 'who else should we talk to?'. Should mention incentives ($50/call, $5/survey; aim for 10 calls, be happy with 5). Should keep it casual ('you do not talk about customer research') and aim to prove yourself wrong, not right. Should mention 5-why laddering (Keep Asking Why) and provide an outreach email approach.",
+      "assertions": [
+        "Checks for product-marketing.md",
+        "Recommends the PMF survey question and cites the 40% 'very disappointed' benchmark (Superhuman 58%)",
+        "Recommends recruiting best customers by deal size / short sales cycle / low churn and asking 'who else should we talk to?'",
+        "Mentions incentives ($50/call, $5/survey) and aiming for 10 calls / happy with 5",
+        "Frames research as casual and disconfirming (prove yourself wrong, not right)",
+        "Mentions 5-why laddering (Keep Asking Why) or an outreach email template"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/customer-research/references/interviews-and-surveys.md
+++ b/skills/customer-research/references/interviews-and-surveys.md
@@ -1,0 +1,155 @@
+# Customer Research — Interviews & Surveys (Primary Research)
+
+Going to the source. Mode 2 mines what customers already said in public; this is Mode 3 — you *ask*. Customer research is your marketing cheat code, and the highest-signal version is talking to customers directly.
+
+Three primary-research pillars, best used together:
+1. **Video calls** — deep, unstructured, follow-the-thread (this file)
+2. **Surveys** — broad, quantified, benchmarkable (this file)
+3. **Online sleuthing** — Sales Safari and watering-hole mining (see `references/source-guides.md`)
+
+---
+
+## The First Rule of Customer Research
+
+> The first rule of customer research: you do not talk about customer research.
+
+Keep it casual. The moment a customer thinks they're in "a research study" they perform — they give you the polished, socially-acceptable answer instead of the real one. Frame calls as a chat, not an interview. Don't lead. Don't pitch. Don't defend the product. You're there to listen and learn how they actually think, talk, and decide.
+
+**Prove yourself wrong, not right.** The point of research is not validation — it's disconfirmation. Go in trying to *break* your assumptions, not confirm them. If you only look for evidence you're right, you'll find it, and it'll be worthless.
+
+- **Dropbox example**: the team assumed users would care most about sync *speed*. Research aimed at disproving the assumption revealed users cared more that files were *reliably there and safe* than about raw speed. Chasing the confirmation would have optimized the wrong thing.
+- Ask questions that could return an answer you don't want to hear. If none of your questions can prove you wrong, rewrite them.
+
+---
+
+## Sales Safari (Amy Hoy)
+
+Amy Hoy's **Sales Safari**: go where your audience already congregates and observe them in the wild, without interrupting. It's structured online sleuthing — read threads, reviews, comments, and forum posts to mine four things:
+
+| Mine for | What you're capturing |
+|----------|-----------------------|
+| **Pains** | The problems, frustrations, and workarounds they describe unprompted |
+| **Jargon** | The exact words, phrases, and shorthand they use — copy gold |
+| **Recommendations** | What they tell each other to buy, try, or avoid |
+| **Worldview** | Their beliefs, biases, and how they see themselves and the problem |
+
+Safari is passive (you observe) where interviews are active (you ask). Run it first: it tells you what to ask about, and in whose words. For per-platform search operators and extraction tips, see `references/source-guides.md`.
+
+---
+
+## Customer Interviews (Video Calls)
+
+### Recruit your best customers
+
+Don't interview whoever answers first. Interview the customers you want *more of*. Segment your CRM and prioritize by:
+
+- **High deal size** — the accounts worth the most
+- **Short sales cycle** — they "got it" fast; their language converts fast
+- **Low churn / high retention** — they got real, lasting value
+
+Recruitment methods, in order of leverage:
+1. **Segment the CRM** by the three signals above and pull a shortlist
+2. **Ask sales and CS for referrals** — they know who loves the product and who articulates why
+3. **Always close every call with**: *"Who else should we talk to?"* — the single most reliable way to compound your interview pipeline
+
+### Incentives
+
+- **$50 per call** (~30 min); **$5 per survey response**
+- Aim for **10 calls, be happy with 5.** Signal saturates fast — by call 5-6 you'll hear the same themes repeat. Don't stall the project waiting for a perfect sample.
+- Offer the incentive up front; it dramatically lifts response rate and shows you value their time. Gift cards work fine.
+
+### Outreach email template
+
+Keep it short, casual, specific, and low-commitment. Not a "research study."
+
+```
+Subject: Quick favor — 30 min, on us
+
+Hi [First name],
+
+I'm [name] from [company]. I'm trying to get better at helping customers
+like you, and I'd love to steal 30 minutes to hear how [product area] is
+actually working for you — what's good, what's annoying, what you wish
+were different. No pitch, no agenda.
+
+As a thank you I'll send you a $50 [Amazon/Visa] gift card.
+
+Are you free [day] or [day] this week? Here's my calendar: [link]
+
+Thanks either way,
+[Name]
+```
+
+Notes:
+- "No pitch, no agenda" and "what's annoying" signal you actually want the truth.
+- One clear ask, two concrete time options, a booking link. Remove friction.
+- Never say "customer research study."
+
+---
+
+## Keep Asking Why (5-Why Laddering)
+
+The first answer is never the real answer. **Keep Asking Why** — ladder each response down 3-5 levels until you hit the root motivation, the business outcome, or the emotional driver. Surface answers are features; the bottom of the ladder is why they pay and why they stay.
+
+**Worked example** — laddering a churn signal to NRR:
+
+- **Q: Why did you downgrade your plan last quarter?**
+  - "We weren't using the advanced reports."
+- **Why weren't you using them?**
+  - "Nobody on the team knew how to build one."
+- **Why didn't anyone learn?**
+  - "The person who set us up left, and onboarding never got re-run for the new hires."
+- **Why did that matter enough to downgrade?**
+  - "Without the reports, my boss couldn't see the ROI, so at renewal it looked like an easy cost to cut."
+- **Why is that the real risk?**
+  - "If leadership can't see value, we churn — and if we *had* seen it, we'd probably have added seats, not cut them."
+
+The surface answer was "we don't use reports." The root is an **onboarding gap that quietly converts an expansion (NRR up) into a contraction or churn (NRR down)**. You can't fix "they don't use reports." You can fix re-onboarding new hires and surfacing ROI to the buyer — which is the difference between contraction and net revenue retention.
+
+**Pain points vs. passion points.** Ladder for both. Pain points are what's broken and what they'll pay to escape. Passion points are what they love, brag about, and would be "very disappointed" to lose. Passion points drive retention and referrals; pains drive acquisition. Capture both in their words.
+
+---
+
+## Surveys
+
+### The PMF Survey (Sean Ellis / Superhuman)
+
+The single most useful survey question, from Sean Ellis and popularized by Superhuman's Rahul Vohra:
+
+> **"How would you feel if you could no longer use [product]?"**
+> - Very disappointed
+> - Somewhat disappointed
+> - Not disappointed
+> - N/A — I no longer use it
+
+**The 40% benchmark**: if **40% or more** of users answer **"very disappointed,"** you likely have product/market fit. Below 40%, keep iterating. **Superhuman reached 58%** by engineering their roadmap around this metric — segmenting on the "very disappointed" cohort, doubling down on what that cohort loved, and converting the "somewhat disappointed" fence-sitters.
+
+Run it as a recurring pulse, not once. Follow the core question with:
+- *"What type of person do you think would most benefit from [product]?"* (sharpens ICP)
+- *"What is the main benefit you receive from [product]?"* (your positioning, in their words)
+- *"How can we improve [product] for you?"* (roadmap fuel from fence-sitters)
+
+Segment every answer by the "very disappointed" cohort vs. the rest — that cohort is your true market.
+
+### Survey design guardrails
+
+- Keep it short — every extra question drops completion.
+- Prefer open-ended for language mining; multiple-choice answers are artifacts of the options you gave.
+- Don't lead. A question that telegraphs the answer you want returns the answer you want, not the truth.
+- $5/response incentive lifts completion; deliver it on submit.
+
+---
+
+## Case Anchors
+
+- **Airbnb (host photography)**: research revealed listings failed because the *photos* were bad, not the pricing or copy. Airbnb sent photographers to shoot host homes — a fix nobody would have guessed without talking to the market. Research points at problems you can't see from inside.
+- **Dropbox (confirmation bias)**: assumed sync speed mattered most; disconfirming research showed reliability/safety of files mattered more. Prove yourself wrong.
+- **Superhuman (PMF survey)**: engineered the roadmap around the "very disappointed" metric, 40% → 58%.
+
+---
+
+## Where This Fits
+
+- **Analyze what you gather** with the Mode 1 extraction framework in `SKILL.md` (jobs to be done, pains, triggers, outcomes, language, alternatives) and the confidence guardrails.
+- **Mine public sources** (the passive Safari half) via `references/source-guides.md`.
+- Interview + survey signal is **first-party and high-confidence** — weight it above scraped online sources when they conflict.

--- a/skills/free-tools/SKILL.md
+++ b/skills/free-tools/SKILL.md
@@ -2,7 +2,7 @@
 name: free-tools
 description: When the user wants to plan, evaluate, or build a free tool for marketing purposes — lead generation, SEO value, or brand awareness. Also use when the user mentions "engineering as marketing," "free tool," "marketing tool," "calculator," "generator," "interactive tool," "lead gen tool," "build a tool for leads," "free resource," "ROI calculator," "grader tool," "audit tool," "should I build a free tool," or "tools for lead gen." Use this whenever someone wants to build something useful and give it away to attract leads or earn links. For downloadable content lead magnets (ebooks, checklists, templates), see lead-magnets.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Free Tool Strategy (Engineering as Marketing)
@@ -25,6 +25,8 @@ Before designing a tool strategy, understand:
 ---
 
 ## Core Principles
+
+**"Your product is my marketing opportunity."** Bezos said "your margin is my opportunity." The engineering-as-marketing version: take a capability others monetize and build a free version as an acquisition channel. Unsplash gave away the stock photos Getty sold — and Getty acquired it. See [references/tool-benchmarks.md](references/tool-benchmarks.md) for named cases and conversion numbers.
 
 ### 1. Solve a Real Problem
 - Tool must provide genuine value
@@ -58,6 +60,8 @@ Before designing a tool strategy, understand:
 | Interactive | Tutorials, playgrounds, quizzes | Learning/understanding |
 
 **For detailed tool types and examples**: See [references/tool-types.md](references/tool-types.md)
+
+**For named case benchmarks (Unsplash, HubSpot Website Grader, Moz, Buffer, Shopify) with real conversion numbers**: See [references/tool-benchmarks.md](references/tool-benchmarks.md)
 
 ---
 
@@ -169,6 +173,13 @@ Rate each factor 1-5:
 4. What's the timeline and budget?
 
 ---
+
+## Common Pitfalls
+
+- **Over-engineering** — Shipping a bloated tool when the winning cases were tiny (Unsplash: 3 hrs; Website Grader: 2 engineers, 2 weeks). Scope to the one job.
+- **Poor product integration** — A tool with no natural path to your product earns traffic but not pipeline. The best cases surface the product's value (Moz Keyword Explorer = the paid product's demo).
+- **Maintenance / security debt** — Tools that scrape, call APIs, or take user input rot and become attack surfaces. Budget for upkeep before you build.
+- **Vanity metrics** — Visitors and usage feel good but don't pay. Track leads, qualification rate, and trial/signup conversion — the numbers the case library reports.
 
 ## Related Skills
 

--- a/skills/free-tools/evals/evals.json
+++ b/skills/free-tools/evals/evals.json
@@ -85,6 +85,19 @@
         "Does not attempt full page CRO using free tool strategy patterns"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're deciding whether a free tool is worth building for our SaaS. What kind of results do free tools actually get, and what usually goes wrong?",
+      "expected_output": "Should reference the named case benchmarks (e.g. Crew/Unsplash 3 hrs to 11M monthly visitors and Getty acquisition, HubSpot Website Grader 250K leads / $6M, Moz Keyword Explorer 40% trial conversion / CAC down 65%, Buffer Salary Calculator 1.5M visitors / 12% signup, Shopify Hatchful 25% trial conversion) to set realistic expectations. Should invoke the 'your product is my marketing opportunity' framing. Should surface the common pitfalls: over-engineering, poor product integration, maintenance/security debt, and vanity metrics. Should tie expectations to tool type (analyzers convert/qualify leads, calculators drive reach, generators feed onboarding). Should recommend tracking leads and conversion rather than vanity metrics.",
+      "assertions": [
+        "Cites named case benchmarks with real numbers",
+        "Invokes 'your product is my marketing opportunity' framing",
+        "Lists the common pitfalls (over-engineering, poor product integration, maintenance/security debt, vanity metrics)",
+        "Connects expected results to tool type",
+        "Recommends tracking leads/conversion over vanity metrics"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/free-tools/references/tool-benchmarks.md
+++ b/skills/free-tools/references/tool-benchmarks.md
@@ -1,0 +1,35 @@
+# Free Tool Case Benchmarks
+
+Real free tools and the numbers they produced. Use these to set expectations, justify the build, and pattern-match your concept against what actually worked.
+
+## Framing: "Your product is my marketing opportunity"
+
+Bezos's line was **"your margin is my opportunity"** — where a competitor monetizes something, undercut it. The engineering-as-marketing version is **"your product is my marketing opportunity."** Take a capability others sell, build a simple free version, and turn it into an acquisition channel. Unsplash gave away the stock photos that Getty charged for — and Getty ended up acquiring it.
+
+## Case Library
+
+| Tool | Company | Build cost | Result |
+|------|---------|-----------|--------|
+| Unsplash | Crew | 3 hrs, leftover redesign photos | 11M monthly visitors; acquired by Getty |
+| Website Grader | HubSpot | 2 engineers, 2 weeks | 250K leads, 98% auto-qualification, $6M revenue |
+| Forecasting | Baremetrics | — | 35% trial conversion |
+| Headline Analyzer | CoSchedule | — | ~20% of users convert to subscribers |
+| Keyword Explorer | Moz | — | 40% trial conversion, CAC down 65% |
+| Salary Calculator | Buffer | — | 1.5M visitors, 12% signup rate |
+| Hatchful | Shopify | — | 25% trial conversion |
+
+## What each case teaches
+
+- **Crew → Unsplash** — The anchor case. A near-zero-cost byproduct (leftover photos from a redesign, ~3 hrs to ship) became a top-of-funnel giant. Give away what others charge for; the reach compounds.
+- **HubSpot Website Grader** — Small build (2 engineers, 2 weeks), enormous return. Proof that an analyzer/grader can double as a lead engine *and* a qualification engine — 98% of leads auto-qualified because the tool's inputs revealed fit.
+- **Baremetrics Forecasting** — A tool adjacent to the core product (revenue analytics) that converts trials at 35% because using it makes the paid product's value obvious.
+- **CoSchedule Headline Analyzer** — Repeat-use analyzer with a low-friction path to subscription (~20%). High recurring usage keeps the brand in front of the audience.
+- **Moz Keyword Explorer** — A free surface of the paid product itself: 40% trial conversion and a 65% drop in CAC because the tool *is* the demo.
+- **Buffer Salary Calculator** — Not adjacent to the product at all, but massively shareable: 1.5M visitors, 12% signup. Pure reach + brand play that still converts.
+- **Shopify Hatchful** — A generator (logo maker) that feeds the core product's onboarding, converting trials at 25%.
+
+## How to use these benchmarks
+
+- **Set expectations**: Analyzer/grader tools tend to convert visitors to leads well and qualify them; calculators skew toward reach and share-worthiness; generators feed onboarding.
+- **Justify the build**: Compare your expected lead value × volume against these ratios before committing engineering time.
+- **Pattern-match**: Find the case closest to your concept (adjacent-to-product vs pure-reach) and borrow its gating and distribution approach.

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -2,7 +2,7 @@
 name: launch
 description: "When the user wants to plan a product launch, feature announcement, or release strategy. Also use when the user mentions 'launch,' 'Product Hunt,' 'feature release,' 'announcement,' 'go-to-market,' 'beta launch,' 'early access,' 'waitlist,' 'product update,' 'how do I launch this,' 'launch checklist,' 'GTM plan,' or 'we're about to ship.' Use this whenever someone is preparing to release something publicly. For ongoing marketing after launch, see marketing-ideas. For the offer being launched (bonuses, guarantees, scarcity, naming), see offers."
 metadata:
-  version: 2.0.1
+  version: 2.0.2
 ---
 
 # Launch Strategy
@@ -99,6 +99,34 @@ Tap into someone else's audience to shortcut the hardest part—getting noticed.
 Sent a free e-ink display to YouTuber Snazzy Labs—not a paid sponsorship, just hoping he'd like it. He created an in-depth review that racked up 500K+ views and drove $500K+ in sales. They also set up an affiliate program for ongoing promotion.
 
 Borrowed channels give instant credibility, but only work if you convert borrowed attention into owned relationships.
+
+---
+
+## Readiness Gate: Are You Ready to Launch?
+
+Run this **before** the phased mechanics. Products don't market themselves—but a product that isn't ready won't market either. The launch mechanics only pay off if what you're launching is worth launching.
+
+Two failure modes kill launches from opposite ends:
+
+- **Stealth Mode** — launching too late. "Procrastination in a fancy suit." You keep polishing in private, waiting for the product to be perfect. It never ships, and nobody learns you exist.
+- **"Just One More Feature"** — never launching. Every proposed launch date gets pushed for one more thing. The scope creeps forever; the launch never comes.
+
+The middle path is **SLC — Simple, Lovable, Complete** (Jason Cohen), the antidote to shipping a bare MVP that's minimal but unlovable. Don't launch a stub nobody wants; don't wait for a bloated everything-app. A launchable v1 is:
+
+- **Simple** — it does *one* thing. Not many things poorly. One clear job, done well.
+- **Lovable** — people *want* to use it, not just tolerate it. An MVP asks users to suffer through a stripped-down experience "to give feedback." SLC gives them something they'd choose. If nobody would be sad to lose it, it isn't lovable yet.
+- **Complete** — it's a *whole* experience for that one thing, not a stub with obvious holes. Complete at its chosen scope, not a teaser of a bigger promise.
+
+**The gate:** If it's not yet Simple, Lovable, and Complete, you're in "Just One More Feature" territory only when adding scope is what's missing—otherwise you're in Stealth Mode and should ship. Cut scope until one thing is lovable and complete, then launch that. SLC gives you a real launch now instead of a perfect launch never.
+
+**Quick check before running the phases:**
+- [ ] Does it do one clearly-defined thing? (Simple)
+- [ ] Would a target user *choose* to use it, not just endure it? (Lovable)
+- [ ] Is that one thing a whole experience, with no glaring stubs? (Complete)
+- [ ] Are you polishing past this bar? → Stop. You're in Stealth Mode. Ship.
+- [ ] Are you still adding new things to the scope? → Stop. You're in "Just One More Feature." Cut back to SLC.
+
+Pass the gate, then run the phases below.
 
 ---
 

--- a/skills/launch/evals/evals.json
+++ b/skills/launch/evals/evals.json
@@ -86,6 +86,21 @@
         "May provide some launch-related tactical ideas"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We've been building our product in private for 8 months and keep pushing the launch date because there's always one more feature we want to add first. How do we know when we're actually ready to launch?",
+      "expected_output": "Should apply the Readiness Gate before jumping to launch mechanics. Should name the two failure modes: Stealth Mode (launching too late, 'procrastination in a fancy suit') and 'Just One More Feature' (never launching), and identify that this user is exhibiting both. Should introduce SLC (Simple, Lovable, Complete) by Jason Cohen as the middle path and the alternative to a bare MVP. Should explain each: Simple (does one thing), Lovable (users want to use it, not just tolerate it), Complete (a whole experience, not a stub). Should advise cutting scope to reach SLC on one thing rather than adding more features, and to ship once the gate is passed. Should not just dump the five-phase mechanics without addressing readiness first.",
+      "assertions": [
+        "Applies the readiness gate before launch mechanics",
+        "Names Stealth Mode and 'Just One More Feature' failure modes",
+        "Diagnoses the user as stuck in these failure modes",
+        "Introduces SLC (Simple, Lovable, Complete) as the middle path vs a bare MVP",
+        "Explains Simple, Lovable, and Complete distinctly",
+        "Advises cutting scope to reach SLC rather than adding features",
+        "Recommends shipping once the gate is passed"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/marketing-ideas/SKILL.md
+++ b/skills/marketing-ideas/SKILL.md
@@ -2,7 +2,7 @@
 name: marketing-ideas
 description: "When the user needs marketing ideas, inspiration, or strategies for their SaaS or software product. Also use when the user asks for 'marketing ideas,' 'growth ideas,' 'how to market,' 'marketing strategies,' 'marketing tactics,' 'ways to promote,' 'ideas to grow,' 'what else can I try,' 'I don't know how to market this,' 'brainstorm marketing,' or 'what marketing should I do.' Use this as a starting point whenever someone is stuck or looking for inspiration on how to grow. For specific channel execution, see the relevant skill (ads, social, emails, etc.)."
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Marketing Ideas for SaaS
@@ -38,13 +38,16 @@ When asked for marketing ideas:
 | Launches | 77-86 | Product Hunt, Lifetime deals, Giveaways |
 | Product-Led | 87-96 | Viral loops, Powered-by marketing, Free migrations |
 | Content Formats | 97-109 | Podcasts, Courses, Annual reports, Year wraps |
-| Unconventional | 110-122 | Awards, Challenges, Guerrilla marketing |
+| Unconventional | 110-122 | Awards, Challenges, [Guerrilla marketing](references/guerrilla-marketing.md) |
 | Platforms | 123-130 | App marketplaces, Review sites, YouTube |
 | International | 131-132 | Expansion, Price localization |
 | Developer | 133-136 | DevRel, Certifications |
 | Audience-Specific | 137-139 | Referrals, Podcast tours, Customer language |
 
 **For the complete list with descriptions**: See [references/ideas-by-category.md](references/ideas-by-category.md)
+
+**Deep dives** (full framework + case library for a single idea):
+- **Guerrilla marketing (#121)**: [references/guerrilla-marketing.md](references/guerrilla-marketing.md) — the direct-mail 3-rule framework (relevance / relationship-building / precision targeting), ROI discipline, "think in stories, not campaigns," "test small before going big," and a named case library (WePay, Xero, Red Bull, Antimetal, Arrows, ProfitWell, Buzzsprout, Wistia).
 
 ---
 

--- a/skills/marketing-ideas/evals/evals.json
+++ b/skills/marketing-ideas/evals/evals.json
@@ -85,6 +85,21 @@
         "May briefly mention as a marketing idea"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We sell a $30k/year data platform and can't get marketing VPs at target accounts to reply to email or take calls. We have budget for something creative. What guerrilla tactics could break through?",
+      "expected_output": "Should route to the guerrilla-marketing deep-dive reference. Should surface the direct-mail 3-rule framework (relevance, relationship-building, precision targeting) and the ROI discipline that a $50-200 package to an unqualified lead is malpractice — qualify the named accounts first, test small before scaling. Should note the deal size ($30k/year) justifies high-cost mailers. Should draw on the case library for inspiration (e.g. Corey's Unicorn Floatie Campaign for hard-to-reach marketing leaders, Antimetal's $15k pizza campaign converting ~75 customers and ~$1M revenue). Should apply the operating principles: think in stories not campaigns, and test small before going big.",
+      "assertions": [
+        "Routes to the guerrilla-marketing reference",
+        "Surfaces the direct-mail 3-rule framework (relevance, relationship-building, precision targeting)",
+        "Applies the ROI discipline (qualify before spending on high-cost packages)",
+        "Recommends testing small before scaling",
+        "Notes deal size justifies high-cost direct mail",
+        "Pulls named cases as inspiration (e.g. Unicorn Floatie, Antimetal pizza)",
+        "Applies 'think in stories, not campaigns' principle"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/marketing-ideas/references/guerrilla-marketing.md
+++ b/skills/marketing-ideas/references/guerrilla-marketing.md
@@ -1,0 +1,56 @@
+# Guerrilla Marketing (#121)
+
+Unconventional stunts that earn attention in unexpected places — then get turned into repeatable strategy. The point isn't the one-off spectacle. It's finding a memorable, low-cost way to break through, proving it works small, and running it again.
+
+Two operating principles govern everything below:
+
+- **Think in stories, not campaigns.** People don't share your funnel. They share a story worth retelling. Design the moment so the person who receives it wants to tell someone else.
+- **Test small before going big.** A guerrilla idea is a hypothesis. Prove it on a handful of targets before you spend real money scaling it.
+
+---
+
+## Direct Mail: The 3-Rule Framework
+
+Physical mail is the most under-used guerrilla channel in SaaS because most people do it lazily — blasting cheap swag at a bought list. Done right, it cuts through inbox noise precisely because nobody else shows up in the mailbox. Every direct-mail play must satisfy all three rules:
+
+1. **Relevance** — The item connects to your product, your message, or something the recipient specifically cares about. A random branded mug is noise. A gift that lands a joke about their exact problem is a story.
+2. **Relationship-building** — The mailer opens or deepens a relationship. It's a gift, not a pitch. If the recipient feels sold to, you've spent money to annoy someone.
+3. **Precision targeting** — You know exactly who is receiving it and why. Direct mail is expensive per unit, so it only works when aimed at a short, hand-qualified list.
+
+### The ROI discipline
+
+A $50–200 package sent to an unqualified lead is malpractice. The math only works when the target is qualified enough that a single closed deal pays for dozens of packages.
+
+- **Qualify before you spend.** Reserve high-cost mailers for named accounts and hard-to-reach decision-makers where the deal size justifies the cost.
+- **Test small before scaling.** Send to a handful first. Measure reply and meeting rates. Only scale the version that actually earns responses.
+
+### Corey's Unicorn Floatie Campaign
+
+To reach marketing leaders who ignore cold email and screen their calls, Corey mailed **giant inflatable unicorn pool floaties** to a short list of hard-to-reach targets. The floatie is absurd, oversized, and impossible to ignore — it lands as a story, not a pitch (relevance + relationship), aimed at a hand-picked list where each closed deal dwarfs the package cost (precision + ROI discipline). Recipients remembered it, mentioned it, and replied.
+
+---
+
+## Case Library (inspiration fuel)
+
+Steal the *pattern*, not the prop. Each of these turned a small, unconventional act into outsized attention or revenue.
+
+- **WePay's 600-lb ice block** — At PayPal's developer conference, WePay dropped a 600-pound block of ice with money frozen inside and a sign reading **"PayPal Freezes Your Accounts."** A pointed, physical jab at a competitor's real weakness, staged exactly where the audience was.
+- **Xero skywriting** — Xero paid for **skywriting over TechCrunch Disrupt**, hijacking a competitor-heavy event's attention from above without buying a booth.
+- **Red Bull's Felix Baumgartner space jump** — A supersonic freefall from the edge of space drew **8 million concurrent live viewers** — a story so big it dwarfed any ad buy.
+- **Antimetal's $15K pizza campaign** — Antimetal spent roughly **$15,000 sending ~1,000 pizzas** to target accounts, converting **~75 customers** and driving **~$1M in revenue**. Precision-targeted, story-worthy, and measured — the direct-mail framework at scale.
+- **Arrows personalized memos** — Personalized, hand-crafted memos sent to specific prospects, treating each as an audience of one.
+- **ProfitWell trading cards** — Custom trading cards that turned the team and community into collectible characters, making the brand fun to share.
+- **Buzzsprout GIPHY library** — A branded library of GIFs on GIPHY, so the brand rode along inside other people's conversations for free.
+- **Wistia "Gear Squad vs Dr. Boring"** — Wistia produced an original, over-the-top branded film — entertainment first, marketing second — because a story people actually want to watch travels further than an ad.
+
+---
+
+## How to Use This With a Client
+
+1. **Pick the story.** What's the one memorable thing a target would retell? Start from the story, then reverse-engineer the tactic.
+2. **Qualify the list.** For any high-cost play (direct mail especially), name the exact accounts and confirm the deal size justifies the spend.
+3. **Run the 3-rule check** on physical mail: relevance, relationship-building, precision targeting. If it fails any one, redesign it.
+4. **Test small.** Ship to a handful, measure replies/meetings/coverage, and only scale what earns a response.
+5. **Turn the stunt into a system.** If it works, make it repeatable — a recurring mailer program, a series of films, an ongoing library — rather than a one-time spike.
+
+*Source: Corey Haines, Founding Marketing, ch. 13.*

--- a/skills/marketing-ideas/references/ideas-by-category.md
+++ b/skills/marketing-ideas/references/ideas-by-category.md
@@ -311,7 +311,7 @@ Complete list of proven marketing approaches organized by category.
 
 120. **Marketing Stunts** - Bold, attention-grabbing marketing moments.
 
-121. **Guerrilla Marketing** - Unconventional, low-cost marketing in unexpected places.
+121. **Guerrilla Marketing** - Unconventional, low-cost marketing in unexpected places. Deep dive: direct-mail 3-rule framework (relevance / relationship / precision), ROI discipline, and a named case library in [guerrilla-marketing.md](guerrilla-marketing.md).
 
 122. **Humor Marketing** - Use humor to stand out and create memorability.
 

--- a/skills/marketing-plan/SKILL.md
+++ b/skills/marketing-plan/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: marketing-plan
 description: When the user needs a comprehensive marketing plan for a client, a company they advise, or their own product. Also use when the user mentions "marketing plan," "growth plan," "GTM plan," "go-to-market plan," "AARRR plan," "90-day marketing plan," "12-month marketing roadmap," "fractional CMO plan," or "fCMO plan." Generates an exhaustive 13-section plan structured by AARRR (Acquisition, Activation, Retention, Referral, Revenue), customized to the client's current budget, team, and stage, mapped to future funding milestones, cross-referenced with the 139-idea marketing-ideas library and an embedded 17-section current-state audit rubric, with a full marketing operations stack showing which skills and MCP/API integrations execute each part. Outputs a Notion-paste-ready markdown document. For positioning and ICP context before planning, see product-marketing. For stage-specific deep work, see onboarding, signup, emails, referrals, pricing.
+metadata:
+  version: 1.1.1
 ---
 
 # Marketing Plan
@@ -92,6 +94,32 @@ Full primer in `references/aarrr-framework.md`. Quick rule:
 
 Brand and content are **cross-cutting**, not their own AARRR stage — they serve every stage.
 
+## Marketing as investing — the north-star framing
+
+AARRR gives the plan its *structure*. This gives it its *spine*. Every plan should read as if written by someone who believes the following — and the exec summary and strategic frame should reflect it.
+
+Adapted from *Founding Marketing* by Corey Haines (Ch. 1).
+
+- **Marketing is like investing.** Treat the plan as a **compounding portfolio**, not a campaign calendar. Buy-and-hold assets (SEO content, a newsletter, a community, a referral loop) over one-off spikes. Diversify — no single channel carries the plan. Time in market beats timing the market.
+- **No silver bullets, a hundred golden pellets.** There is no one move that fixes growth. The plan wins by stacking many small compounding assets. Be suspicious of any recommendation that promises to be *the* thing.
+- **One asset, many returns.** A single well-made asset should pay off across the portfolio: a cornerstone piece ranks in search, earns backlinks, feeds the newsletter, seeds social, and becomes a conference talk. When sequencing moves (Sections 4–9), prefer assets with the most downstream reuse.
+- **Audition, not an auction.** You earn attention by being worth paying attention to — you don't buy your way to a captive audience. Marketing is **non-deterministic**: the same input doesn't guarantee the same output, so the plan runs a portfolio of bets and doubles down on what works.
+- **Hope is not a strategy.** Every move in the plan names its mechanism and its leading indicator. "Post more and hope it works" is not a line item. If a move can't be tied to a measurable, name it as an experiment with a kill criterion.
+
+### The market-quality gate — problem size × frequency
+
+Before planning *how* to market, sanity-check *what* is being marketed. Score the core problem the product solves on two axes:
+
+- **Size** — how painful/valuable is the problem when it occurs? (small → large)
+- **Frequency** — how often does the customer feel it? (rare → constant)
+
+|  | **Low frequency** | **High frequency** |
+|---|---|---|
+| **Large problem** | Winnable but expensive to keep top-of-mind (long sales cycles, retargeting-heavy) | **Best quadrant — build here.** Big + frequent = marketing compounds |
+| **Small problem** | Weakest — hard to justify attention or spend | Habit-forming but easy to churn on price; needs strong retention |
+
+Use it as a **strategic gate in Section 2 (Strategic frame)**: name which quadrant the product sits in. Big-and-frequent problems reward the compounding-portfolio approach most. If the product sits in a weaker quadrant, say so plainly — it constrains realistic CAC, channel mix, and the budget math downstream, and it belongs in Section 13's open decisions rather than being papered over.
+
 ## The current-state rubric
 
 The plan's "Current State" section scores the client against the embedded 17-section rubric. Full rubric in `references/current-state-rubric.md` — it's the source of truth, not a derivative of any external skill.
@@ -145,6 +173,8 @@ Pitch decks show hockey sticks. Real growth is a series of S-curves with plateau
 - **Phase identification** — $0–10K ARR (grueling), $10K–100K (treacherous middle), $100K–1M (acceleration). Section 3 names the current phase; Section 10 sequences the next.
 - **Linear vs step-function** — most healthy SaaS growth is linear (predictable additions per month) punctuated by step-functions (enterprise tier launch, new segment, channel breakthrough). The plan should describe both honestly — not promise exponential.
 - **S-curve layering** — Channel × Product × Market. Start the next S-curve while the current one is still growing. Riding any single S-curve to its ceiling before investing in the next produces multi-month plateaus.
+- **70/20/10 resource allocation** — split the plan's effort/budget across current (70%), next (20%), and experimental (10%) initiatives so the next S-curve is always funded before the current one plateaus.
+- **Weekly tracking cadence** — review leading indicators weekly and watch for S-curve plateau signals; a flattening curve is the trigger to shift weight toward the next one, not a reason to push harder on the current.
 
 ## Team and agency model
 

--- a/skills/marketing-plan/evals/evals.json
+++ b/skills/marketing-plan/evals/evals.json
@@ -91,6 +91,22 @@
         "Does not silently produce a stripped-down plan"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "A founder wants a plan but keeps asking 'what's the one channel that will make us blow up?' They also want a defensible way to split the budget so they don't starve future growth, and a way to know when a channel is running out of steam. Frame the strategic thinking for the plan.",
+      "expected_output": "Should push back on silver-bullet thinking with the marketing-as-investing framing — a compounding portfolio, 'no silver bullets, a hundred golden pellets,' one asset that ranks + earns backlinks + feeds the newsletter + becomes a talk, audition not an auction, hope is not a strategy. Should apply the problem size x frequency market-quality gate to sanity-check whether the product is even in a build-big-and-frequent quadrant. Should introduce the 70/20/10 resource-allocation rule (current / next / experimental) so future growth stays funded. Should introduce a weekly tracking cadence with plateau-indicator alerts (flattening week-over-week additions, rising CAC, effort up / output flat) that trigger shifting weight to the next S-curve. Should tie these into Section 2 (Strategic frame), Section 10 (12-month outlook), and Section 13 (Measurement).",
+      "assertions": [
+        "Rejects silver-bullet framing using marketing-as-investing / compounding portfolio",
+        "Uses the 'no silver bullets, a hundred golden pellets' and 'audition, not an auction' framing",
+        "Invokes 'hope is not a strategy' — every move has a mechanism and leading indicator",
+        "Applies the problem size x frequency market-quality gate",
+        "Introduces the 70/20/10 resource-allocation rule (current / next / experimental)",
+        "Introduces a weekly tracking cadence with plateau-indicator alerts",
+        "Ties plateau alerts to shifting weight toward the next S-curve",
+        "Maps the framing to Section 2, Section 10, and Section 13"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/marketing-plan/references/growth-patterns.md
+++ b/skills/marketing-plan/references/growth-patterns.md
@@ -110,6 +110,47 @@ The real magic: while SEO is maturing, you're using paid for quick wins. As thos
 
 This is the operational thesis behind the AARRR mapping (Sections 4–8) and the 12-month outlook (Section 10): each section is a curve, and the plan sequences them so the next curve is ramping while the current one is still growing.
 
+## The 70/20/10 resource-allocation rule
+
+Layering S-curves only works if the next curve is funded *before* the current one plateaus. The 70/20/10 rule is the budgeting discipline that guarantees it. Split marketing effort and spend across three buckets:
+
+| Bucket | Share | What it covers |
+|---|---|---|
+| **Current** | **70%** | The initiatives already working — the channels, content, and campaigns driving today's growth. Protect and optimize. |
+| **Next** | **20%** | The S-curve you're deliberately building — the channel/product/market bet that becomes the *current* 70% in 2–4 quarters. |
+| **Experimental** | **10%** | Unproven bets and small tests. Most fail; the ones that work graduate into the 20%, then the 70%. |
+
+Why it matters for the plan:
+
+- It operationalizes "start the next S-curve before the current one plateaus" — the 20% + 10% *is* the next curve, funded on purpose rather than scrambled for after a plateau hits.
+- It maps cleanly onto the **10–20% experimental budget buffer** in `budget-planning.md` — the experimental layer is the 10% here.
+- It gives Section 11 (Ops stack) and Section 10 (12-month outlook) a defensible allocation logic instead of dumping the whole budget into what's currently working.
+
+**In the plan:** Section 10 (12-month outlook) names what sits in each bucket now, and what's expected to graduate. Section 11 (Ops stack) shows the 70/20/10 split across the AARRR stages. Adjust the ratio by phase — Phase 1 companies (still hunting for any channel that works) may run closer to 40/30/30; Phase 3 companies with a proven engine can run 80/15/5.
+
+## Weekly tracking cadence and plateau alerts
+
+S-curve plateaus are the single most important thing to catch early — the whole point of layering curves is to shift weight to the next one *before* the current plateau bites. That requires a review rhythm, not an annual look-back.
+
+### The cadence
+
+- **Weekly** — review the leading indicators for each active S-curve (new signups per channel, content velocity, activation rate, MRR added). Weekly is frequent enough to spot a curve flattening while there's still time to act.
+- **Monthly** — roll the weeklies up; confirm which bucket (70/20/10) each initiative belongs in and whether anything should graduate or be cut.
+- **Quarterly** — the plan itself adjusts (re-sequence Section 10, reallocate the budget).
+
+### Plateau-indicator alerts
+
+Watch for these signals that a curve is topping out — each is a trigger to shift weight toward the next curve, not to push harder on the current one:
+
+- **Week-over-week additions flattening** — the channel is adding the same absolute numbers it did last month despite equal or greater effort (declining marginal return).
+- **Rising CAC on a formerly cheap channel** — paying more for the same result is the classic plateau tell.
+- **Engagement/activation softening at the top of the funnel** — the audience for this channel/message is saturating.
+- **Effort up, output flat** — the team is working harder to hold the line rather than to grow it.
+
+When two or more fire on the same curve, that's the trigger to accelerate the **20% "next" bucket** — the plateau is the moment between two S-curves, and it should already have a successor ramping.
+
+**In the plan:** Section 13 (Measurement) names the weekly leading indicators per S-curve and the specific plateau thresholds that trigger the next move. This turns "watch for plateaus" from a platitude into an operational alert.
+
 ## The 3-3-2-2-2 VC growth path
 
 For companies that have crossed $1M ARR and raised institutional capital, the VC benchmark is:
@@ -137,8 +178,9 @@ For non-VC-backed (bootstrapped, founder-funded, profit-focused) companies, this
 | **4 (Acquisition)** | Current channels + their position on the S-curve (early / mature / plateauing). Next channel investment with rationale. |
 | **5–8 (AARRR)** | Each section names the binding constraint at the current phase. For Phase 2 companies, Activation is usually the leverage point. For Phase 3, Retention + Referral compound the existing growth. |
 | **9 (90-day roadmap)** | Linear-pattern moves dominate (predictable additions). Step-function setups (the build-up to a launch, an enterprise tier, a new market segment) live here. |
-| **10 (12-month outlook)** | Sequence channel S-curves, product S-curves, market S-curves. If VC-backed Series A+, anchor against 3-3-2-2-2. If not, name the linear or step-function targets. |
-| **13 (Measurement)** | The north-star metric reflects the current phase (Phase 1 is usually pure new-signup; Phase 3 is usually expansion ARR or NRR). |
+| **10 (12-month outlook)** | Sequence channel S-curves, product S-curves, market S-curves. Apply the 70/20/10 split (current / next / experimental) so the next curve is funded before the current one plateaus. If VC-backed Series A+, anchor against 3-3-2-2-2. If not, name the linear or step-function targets. |
+| **11 (Ops stack)** | Show the 70/20/10 allocation across the AARRR stages — what share protects what's working vs. builds the next curve vs. experiments. |
+| **13 (Measurement)** | The north-star metric reflects the current phase (Phase 1 is usually pure new-signup; Phase 3 is usually expansion ARR or NRR). Name the weekly leading indicators per S-curve and the plateau thresholds that trigger the next move. |
 
 ## Operational guidance for the planner
 

--- a/skills/offers/SKILL.md
+++ b/skills/offers/SKILL.md
@@ -2,7 +2,7 @@
 name: offers
 description: "When the user wants to design, construct, or improve an offer — the thing they actually sell — including value framing, bonus stacking, guarantee design, scarcity/urgency, naming, and payment structure. Also use when the user mentions 'offer,' 'offer design,' 'build an offer,' 'grand slam offer,' 'irresistible offer,' 'value stack,' 'bonus stack,' 'guarantee,' 'risk reversal,' 'money-back guarantee,' 'scarcity,' 'urgency,' 'high-ticket offer,' 'productize a service,' 'naming an offer,' 'payment plan,' 'down-sell,' 'upsell offer,' or 'why isn't my offer converting.' Best for services, agencies, courses, coaching, info products, high-ticket B2B, and direct-response. If you run pure self-serve SaaS, read pricing first — tiers and packaging do more work there. For price level itself (tiers, freemium, value metric), see pricing. For the page that presents the offer, see copywriting. For the launch moment, see launch. For sales collateral, see sales-enablement."
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Offer Design
@@ -96,6 +96,7 @@ Most weak offers fail on bonuses (none), guarantees (none or wrong type), or sca
 | [bonus-stacking.md](references/bonus-stacking.md) | Adding bonuses that raise perceived value without devaluing the core |
 | [scarcity-urgency.md](references/scarcity-urgency.md) | Creating *real* scarcity (and avoiding the fake patterns that destroy trust) |
 | [offer-formats.md](references/offer-formats.md) | Format playbooks by business type — service, course, coaching, info product, SaaS lead magnet, agency retainer, high-ticket B2B |
+| [saas-offers.md](references/saas-offers.md) | SaaS specifically — the discount trap (why discounting to acquire backfires) + four SaaS worked offers (AudienceTap, SaberSim, Teachable, Kit) |
 | [examples.md](references/examples.md) | Anonymized worked examples — before/after for each business type |
 
 ---
@@ -122,6 +123,7 @@ Some offer patterns work but cost more than they're worth:
 - **Over-promising guarantees** — "double your revenue or refund + $1,000." Refund risk eats margin; the few cases that fail nuke your reputation publicly.
 - **Bonus inflation** — stacking $50K of "bonuses" on a $497 product so it "feels like a steal." Sophisticated buyers see this. Treat bonuses as additive, not exaggerated.
 - **Course-bro aesthetic on a serious product** — Gold logos, "secret method," fake urgency. Pattern-matches to scam. Wrong room.
+- **Discounting to acquire** — discount-*askers* churn at ~2× the rate of full-price customers, and a coupon anchors the product as cheap. Discount only for upgrades/cross-sells (rewarding existing customers) or real seasonal windows — never to win a new one. Raise value with an offer instead. See [saas-offers.md](references/saas-offers.md).
 
 The repo voice: opinionated, but honest. Building offers well doesn't mean building offers loud.
 

--- a/skills/offers/evals/evals.json
+++ b/skills/offers/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "offers",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Our B2B SaaS trial-to-paid conversion is stuck. Our plan is to run a 50% off first 3 months coupon to push more people to convert. It's a $99/month email-tool competitor and the biggest thing prospects say is they're scared to migrate their list and automations off their current provider. Is the discount the right move?",
+      "expected_output": "Should push back on discounting to acquire and cite that discount-askers churn at roughly 2x the rate of full-price customers, that a coupon anchors the product as cheap, and attracts price-shoppers over value-buyers. Should state the rule: discount only for upgrades/cross-sells or real seasonal windows, never to acquire a new customer. Should reframe 'offers > discounts' — raise value instead of cutting price. Should diagnose that the real objection is switching cost / migration risk, not price, so a discount does nothing about it. Should recommend a real offer that reverses that risk — e.g. a done-for-you 'Painless Switch' style migration offer with a switching-cost guarantee (migration live/verified in N days or it's free) and a bonus that removes the secondary fear (deliverability/re-warm). May reference the value equation (lower effort/sacrifice and raise perceived likelihood rather than lower price). Should tie back to real, honest scarcity (capacity/queue) rather than a fake timer.",
+      "assertions": [
+        "Advises against discounting to acquire new customers",
+        "Cites discount-askers churn at ~2x full-price customers",
+        "States discount only for upgrades/cross-sells or seasonal moments",
+        "Frames offers as beating discounts (raise value, not cut price)",
+        "Identifies migration/switching cost as the real objection, not price",
+        "Recommends a done-for-you migration offer with a switching-cost guarantee",
+        "Suggests a bonus or risk-reversal that removes the real fear",
+        "Uses real scarcity (capacity/queue) rather than a fake timer"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/offers/references/saas-offers.md
+++ b/skills/offers/references/saas-offers.md
@@ -1,0 +1,116 @@
+# SaaS Offers — the discount trap + worked examples
+
+The rest of the offers library skews services, courses, and coaching. This reference covers the SaaS case specifically: why discounting is the wrong acquisition lever, and four worked offers that stack risk-reversal, bonuses, and scarcity for a software business.
+
+Read this alongside [offer-formats.md](offer-formats.md#self-serve-saas). For price level and tier structure, the `pricing` skill still does the heavier lifting — this covers the *offer* wrapped around the price.
+
+---
+
+## The discount trap
+
+The instinct when a SaaS isn't converting is to cut the price — a launch coupon, a "50% off first 3 months," a permanent lower tier. It's the most-reached-for lever and one of the worst.
+
+**Offers beat discounts.** A discount lowers the price. An offer raises the value — a guarantee, a done-for-you migration, a bonus that removes the switching cost. Same net price to the buyer, but one trains them to expect cheap and the other trains them to expect valuable.
+
+### The data
+
+**Discount-*askers* churn at roughly 2× the rate of full-price customers.** The buyer who negotiated their way in is signaling something: price was the reason they bought, not value. When a cheaper option appears — or when the renewal hits full price — they leave. You bought a customer who was never yours.
+
+This compounds. Discounting to acquire also:
+
+- **Anchors the product as cheap** — hard to raise later without churn spikes
+- **Attracts the wrong ICP** — price-shoppers, not value-buyers
+- **Trains the market to wait** — buyers learn there's always a sale coming, so they never pay full
+- Sits next to **trial fatigue and discount fatigue** — the same buyer who's seen a hundred "50% off" banners no longer feels urgency from yours
+
+### The rule
+
+**Never discount to acquire.** Discount only in two moments, where the mechanics actually work for you:
+
+| When | Why it works |
+|------|--------------|
+| **Upgrades / cross-sells** | The customer already values the product. A discount to move up a tier or add a product rewards commitment instead of buying a stranger. |
+| **Seasonal moments** | Black Friday, year-end, an annual-plan push — a real, time-bound, everyone-gets-it window. Not a permanent price cut wearing a costume. |
+
+Everything else is an **offer**, not a discount. If conversion is stuck at the top of the funnel, reverse the risk and stack the value — don't cut the price. See the four examples below.
+
+---
+
+## Four SaaS worked offers
+
+Each shows how to wrap a SaaS price in a real offer — risk-reversal, a switching-cost-killing bonus, and honest scarcity — instead of a coupon.
+
+### 1. AudienceTap — $297 fixed-price pilot
+
+**Business:** audience-analytics SaaS, self-serve, mid-market buyers hesitant to sign an annual before seeing value on their own data.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$297 fixed-price 30-day pilot** — full product, run against the buyer's real audience, not a demo dataset |
+| **Risk reversal** | "If the pilot doesn't surface an insight your team acts on, the $297 is refunded — and it credits toward annual if you convert." |
+| **Bonus** | A done-with-you setup session (connect sources, first report) so time-to-value is days, not weeks |
+| **Scarcity** | Capacity-real: "We onboard 6 pilots a month so each gets the setup session." Not a fake counter. |
+
+**Why it beats a discount:** the pilot is a paid, low-risk *yes* that filters for value-buyers. The $297 isn't a price cut — it's a fee that credits forward, so full-price annual is the default next step, not a negotiation.
+
+### 2. SaberSim — $497 bundle
+
+**Business:** sports-analytics/optimizer SaaS. Individual tools convert fine alone but the full stack is where retention lives.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$497 bundle** of the optimizer + sync + data feed — the tools that only pay off together |
+| **Risk reversal** | 14-day "run it on a real slate" guarantee — use it live, full refund if it doesn't beat the buyer's current workflow |
+| **Bonus** | Strategy walkthroughs + a starter template library so the bundle produces a result on day one |
+| **Scarcity** | Seasonal: bundle priced for the **start of the season**; after kickoff it unbundles to full à-la-carte |
+
+**Why it beats a discount:** the bundle raises perceived value (three tools, one decision) rather than lowering price on one. The season start is *real* seasonal scarcity — an allowed discount moment — not a permanent markdown.
+
+### 3. Teachable — $1,997 accelerator
+
+**Business:** course-platform SaaS. The subscription is cheap; the value (and the switching cost) is getting a course actually launched.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$1,997 "Launch Accelerator"** — the platform plan **plus** a structured 6-week program to ship the buyer's first course |
+| **Risk reversal** | Outcome guarantee: "Publish your course in 6 weeks or we work with you free until you do." Tied to a completion condition. |
+| **Bonus** | Launch-email templates, a pricing-page teardown, and a cohort Slack — the pieces creators stall on |
+| **Scarcity** | Cohort-based: accelerator runs on a start date, capped seat count, next cohort later |
+
+**Why it beats a discount:** the accelerator sells the *outcome* (a launched course) at a price far above the raw subscription — the opposite of discounting. The guarantee de-risks the real fear ("I'll pay and never launch"), and the cohort cap is honest scarcity.
+
+### 4. Kit — "Painless Switch" $997 migration offer
+
+**Business:** email-platform SaaS. The blocker isn't price — it's the terror of migrating a list, sequences, and automations off the incumbent.
+
+**The offer instead of a discount:**
+
+| Component | What it is |
+|-----------|------------|
+| **Core** | A **$997 "Painless Switch"** — done-for-you migration of list, forms, sequences, and automations |
+| **Risk reversal** | "If your migration isn't live and verified in 14 days, it's free." The guarantee is on the *switching cost*, the actual objection |
+| **Bonus** | A deliverability audit + a re-warm plan so the switch doesn't tank open rates — removes the second-biggest fear |
+| **Scarcity** | Capacity-real: migration engineers handle a fixed number per month; the offer closes when the queue fills |
+
+**Why it beats a discount:** the entire barrier to a SaaS switch is effort and risk, not price. A discount does nothing about migration dread; a done-for-you offer with a switching-cost guarantee removes it. The buyer pays *more* up front and churns *less*, because they're a value-buyer who committed.
+
+---
+
+## The pattern across all four
+
+| Offer | Price | Risk reversal is on… | Scarcity type |
+|-------|-------|----------------------|---------------|
+| AudienceTap pilot | $297 | Whether it surfaces an actionable insight | Capacity (setup sessions) |
+| SaberSim bundle | $497 | Whether it beats the current workflow | Seasonal (season start) |
+| Teachable accelerator | $1,997 | Whether the course actually launches | Cohort (start date + cap) |
+| Kit Painless Switch | $997 | Whether migration is live in 14 days | Capacity (engineer queue) |
+
+Notice what's *not* here: a coupon, a "% off," a slashed sticker price. Every one raises value and reverses the real risk — and the scarcity is either capacity, cohort, or a genuine seasonal window, never a fake timer.
+
+**The SaaS takeaway:** when conversion is stuck, your instinct will be to discount. Build the offer instead. Discount only to reward existing customers (upgrades, cross-sells) or in a real seasonal window — never to acquire a stranger you'll watch churn at 2×.

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -2,7 +2,7 @@
 name: onboarding
 description: When the user wants to optimize post-signup onboarding, user activation, first-run experience, or time-to-value. Also use when the user mentions "onboarding flow," "activation rate," "user activation," "first-run experience," "empty states," "onboarding checklist," "aha moment," "new user experience," "users aren't activating," "nobody completes setup," "low activation rate," "users sign up but don't use the product," "time to value," or "first session experience." Use this whenever users are signing up but not sticking around. For signup/registration optimization, see signup. For ongoing email sequences, see emails.
 metadata:
-  version: 2.0.0
+  version: 2.0.1
 ---
 
 # Onboarding CRO
@@ -25,7 +25,7 @@ Before providing recommendations, understand:
 ## Core Principles
 
 ### 1. Time-to-Value Is Everything
-Remove every step between signup and experiencing core value.
+Remove every step between signup and experiencing core value. Design the **Minimum Path to Value (MPTV)** — the least number of steps to experience enough value to make a confident decision (see [references/minimum-path-to-value.md](references/minimum-path-to-value.md)).
 
 ### 2. One Goal Per Session
 Focus first session on one successful outcome. Save advanced features for later.
@@ -34,11 +34,44 @@ Focus first session on one successful outcome. Save advanced features for later.
 Interactive > Tutorial. Doing the thing > Learning about the thing.
 
 ### 4. Progress Creates Motivation
-Show advancement. Celebrate completions. Make the path visible.
+Show advancement. Celebrate completions. Make the path visible. (See onboarding psychology below for the mechanisms.)
+
+---
+
+## Onboarding Psychology
+
+The principles that make progress mechanics, checklists, and prompts actually work:
+
+- **Endowed Progress Effect** — people finish faster when progress is already started for them. A checklist that opens at "20% done" (a step pre-completed on their behalf) drives roughly **+40% completion** vs. starting at 0%. Give users a head start, don't make them start from nothing.
+- **Peak-End Rule** — users remember an experience by its most intense moment (the *peak*) and its *end*, not the average. Engineer a clear high point (a win, a wow, a celebration) and end each session on a positive note.
+- **Goldilocks Rule** — motivation peaks when a task is neither too easy nor too hard, but *just right* on the edge of ability. Tune early steps so they're achievable but not trivial.
+- **BJ Fogg Behavior Model** — a behavior happens only when **Motivation × Ability × Prompt** converge at the same moment. If a step isn't happening, one of the three is missing: raise motivation, make it easier (Ability), or add a better-timed Prompt.
+- **Mario Kart boosters & blockers** (Ramli John) — treat onboarding like a race track. Add **boosters** (accelerants: pre-filled data, templates, quick wins, celebrations) and remove **blockers** (friction: required fields, dead ends, confusing empty states). Speed users toward value and clear obstacles from the lane.
+
+## Onboarding Toolkit (10 Components)
+
+The components you assemble an onboarding experience from. Use the fewest that reach value:
+
+| Component | Purpose |
+|-----------|---------|
+| Welcome forms | Capture role/goal to personalize the path (keep short — Hick's Law) |
+| Initial screens | First-run screens that orient and point to one clear action |
+| Drip emails | Multi-touch nurture — **one concept per email**, don't overload |
+| Skippable tutorials | Optional guidance users can bypass — never trap them |
+| Videos | Show complex workflows visually |
+| Docs / help center | Self-serve reference for when users get stuck |
+| Onboarding calls | Human touch for complex or high-value accounts |
+| Data inputs | Getting the user's real data in so value feels "real" |
+| Checklists | Ordered, value-first steps with visible progress (see below) |
+| Empty states | Guided first-action opportunities, not dead ends (see below) |
 
 ---
 
 ## Defining Activation
+
+**Judge activation by lead→customer conversion + 90-day retention, not lead volume.** More signups mean nothing if they don't convert and stick.
+
+Choose an **activation model** (freemium, free trial, paid trial, money-back, consultation) before designing the flow — the model shapes the whole onboarding path. See [references/activation-models.md](references/activation-models.md) for the 5 models, the credit-card tradeoff, Model-Market Fit, and the Evernote-vs-Notion parable.
 
 ### Find Your Aha Moment
 
@@ -199,6 +232,14 @@ When recommending experiments, consider tests for:
 - Support and help availability
 
 **For comprehensive experiment ideas**: See [references/experiments.md](references/experiments.md)
+
+---
+
+## References
+
+- **[references/minimum-path-to-value.md](references/minimum-path-to-value.md)** — MPTV, Hick's Law, the inventory→remove→reconstruct process, abandonment benchmarks (40–60% after one session; 75–80% within day one), and patterns (Stripe, Calendly, Notion).
+- **[references/activation-models.md](references/activation-models.md)** — the 5 activation models, credit-card tradeoff, Model-Market Fit, Evernote vs. Notion.
+- **[references/experiments.md](references/experiments.md)** — comprehensive A/B test and experiment ideas.
 
 ---
 

--- a/skills/onboarding/evals/evals.json
+++ b/skills/onboarding/evals/evals.json
@@ -87,6 +87,22 @@
         "Does not attempt signup form redesign using onboarding patterns"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We're launching a new B2B analytics product and can't decide how to let people try it. Should we do a free tier, a free trial, require a credit card, or something else? And once they're in, how do we make sure they actually reach value fast?",
+      "expected_output": "Should walk through the 5 activation models (freemium, free trial with 3/7/14/30-day options, paid trial, money-back guarantee, consultation/Superhuman-style) and help choose based on Model-Market Fit (Balfour — the market dictates the model). Should explain the credit-card tradeoff: requiring a card cuts signups 50–70% but converts 2–3× better. Should reference the Evernote-vs-Notion lesson (hook then limit vs. give away too much). Should then design the Minimum Path to Value (MPTV) — the least steps to enough value to decide — grounded in Hick's Law, using inventory → remove → reconstruct. Should cite abandonment reality (40–60% abandon after one session; 75–80% within the first day). May reference psychology mechanisms (Endowed Progress Effect, Peak-End, BJ Fogg, Mario Kart boosters/blockers). Should point to the activation-models and minimum-path-to-value references.",
+      "assertions": [
+        "Presents the 5 activation models",
+        "Applies Model-Market Fit to the choice",
+        "Explains the credit-card tradeoff (cuts signups 50-70%, 2-3x conversion)",
+        "References Evernote-vs-Notion hook-then-limit lesson",
+        "Designs a Minimum Path to Value grounded in Hick's Law",
+        "Uses inventory -> remove -> reconstruct process",
+        "Cites first-session/first-day abandonment stats",
+        "Points to activation-models.md and minimum-path-to-value.md references"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/onboarding/references/activation-models.md
+++ b/skills/onboarding/references/activation-models.md
@@ -1,0 +1,57 @@
+# Activation Models
+
+The activation model is *how* you let a user experience value before they pay. It shapes signup volume, conversion, and the entire onboarding path. Pick the model before you design the flow.
+
+## The 5 activation models
+
+### 1. Freemium
+A free tier that never expires, with paid tiers for more capacity or features.
+
+- Best when: the free tier delivers real value *and* naturally hits limits that motivate upgrading.
+- Risk: give away too much and users never need to pay (see Evernote below).
+
+### 2. Free trial
+Full (or near-full) access for a fixed window: **3, 7, 14, or 30 days**.
+
+- Shorter trials create urgency and force faster time-to-value; longer trials suit complex products with longer setup.
+- **Credit-card requirement is the key lever**: requiring a card up front **cuts signups by 50–70%**, but the users who do sign up **convert 2–3× better**. Fewer, higher-intent leads vs. more, lower-intent leads — choose based on your funnel goals.
+
+### 3. Paid trial
+A low-cost paid entry, typically **$7–10 for 7 days**.
+
+- Filters out tire-kickers while lowering the barrier vs. full price.
+- Signals seriousness on both sides and pre-collects payment details.
+
+### 4. Money-back guarantee
+Charge full price up front, with a no-questions refund window.
+
+- Removes purchase risk without giving anything away for free.
+- Works when the product delivers value quickly enough to beat the refund window.
+
+### 5. Consultation / white-glove
+A human conversation (demo, call, or hands-on setup) gates access — the **Superhuman** model.
+
+- Best for high-touch, high-price, or complex products where a human ensures the user reaches value.
+- Doesn't scale cheaply, but converts and retains well when done right.
+
+## Model-Market Fit
+
+**Model-Market Fit (Brian Balfour): "your market dictates your model."**
+
+You don't get to freely choose your activation model — your market chooses it for you. Price point, buyer sophistication, sales complexity, time-to-value, and competitor norms all constrain what will work. A self-serve $20/mo tool and a $50k enterprise platform cannot use the same model. Match the model to the market before optimizing the onboarding inside it.
+
+## The Evernote vs. Notion parable
+
+Two lessons on how much to give away:
+
+- **Evernote — gave away too much free.** The free tier was generous enough that most users never needed to upgrade. Free was a destination, not a doorway. Growth without matching monetization.
+- **Notion — hook, then limit.** Let users experience real value, then hit meaningful limits (blocks, members, features) that create a natural, well-timed reason to pay.
+
+The principle: **the free experience should hook, not satisfy.** Give enough value to prove the product and build the habit — but structure the limits so that continued value requires upgrading.
+
+## Choosing
+
+1. Start from your market (Model-Market Fit), not your preference.
+2. Decide the card-vs-no-card tradeoff explicitly: volume of leads vs. quality of leads.
+3. Design the free/trial experience to hook and then limit — never to fully satisfy.
+4. Whatever the model, the onboarding inside it still needs the shortest possible path to value (see [minimum-path-to-value.md](minimum-path-to-value.md)).

--- a/skills/onboarding/references/minimum-path-to-value.md
+++ b/skills/onboarding/references/minimum-path-to-value.md
@@ -1,0 +1,49 @@
+# Minimum Path to Value (MPTV)
+
+**Minimum Path to Value (MPTV)** — the least number of steps to experience *enough* value to make a confident decision.
+
+Not the fastest path to *any* value, and not the full feature tour. It's the shortest route to a moment that's convincing enough for the user to decide "yes, this is for me." Everything else waits.
+
+## Why fewer steps win: Hick's Law
+
+**Hick's Law** — the time and effort to make a decision grows with the number and complexity of choices. Every step, field, and option in onboarding is another decision. More decisions = more hesitation, more drop-off.
+
+MPTV is the deliberate application of Hick's Law to onboarding: strip the path down to the fewest decisions required to reach value.
+
+## The abandonment reality
+
+You have far less time and patience than you think:
+
+- **40–60% of users who sign up for a free trial abandon after a single session** — and never return.
+- **75–80% of trial abandonment happens within the first day.**
+
+The decision to stick or bail is made almost immediately. If value isn't reached in the first session, most users are already gone. MPTV exists because the window is that small.
+
+## The process: inventory → remove → reconstruct
+
+Build (or fix) your MPTV in three passes:
+
+1. **Take inventory.** List *every* step between signup and value — every screen, form field, click, confirmation, permission prompt, and empty state. Be exhaustive and honest. Most teams underestimate their own step count by half.
+
+2. **Remove the nonessential.** For each step ask: does the user *have* to do this to reach value right now? If not, cut it, defer it, pre-fill it, or make it skippable. Default to removal. Configuration, profile completeness, advanced settings, and "nice to know" education are almost never essential to first value.
+
+3. **Reconstruct / iterate.** Rebuild the path with only what survived, in value-first order. Then measure and iterate — the first reconstruction is a hypothesis, not a finish line. Watch where users still stall and cut again.
+
+## Benchmark patterns
+
+Products with famously short paths to value:
+
+| Product | MPTV pattern |
+|---------|--------------|
+| **Stripe** | Get a working payment integration in **~7 lines of code / ~60% activation** — value (a real charge) before any account polish. |
+| **Calendly** | **3-step** setup to a shareable, working booking link. Value is a link you can send immediately. |
+| **Notion** | **Progressive disclosure** — starts nearly empty, reveals features only as the user needs them. The path to first value (a written page) is trivial; depth unfolds later. |
+
+The pattern across all three: reach a real, usable outcome fast, and hide complexity until it's asked for.
+
+## Applying it
+
+- Define the value moment first (the aha moment — see SKILL.md). MPTV is the path *to* that moment.
+- Count your current steps before optimizing. You can't remove what you haven't inventoried.
+- Treat every retained step as guilty until proven essential.
+- Measure step-completion and time-to-value after each reconstruction; the abandonment stats mean your margin for error is one session.

--- a/skills/pricing/SKILL.md
+++ b/skills/pricing/SKILL.md
@@ -2,7 +2,7 @@
 name: pricing
 description: "When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,' 'packaging,' 'price increase,' 'value metric,' 'Van Westendorp,' 'willingness to pay,' 'monetization,' 'how much should I charge,' 'my pricing is wrong,' 'pricing page,' 'annual vs monthly,' 'per seat pricing,' 'should I offer a free plan,' 'pricing page teardown,' 'pricing page audit,' 'is my pricing page AI-readable,' or 'can AI read my pricing.' Use this whenever someone is figuring out what to charge, how to structure their plans, or wants to audit a pricing page (for humans and for the AI agents that shortlist tools). For in-app upgrade screens, see paywalls. For offer construction (bonuses, guarantees, value framing, naming) on services/courses/coaching/high-ticket B2B, see offers."
 metadata:
-  version: 2.1.0
+  version: 2.1.1
 ---
 
 # Pricing Strategy
@@ -65,6 +65,40 @@ Price should be based on value delivered, not cost to serve:
 
 **Key insight:** Price between the next best alternative and perceived value.
 
+**Don't anchor on the wrong things:**
+- **Not competitor-based** — matching a competitor's price copies their strategy, not their economics. It's a data point, not a target.
+- **Not cost-based** — cost is a floor, never the basis. Value + differentiation set the price.
+
+---
+
+## Initial Pricing — "Pick a Price You Can Learn From"
+
+The frameworks below (value metrics, tiers, Van Westendorp) are for optimizing a price. **On day one you don't have a price to optimize — you have a bet to place.** The goal of your first price is *learning*, not precision. Pick a number, ship it, and let real buyers tell you if it's wrong.
+
+### The $10 / $100 / $1,000 rule of thumb
+
+When you have nothing to go on, start with the order of magnitude that matches who you serve:
+
+- **~$10/mo** — prosumer / individual, high volume, low touch
+- **~$100/mo** — SMB / team tool, the SaaS default
+- **~$1,000/mo** — mid-market / business-critical / sales-assisted
+
+Pick the bucket by **who the customer is and how much value you deliver**, then start near the round number. You can move within the bucket fast once you have signal.
+
+### Avoid the $9 trap
+
+Resist the urge to price ultra-low (e.g. **$9/mo**) to reduce friction. Ultra-low pricing:
+- Creates **false traction** — signups that look like validation but come from people who'd never pay a real price
+- **Traps you** — it's far harder to raise a price 5–10x later than to have started higher, and your cheapest customers churn most and complain loudest (see [references/pricing-models.md](references/pricing-models.md) on low-price retention)
+
+Round-and-slightly-higher beats clever-and-cheap.
+
+### "Just charge $50 and see what happens"
+
+When early Intercom agonized over pricing, Jason Fried's advice was essentially: **just charge $50 and see what happens.** Stop modeling; get a real signal. If people pay without flinching, raise it. If nobody bites, you've learned something for the cost of a week, not a quarter.
+
+**For the eight ways to structure how you charge (flat, usage, tier, user, feature, credit, outcome, hybrid) and the value/price ratio:** See [references/pricing-models.md](references/pricing-models.md).
+
 ---
 
 ## Value Metrics
@@ -95,6 +129,8 @@ The value metric is what you charge for—it should scale with the value custome
 Ask: "As a customer uses more of [metric], do they get more value?"
 - If yes → good value metric
 - If no → price doesn't align with value
+
+**The value metric picks the pricing model.** Once you know what scales with value, choose how to charge on it — flat, usage, tier, user, feature, credit, outcome, or a hybrid. See [references/pricing-models.md](references/pricing-models.md).
 
 ---
 
@@ -164,6 +200,17 @@ Identifies which features customers value most:
 2. **Delayed increase** — Announce 3-6 months out
 3. **Tied to value** — Raise price but add features
 4. **Plan restructure** — Change plans entirely
+
+### Rollout Methodology
+
+A price change is a rollout, not a switch you flip. Sequence it to de-risk:
+
+1. **Test on new customers first.** Raise the price only for *new* signups and watch conversion. New customers have no anchor and no relationship at stake, so they give you a clean read on whether the market accepts the number — before you touch a single existing account.
+2. **Don't reflexively grandfather forever.** Grandfathering feels kind, but it can leave enormous money on the table. Run the math: a customer paying **$50/mo** who *should* be at **$250/mo** is a **$2,400/yr** gap — and $200/mo you're subsidizing indefinitely across your whole base. Grandfather as a *transition* (a grace period), not a permanent exemption.
+3. **Roll out small, then gradually.** Move **5–10%** of existing customers to the new price first. Watch churn and support volume for a cycle, then expand in staggered waves. A staggered rollout contains the blast radius and gives you an off-ramp if churn spikes.
+4. **Communicate the *why*, months ahead, with a generous offer.** Tell customers why the price is changing (usually: more value shipped) well in advance. Soften it: lock-in-the-old-price-if-you-upgrade-to-annual-now, an extended grace window, or a one-time credit. Advance notice + a generous option converts a resentment moment into a loyalty one.
+
+Expect — and accept — some churn. The customers most likely to leave over a justified increase are usually your least-profitable, highest-support, most price-sensitive accounts.
 
 ---
 

--- a/skills/pricing/evals/evals.json
+++ b/skills/pricing/evals/evals.json
@@ -99,6 +99,21 @@
         "Does not treat this as pure conversion-rate CRO"
       ],
       "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "We're launching an AI writing tool for solo creators next week and I genuinely have no idea what to charge on day one. I was going to just do $9/month to get people in the door. What price should I pick and how should I even structure it?",
+      "expected_output": "Should treat this as an INITIAL pricing question, not a price-optimization one — the goal of a first price is learning, not precision ('pick a price you can learn from'). Should apply the $10/$100/$1,000 rule of thumb and place a solo-creator tool near the ~$10 bucket. Should warn against the $9 trap (false traction, hard to raise later, cheapest customers churn most). May cite the Intercom/Jason Fried 'just charge $50 and see what happens' idea — ship a price and get real signal. Should reject competitor-based and cost-based anchoring in favor of value + differentiation. Should recommend a pricing MODEL/structure: for an AI actions-based tool, credit-based or usage-based (or a hybrid) is a natural fit; may reference the 8 models. May mention the ~10:1 value/price ratio and the low-price-hurts-retention counterpoint (when in doubt, price higher).",
+      "assertions": [
+        "Frames the first price as a learning bet, not an optimization",
+        "Applies the $10/$100/$1,000 rule of thumb and buckets the tool appropriately",
+        "Warns against the $9 / ultra-low trap (false traction, hard to raise, low-price churn)",
+        "References 'just charge $50 and see' / getting a real signal (Intercom/Jason Fried)",
+        "Rejects competitor-based and cost-based pricing in favor of value + differentiation",
+        "Recommends a pricing model/structure (e.g. credit-based or usage-based for an AI tool)",
+        "Notes value/price ratio (~10:1) or that low prices hurt retention"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/pricing/references/pricing-models.md
+++ b/skills/pricing/references/pricing-models.md
@@ -1,0 +1,66 @@
+# Pricing Models
+
+The eight core ways to structure *how* you charge. This is distinct from the value metric (what unit you charge on) and the tier structure (how you package). Most real products **combine** two or more of these.
+
+## Contents
+- The 8 Pricing Models
+- Combining Models
+- The Value/Price Ratio
+- The Low-Price Retention Counterpoint
+
+---
+
+## The 8 Pricing Models
+
+| Model | How it works | Best when | Reference |
+|-------|-------------|-----------|-----------|
+| **Flat-rate** | One price, one product, everyone pays the same | Simple product, one persona, you want zero pricing friction | Basecamp |
+| **Usage-based** | Pay for what you consume (metered) | Value scales directly with volume; consumption is variable and easy to meter | Stripe |
+| **Tier-based** | Good-better-best packages at set prices | Distinct segments with different needs and budgets | Kinsta |
+| **User-based** | Price per seat/user | Value grows as more people in the org use it (collaboration) | Notion |
+| **Feature-based** | Price gated by which capabilities are unlocked | Clear feature tiers map to willingness to pay | Intercom |
+| **Credit-based** | Buy a bucket of credits, spend them on actions | Usage is lumpy or bursty; you want prepaid commitment and simple mental accounting | Audible |
+| **Outcome-based** | Pay per result delivered (resolution, task completed) | You can measure and attribute the outcome, and the outcome is what the buyer actually wants | Intercom Fin, Zapier |
+| **Hybrid** | Deliberate mix (e.g. platform fee + usage, or seats + credits) | A single model under- or over-charges different customers | Drift |
+
+### When to reach for each
+
+- **Flat-rate** — reach for it first if you can. It's the easiest to sell, easiest to understand, easiest to forecast. The tradeoff: you leave money on the table with your biggest customers.
+- **Usage-based** — the fairest model when consumption tracks value, but revenue is less predictable and buyers fear a surprise bill. Pair with spend caps or alerts.
+- **Tier-based** — the default for self-serve SaaS. Lets one page serve SMB through mid-market.
+- **User-based** — only if value genuinely rises with headcount. If it doesn't, seats punish adoption (teams share logins to avoid paying).
+- **Feature-based** — powerful for segmentation, but don't gate the feature that delivers your core value; gate the ones that separate casual from serious users.
+- **Credit-based** — good for AI/actions-based products where each action has a cost. Credits decouple price from a single unit and make prepayment feel natural.
+- **Outcome-based** — the emerging model for AI agents (charge per resolved ticket, per automation run). Highest trust because the buyer only pays when they win — but only viable when the outcome is measurable and clearly attributable to you.
+- **Hybrid** — where most mature products end up. A base platform fee for predictability plus a usage/outcome component for upside.
+
+---
+
+## Combining Models
+
+These aren't mutually exclusive. Common combinations:
+
+- **Tiers + per-user** — seats within each package (most B2B SaaS)
+- **Platform fee + usage** — predictable base, variable upside (Twilio-style)
+- **Seats + credits** — pay per person, then top up credits for heavy actions
+- **Feature tiers + outcome** — unlock capabilities by tier, charge per result on top
+
+Pick the primary model from the value metric, then layer a second only if a single model clearly mis-prices a real segment.
+
+---
+
+## The Value/Price Ratio
+
+Aim for roughly a **10:1 value-to-price ratio** (Ryan Kulp): the customer should perceive about **10x more value than they pay**. This is the buffer that makes the purchase feel obvious rather than negotiated, and it leaves headroom to raise prices later as you add value.
+
+If you can't articulate 10x value, the problem is usually the offer or the positioning, not the price point.
+
+---
+
+## The Low-Price Retention Counterpoint
+
+Charging too little is not the safe choice. **Low prices hurt retention** (Patrick Campbell / ProfitWell data, echoed by operators like Josh Pigford of SpyFu and Tyler Tringas): under-priced customers churn *more*, not less, because a low price signals low value and attracts the least-committed, most price-sensitive buyers.
+
+Related: the **discount-asker signal** — customers who negotiate for a discount tend to churn at roughly **2x** the rate of full-price customers. Discounting to close a deal often buys a customer who leaves anyway.
+
+**Implication:** when in doubt, price higher. It's easier to grandfather a price down than to claw one up, and a higher price selects for better-fit, longer-retained customers.

--- a/skills/public-relations/SKILL.md
+++ b/skills/public-relations/SKILL.md
@@ -2,7 +2,7 @@
 name: public-relations
 description: "When the user wants help with public relations, earned media, press coverage, journalist outreach, or media strategy (not pull requests). Also use when the user mentions 'PR,' 'public relations,' 'press,' 'press release,' 'press coverage,' 'media outreach,' 'pitch a journalist,' 'get featured,' 'media list,' 'media kit,' 'press kit,' 'newsjacking,' 'news hijack,' 'HARO,' 'Qwoted,' 'Featured,' 'Help A Reporter,' 'reporter request,' 'tech press,' 'TechCrunch,' 'earned media,' 'thought leadership placement,' 'op-ed,' 'guest article,' 'press contacts,' 'podcast prep,' 'going on a podcast,' 'podcast guest,' 'prep me for this podcast,' or 'how do I get press.' Use this for earned media work — finding journalists, pitching stories, newsjacking, prepping podcast appearances, and responding to press requests. For startup/SaaS/AI directory submissions, see directory-submissions. For product launches, see launch. For social-media engagement, see social. For cold-email outreach to prospects, see cold-email."
 metadata:
-  version: 1.1.0
+  version: 1.1.1
 ---
 
 # Public Relations & Earned Media
@@ -22,7 +22,8 @@ PR is not a substitute for distribution. It's a multiplier for it.
 
 - **Earned media doesn't drive direct conversions.** A TechCrunch hit will not give you 1,000 paying customers. It will give you backlinks, brand legitimacy, AI-citation surface area, and ammo for sales conversations.
 - **Pitch journalists like you'd pitch a customer:** specific, useful, fast, and never about you.
-- **The story is not your product. The story is the trend, the data, the conflict, or the human.** Your product is the evidence.
+- **The story is not your product. The story is the trend, the data, the conflict, or the human.** Your product is the evidence. Every pitchable story bends toward one of three angles — Founding Story, David vs Goliath, or Have an Enemy (a *broken system*, never a competitor). See [references/story-angles.md](references/story-angles.md).
+- **Chase press for the compound effect, not the traffic bump.** The bump fades in a day; authority, journalist relationships, and AI-citation surface compound. Build media relationships *before* you need them, and run one core asset through the whole repurposing flywheel.
 - **Speed beats polish on reactive PR.** A B+ pitch in the first hour of a story beats an A+ pitch on day three.
 
 ### When PR is worth it
@@ -49,6 +50,8 @@ Four modes. Most teams over-index on one. Run at least three.
 | **Proactive (pitching)** | Build a media list, pitch original stories | High | 2–8 weeks |
 | **Inbound (press requests)** | Respond to journalist queries on HARO/Qwoted/Featured | Low | Days to weeks |
 | **Owned (press page + media kit)** | Make it easy for journalists to find you | One-time setup | N/A |
+
+**For the story angle taxonomy (Founding Story / David vs Goliath / Have an Enemy), data stories, media relationship-building, and the PR repurposing flywheel** — see [references/story-angles.md](references/story-angles.md)
 
 **For the reactive newsjacking workflow** — see [references/newsjacking.md](references/newsjacking.md)
 
@@ -125,6 +128,9 @@ Go to [journalist-pitching.md](references/journalist-pitching.md), use the disco
 
 ### "What's worth pitching this week?"
 Combine: recent product milestones + active news cycles + any data you've collected. Score each potential story by the quality bar above.
+
+### "What's my story angle?" / "How do I get press with no news?"
+Go to [story-angles.md](references/story-angles.md). Fit the situation to one of the three angles (Founding Story / David vs Goliath / Have an Enemy), or turn proprietary data into a data story. Remember: a milestone alone isn't a story — milestone *with narrative* is.
 
 ### "Respond to this HARO query"
 Go to [press-platforms.md](references/press-platforms.md), use the response template, keep it under 200 words.

--- a/skills/public-relations/evals/evals.json
+++ b/skills/public-relations/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "public-relations",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We're a tiny 2-person SaaS competing against Notion in the docs space. We don't have any funding news or a big milestone. How do we get press coverage?",
+      "expected_output": "Should route to references/story-angles.md. Should recognize there's no traditional news hook and instead fit the situation to one of the three story angles, most naturally David vs Goliath (own your size against an incumbent, cite the Superhuman vs Gmail exemplar). Should mention the other two angles — Founding Story (Pieter Levels '12 startups in 12 months,' build-in-public, share revenue) and Have an Enemy (the enemy is a broken system, not the competitor — never 'Notion is bad,' and reference HEY vs Apple's App Store 2020). Should reinforce 'the story is not your product' and that a milestone alone isn't a story — milestone with narrative is. Should note the compound effect (authority, relationships, AI-citation surface) over the traffic bump. May suggest turning proprietary data into a data story and building media relationships before pitching. Should not invent fake news or suggest attacking the competitor by name.",
+      "assertions": [
+        "Routes to references/story-angles.md",
+        "Identifies David vs Goliath as the fitting angle with the Superhuman vs Gmail exemplar",
+        "Names all three angles (Founding Story, David vs Goliath, Have an Enemy)",
+        "Clarifies the enemy is a broken system, not a named competitor (HEY vs Apple App Store 2020)",
+        "Cites Pieter Levels '12 startups in 12 months' for Founding Story",
+        "Reinforces 'the story is not your product'",
+        "Notes milestone-with-narrative and/or the compound effect over the traffic bump",
+        "Does not fabricate news or suggest smearing the competitor by name"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/public-relations/references/story-angles.md
+++ b/skills/public-relations/references/story-angles.md
@@ -1,0 +1,87 @@
+# Story Angles — What Earns Press
+
+Distilled from Corey Haines's *Founding Marketing*, ch. 5. Chase press for the **compound effect** — authority, journalist relationships, AI-citation surface — not the traffic bump. The bump fades in a day; the backlinks, the relationships, and the citable record don't.
+
+**The story is not your product.** Journalists write about trends, data, conflict, and humans. Your product is the evidence, never the headline. If the pitch is "we built a thing," there's no story. If the pitch is "here's a shift happening and we're proof of it," there is.
+
+## Contents
+- The three story angles
+- Newsworthy moments (data stories)
+- Build media relationships before you need them
+- The PR flywheel (repurposing map)
+
+---
+
+## The Three Story Angles
+
+Every earned-media story worth pitching bends toward one of three shapes. Pick the one that fits your moment — don't force all three.
+
+### 1. Founding Story
+
+The origin, the build, the numbers-in-public. Works because people follow *people*, and a founder with skin in the game is quotable in a way a product never is.
+
+- **When to use:** you're early, you have a sharp personal reason you exist, and you're willing to build in public and share real revenue.
+- **Exemplar:** Pieter Levels' "12 startups in 12 months" — shipping in the open, posting MRR screenshots, letting the challenge itself be the story. The build *was* the coverage.
+- **How to run it:** share the arc (why you started, what you've learned, where the numbers are now), not the feature list. Revenue transparency is the hook most founders are too scared to use.
+
+### 2. David vs Goliath
+
+Own your size. Being small against an incumbent is an advantage in the story, not a liability — you're the underdog readers root for.
+
+- **When to use:** there's a giant in your category and you do one thing dramatically better than they do.
+- **Exemplar:** Superhuman vs Gmail — a tiny team reframing "we're small" into "we're the fast, obsessive alternative to the default everyone tolerates."
+- **How to run it:** name the Goliath, name the one thing you beat them at, and let the size gap do the emotional work. Don't hide that you're small — lead with it.
+
+### 3. Have an Enemy
+
+Give the reader something to be against. The enemy is a **broken system**, not a competitor. Attacking a rival looks petty; attacking a genuinely broken status quo looks principled — and journalists cover principled fights.
+
+- **When to use:** there's a systemic wrong in your space you can credibly stand against, and you're willing to take a real position.
+- **Exemplar:** HEY vs Apple's App Store (2020) — the fight wasn't "Basecamp vs Apple the company," it was against App Store rules founders saw as broken. It became a press cycle *and* a policy conversation.
+- **How to run it:** define the broken system precisely, stake a clear position, and make sure you're actually willing to be quoted taking that stance. A half-hearted enemy reads as a marketing stunt.
+
+**Guardrail:** the enemy must be a system or a norm — never a named competitor. "Company X is bad" is a smear; "this way of doing things is broken" is a movement.
+
+---
+
+## Newsworthy Moments: Data Stories
+
+Beyond the three angles, the most reliably pitchable moment is a **data story** — proprietary numbers no one else has, packaged as an industry benchmark. Journalists can build a whole piece around a stat; you get the citation.
+
+- **Exemplars:** Stripe's *State of New User* / annual data reports; Intercom's benchmark reports. Each turns internal data into an annual, citable, must-cover event.
+- **Why it works:** it's original, it's quotable, and it positions you as the source-of-record for your category's numbers. It also compounds in AI answers — benchmark stats get lifted and re-cited for years.
+- **How to run it:** find the one number in your data that surprises, wrap it in methodology, and package it as a standalone one-pager (not your homepage). See [journalist-pitching.md](journalist-pitching.md) → the "Data story" template.
+
+**Milestone reminder:** a milestone alone ("we hit $1M ARR") isn't a story — milestone *with narrative* is. Attach the number to a shift, a lesson, or a David-vs-Goliath frame.
+
+---
+
+## Build Media Relationships Before You Need Them
+
+Cold-pitching a journalist the day you have news is the hard way. The founders who get covered built the relationship months earlier. It's a ladder — climb it before you need the favor.
+
+1. **Follow their beat.** Read their last 5 articles. Know what they cover and what they're tired of covering. (See the discovery checklist in [journalist-pitching.md](journalist-pitching.md).)
+2. **Add value with no ask.** Reply to their work with a genuinely useful data point or correction. Share their pieces. Answer a question they post on X. Give before you take.
+3. **Be a reliable source.** When they need a quote fast, be the person who responds in 20 minutes with a clean, quotable line — even when there's nothing in it for you. Reliability is what turns a contact into a relationship.
+
+Do this for a handful of journalists on your beat and, when you finally have a real story, you're pitching a relationship, not a stranger.
+
+---
+
+## The PR Flywheel (Repurposing Map)
+
+One core asset feeds every other channel. Don't create five things — create one exceptional thing and reformat it five ways. Each format extends the reach of the same idea and gives journalists more of a public trail to find.
+
+```
+Core asset (data report / strong POV / founding story)
+    │
+    ├─→ Thread (X / LinkedIn) — the hook, teased publicly
+    ├─→ Article (your blog) — the full argument, the destination
+    ├─→ Guest post (someone else's audience) — borrow reach
+    ├─→ Podcast appearance — the spoken, citable version
+    └─→ Video — the durable, AI-crawled version
+```
+
+- **Sequence matters less than coverage.** Publish the article as the owned home base, tease it as a thread, pitch the guest post and podcast off the same idea, cut the video from the recording.
+- **Every format strengthens the next pitch.** A journalist who can find your thread, article, and podcast on a topic sees a voice in the space — not an opportunist. This is the public trail that makes newsjacking land (see [newsjacking.md](newsjacking.md) → The Public Trail).
+- **The asset is the flywheel's fuel.** One strong data story or POV can run this loop for weeks. Weak assets stall it immediately.

--- a/skills/referrals/SKILL.md
+++ b/skills/referrals/SKILL.md
@@ -2,7 +2,7 @@
 name: referrals
 description: "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch."
 metadata:
-  version: 2.1.0
+  version: 2.0.1
 ---
 
 # Referral & Affiliate Programs

--- a/skills/referrals/SKILL.md
+++ b/skills/referrals/SKILL.md
@@ -2,7 +2,7 @@
 name: referrals
 description: "When the user wants to create, optimize, or analyze a referral program, affiliate program, or word-of-mouth strategy. Also use when the user mentions 'referral,' 'affiliate,' 'ambassador,' 'word of mouth,' 'viral loop,' 'refer a friend,' 'partner program,' 'referral incentive,' 'how to get referrals,' 'customers referring customers,' or 'affiliate payout.' Use this whenever someone wants existing users or partners to bring in new customers. For launch-specific virality, see launch."
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Referral & Affiliate Programs
@@ -35,6 +35,20 @@ Gather this context (ask if not provided):
 ### 4. Resources
 - Tools/platforms you use or consider?
 - Budget for referral incentives?
+
+---
+
+## Should You Engineer Virality First?
+
+Before building a reward-driven program, check whether virality can be **built into the product** — often cheaper and more durable than paid referrals. But **don't force virality where it doesn't naturally fit.**
+
+Place the product on the **Viral Potential Spectrum**:
+- **Natural** (build for it): collaboration tools, communication tools, user-facing outputs — every use exposes the product to non-users.
+- **Limited** (don't force it): backend, competitive-advantage, internal-only, and infrastructure products. Invest in referral programs, content, and partnerships instead.
+
+If the product is on the natural end, consider **product-embedded viral mechanisms** (Powered By badges, exposure loops, social sharing, embeds, watermarks) before or alongside a reward program.
+
+**For the spectrum diagnostic, the 7 viral mechanisms, value-presentation and timing best practices, and affiliate power-law mechanics**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 
@@ -99,7 +113,11 @@ Trigger Moment → Share Action → Convert Referred → Reward → (Loop)
 
 **Tiered rewards**: Gamifies referral process, increases engagement
 
+**Present the reward with the bigger-*feeling* number** — "lead with the larger number" (say "$10 off," not "40% off," on a low-priced product). Reward at the **aha moment or milestone**, not signup. Reduce friction: one-click share, pre-written messages.
+
 **For examples and incentive sizing**: See [references/program-examples.md](references/program-examples.md)
+
+**For product-embedded virality, value-presentation rules, and affiliate power-law mechanics**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 
@@ -219,6 +237,8 @@ They get [their reward] too.
 ## Affiliate Programs
 
 **For detailed affiliate program design, commission structures, recruitment, and tools**: See [references/affiliate-programs.md](references/affiliate-programs.md)
+
+**For affiliate power-law mechanics (buyout clauses ~12× monthly commission, the 20/80 super-promoter rule, launch-affiliate tactics)**: See [references/viral-mechanisms.md](references/viral-mechanisms.md)
 
 ---
 

--- a/skills/referrals/evals/evals.json
+++ b/skills/referrals/evals/evals.json
@@ -84,6 +84,20 @@
         "Provides specific referral email copy or template"
       ],
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "We build a collaborative design tool. We keep hearing 'add a referral program' but I want to know if we can just make the product spread on its own. What are our options?",
+      "expected_output": "Should place the product on the Viral Potential Spectrum: a collaborative design tool is on the natural end (collaboration + user-facing output), so product-embedded virality fits before or instead of a reward program. Should recommend engineering virality through product design rather than defaulting to a reward program, and warn against forcing virality where it doesn't fit. Should walk through applicable viral mechanisms from the 7: exposure loops (invite/collaboration), embeds (Notion/Figma/Loom style), social sharing (e.g. a #MadeWith hashtag), and Powered By / watermark badges on free-tier output. Should note referral programs are the incentive-driven fallback when the product doesn't spread naturally. Should reference viral-mechanisms.md.",
+      "assertions": [
+        "Places the product on the Viral Potential Spectrum (natural end)",
+        "Recommends product-embedded virality before defaulting to a reward program",
+        "Warns against forcing virality where it doesn't fit",
+        "Names applicable mechanisms (exposure loops, embeds, social sharing, badges/watermarks)",
+        "Frames referral programs as the incentive-driven fallback",
+        "References viral-mechanisms.md"
+      ],
+      "files": []
     }
   ]
 }

--- a/skills/referrals/references/viral-mechanisms.md
+++ b/skills/referrals/references/viral-mechanisms.md
@@ -1,0 +1,102 @@
+# Viral Mechanisms
+
+Virality can be **engineered through product design**, not just bought with reward programs. But don't force it — decide *whether* virality fits your product before building anything.
+
+## Contents
+- Viral Potential Spectrum (the diagnostic)
+- The 7 Viral Mechanisms
+- Referral Best Practices (presentation, timing, friction)
+- Affiliate Mechanics (buyout clauses, the 20/80 power law, launch tactics)
+
+---
+
+## Viral Potential Spectrum
+
+Before engineering virality, place your product on the spectrum. **Don't force virality where it doesn't naturally fit.**
+
+**Natural viral potential (build for it):**
+- **Collaboration tools** — value grows when you invite others (docs, whiteboards, project management)
+- **Communication tools** — you can't use them alone (email, scheduling, messaging)
+- **User-facing outputs** — every use produces something others see (design, video, forms, links)
+
+**Limited viral potential (don't force it):**
+- **Backend / infrastructure** — invisible to end users
+- **Competitive-advantage tools** — users *hide* that they use them (their edge)
+- **Internal-only tools** — never leave the org
+- **Infrastructure** — plumbing no one talks about
+
+If you're on the limited end, invest in referral programs, content, and partnerships instead of embedding viral loops that won't fire.
+
+---
+
+## The 7 Viral Mechanisms
+
+Most are **non-incentive** — the loop is built into the product, not paid for.
+
+### 1. "Powered By" Badges
+A small attributed badge on user-facing output ("Powered by [Product]"). Every page/form/widget a customer ships becomes an ad. Often free-tier only (paid tier removes it).
+
+### 2. Exposure Loops
+The product's normal use exposes it to non-users.
+- **Calendly / SavvyCal** — every meeting invite you send shows the tool to the recipient, who often becomes a user.
+- **Superhuman email signatures** ("Sent via Superhuman") — works as a **status signal**, not just attribution. The signature signaled early-adopter status, so recipients *wanted* it. Exposure loops are strongest when using the product confers status.
+
+### 3. Social Sharing
+Make output natively shareable with a branded hook.
+- **#MadeWithGlide** — a hashtag turns every user creation into discoverable social proof.
+- One-tap "share to X/LinkedIn" on any milestone, result, or artifact.
+
+### 4. Embed Options
+Let users embed their content elsewhere; the embed carries your brand and a link back.
+- **Notion, Figma, Loom** — embedded docs, designs, and videos spread the product to every viewer on every host site.
+
+### 5. Watermarks / Mandatory Badges
+Like "Powered By" but harder to remove — baked into the output itself.
+- **OpusClips** watermark on generated clips.
+- **"Made in Webflow"** badge on free-plan sites.
+Free tier carries the mark; paid tier removes it. The free users become the distribution.
+
+### 6. Referral Programs
+Explicit incentives for referring. Covered in detail in [program-examples.md](program-examples.md) and below. The one *incentive-driven* mechanism on this list — use it when the product itself doesn't naturally spread.
+
+### 7. Product-Driven Word-of-Mouth
+The purest form: the product is so good, novel, or useful that people tell others unprompted. Not a mechanism you bolt on — it's earned through the product experience. Engineering the other six makes this easier to trigger.
+
+---
+
+## Referral Best Practices
+
+Detail beyond the core referral loop (trigger → share → convert → reward).
+
+### Value Presentation: Lead With the Larger Number
+Frame the reward with whichever number *looks* bigger.
+- On a $25 product, say **"$10 off"** — not "40% off."
+- On a $500 product, say **"20% off"** — not "$100 off" if the percentage frames better... but usually the absolute dollar figure wins for smaller prices.
+- Rule of thumb: **under ~$100, lead with the dollar amount; over ~$100, test the percentage.** Always pick the bigger-*feeling* number.
+
+### Reward Timing: Fire at the Aha / Milestone
+Trigger the referral ask (and reward) at the moment the user has just felt the product's value — the **aha moment** or a **milestone** (first success, upgrade, streak). Motivation to share peaks right after value is experienced, not at signup.
+
+### Double-Sided Rewards
+Both referrer and referred get value. Higher conversion than single-sided, and gives the referrer a generous, non-selfish reason to share ("here's $10 for you too").
+
+### Friction Reduction
+Every extra step kills share rate.
+- **One-click sharing** — pre-generated link, no form.
+- **Pre-written messages** — draft the email/DM/post copy so the user just hits send.
+- In-product placement at the trigger moment, not buried in settings.
+
+---
+
+## Affiliate Mechanics
+
+Detail deferred from the partnerships side — for building an affiliate motion into a referral/partner strategy.
+
+### Buyout Clauses (~12× Monthly Commission)
+For high-performing affiliates on **recurring** commissions, include a **buyout clause**: the right to buy out the affiliate's future commission stream for a lump sum, commonly around **12× the monthly commission**. Protects margin on a customer the affiliate referred once but earns on forever, and gives the affiliate an attractive cash-out.
+
+### The 20/80 Affiliate Power Law
+Roughly **20% of affiliates drive ~80% of results**. Don't spread effort evenly across a long tail of dormant sign-ups. **Identify super-promoters and invest in them** — higher tiers, custom assets, co-marketing, direct relationship, early access. Recruiting 1,000 passive affiliates is worth less than activating 10 great ones.
+
+### Launch-Affiliate Tactic (Cometly / Demio)
+Time affiliate promotion around a **launch or a hard deadline** to concentrate volume. Cometly drove **$251K on a single launch day** by mobilizing affiliates simultaneously; Demio ran launch-window affiliate pushes. The mechanic: give affiliates a shared date, shared assets, and a reason for their audience to act *now* (bonus, cohort, closing offer) so promotion stacks instead of trickling.


### PR DESCRIPTION
## Summary
Batch enrichment of **15 existing skills**, distilled from Corey Haines's *Founding Marketing* book (full 19-chapter scan). Repo **2.10.4 → 2.10.5**. No new skills.

This integrates PRs #544–#558 (one per skill) onto a single branch so they land together as one coherent release; each original commit is preserved, so those PRs auto-close as merged.

## What's added (all patch bumps)
| Skill | Add | Ch |
|---|---|---|
| ads | Payback Period gate (anti-LTV:CAC) | 7 |
| customer-research | primary research: PMF survey, 5-why, interview template | 2 |
| onboarding | Minimum Path to Value + 5 activation models + psychology | 16 |
| pricing | learning-price + 8 pricing models + rollout method | 15–16 |
| co-marketing | 5 partnership types + "permissionless co-marketing" | 11 |
| marketing-ideas | guerrilla marketing reference + case library | 13 |
| copywriting | "Now you can" test, Human Action Model, Perception Gap | 3 |
| public-relations | 3 story angles + PR flywheel | 5 |
| content-strategy | Create Once Distribute Twice distribution spine | 6, 14 |
| referrals | product-embedded virality: 7 mechanisms | 10–11 |
| free-tools | named case benchmarks + pitfalls | 8 |
| community-marketing | 5 community models + scaling phases | 12 |
| offers | discount trap + SaaS offer examples | 15 |
| marketing-plan | marketing-as-investing + 70/20/10 | 1, 17 |
| launch | SLC pre-launch readiness gate | 1 |

## Validation
`validate-skills.sh` → **49 passed, 0 warnings**. Every skill's `metadata.version` matches its VERSIONS.md row; all eval JSON valid. content-strategy and referrals were normalized from minor to patch bumps for consistency with AGENTS.md.

Source captured to the second-brain vault (`resource-founding-marketing-book.md`). Excludes the two new-skill candidates (positioning, international-expansion) per direction — existing-skill updates only.
