### PR TITLE
feat: add optional MuAPI video generation CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.11.0",
+      "version": "2.11.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -53,9 +53,13 @@ Current versions of all skills. Agents can compare against local versions to che
 | site-architecture | 2.0.0 | 2026-05-05 |
 | sms | 1.0.0 | 2026-05-21 |
 | social | 2.2.0 | 2026-07-09 |
-| video | 2.1.0 | 2026-07-14 |
+| video | 2.2.0 | 2026-08-24 |
 
 ## Recent Changes
+
+### 2.11.1 (2026-08-24)
+
+- **video** (2.1.0 → 2.2.0): added an optional MuAPI text-to-video and image-to-video CLI with live model metadata discovery, schema-aware payload validation, single-submit semantics, bounded result polling, HTTPS-only downloads, dry runs, focused contract tests, and an integration guide.
 
 ### 2.11.0 (2026-08-23)
 

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -126,6 +126,26 @@ export const ProductDemo: React.FC<{ title: string; features: string[] }> = ({
 
 Generate original footage from text or image prompts. Use for B-roll, hero visuals, and scenes you can't practically film.
 
+### MuAPI (optional hosted generation)
+
+Use MuAPI when the user wants a single API route across current video models or needs an
+agent-callable text-to-video/image-to-video workflow. The repository includes a zero-dependency
+CLI at `tools/clis/muapi-video.js` that discovers the selected model's current metadata, validates
+the request shape, submits exactly once, polls result GETs with a finite budget, and downloads an
+HTTPS output without forwarding credentials.
+
+```bash
+MUAPI_API_KEY=<key> node tools/clis/muapi-video.js generate \
+  --model hunyuan-text-to-video \
+  --prompt "a slow product reveal on a sunlit studio table" \
+  --aspect-ratio 16:9 --output product-reveal.mp4
+```
+
+Generation consumes credits. Confirm the request with the user before the POST, use `--dry-run`
+to inspect the payload without a key or network call, and never retry an ambiguous generation
+submission. See [the MuAPI integration guide](../../tools/integrations/muapi-video.md) and the
+[MuAPI AI Video API](https://muapi.ai/ai-video-api) for the current model catalog and access path.
+
 ### Model Comparison
 
 | Model | Resolution | Max Duration | Best For | Cost |

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -92,6 +92,7 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 | airops | AI Content | ✓ | - | [✓](clis/airops.js) | - | [airops.md](integrations/airops.md) |
 | buffer | Social | ✓ | - | [✓](clis/buffer.js) | - | [buffer.md](integrations/buffer.md) |
 | wistia | Video | ✓ | - | [✓](clis/wistia.js) | - | [wistia.md](integrations/wistia.md) |
+| muapi-video | Video generation | - | - | [✓](clis/muapi-video.js) | ✓ | [muapi-video.md](integrations/muapi-video.md) |
 | heygen | Video | ✓ | ✓ | - | ✓ | [heygen.md](integrations/heygen.md) |
 | hyperframes | Video | - | - | ✓ | ✓ | [hyperframes.md](integrations/hyperframes.md) |
 | trustpilot | Reviews | ✓ | - | [✓](clis/trustpilot.js) | - | [trustpilot.md](integrations/trustpilot.md) |

--- a/tools/clis/README.md
+++ b/tools/clis/README.md
@@ -63,6 +63,7 @@ Every CLI reads credentials from environment variables:
 | `linkedin-ads` | `LINKEDIN_ACCESS_TOKEN` |
 | `livestorm` | `LIVESTORM_API_TOKEN` |
 | `mailchimp` | `MAILCHIMP_API_KEY` |
+| `muapi-video` | `MUAPI_API_KEY` |
 | `mention-me` | `MENTIONME_API_KEY` |
 | `meta-ads` | `META_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID` |
 | `mixpanel` | `MIXPANEL_TOKEN` (ingestion), `MIXPANEL_API_KEY` + `MIXPANEL_SECRET` (query) |
@@ -165,6 +166,7 @@ DOMAINS=$(rewardful affiliates list | jq -r '.data[].email')
 | `linkedin-ads.js` | Ads | [LinkedIn Ads](https://business.linkedin.com/marketing-solutions/ads) |
 | `livestorm.js` | Webinar | [Livestorm](https://livestorm.co) |
 | `mailchimp.js` | Email | [Mailchimp](https://mailchimp.com) |
+| `muapi-video.js` | Video | [MuAPI](https://muapi.ai/ai-video-api) |
 | `mention-me.js` | Referral | [Mention Me](https://www.mention-me.com) |
 | `meta-ads.js` | Ads | [Meta Ads](https://www.facebook.com/business/ads) |
 | `mixpanel.js` | Analytics | [Mixpanel](https://mixpanel.com) |

--- a/tools/clis/muapi-video.js
+++ b/tools/clis/muapi-video.js
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * MuAPI video CLI for text-to-video and image-to-video marketing footage.
+ *
+ * The default API origin is intentionally fixed to api.muapi.ai. Generation
+ * POSTs are sent once; only bounded result GET polling is retried. Credentials
+ * are never included in model-output downloads.
+ */
+
+const API_BASE = 'https://api.muapi.ai';
+const DEFAULT_MODEL = 'hunyuan-text-to-video';
+const DEFAULT_MAX_POLLS = 60;
+const MAX_ALLOWED_POLLS = 120;
+const RETRYABLE_STATUS = new Set([408, 429]);
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      result._.push(arg);
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith('--')) {
+      result[key] = next;
+      index += 1;
+    } else {
+      result[key] = true;
+    }
+  }
+  return result;
+}
+
+function requireApiKey() {
+  const key = process.env.MUAPI_API_KEY;
+  if (!key) throw new Error('MUAPI_API_KEY environment variable required');
+  return key;
+}
+
+function modelProfile(model) {
+  const profiles = {
+    'hunyuan-text-to-video': {
+      category: 'Text to Video',
+      endpoint: '/api/v1/hunyuan-text-to-video',
+      input: { prompt: { type: 'string' }, aspect_ratio: { enum: ['16:9', '9:16', '1:1'] } },
+    },
+    'hunyuan-image-to-video': {
+      category: 'Image to Video',
+      endpoint: '/api/v1/hunyuan-image-to-video',
+      input: {
+        prompt: { type: 'string' },
+        image_url: { type: 'string' },
+        aspect_ratio: { enum: ['16:9', '9:16', '1:1'] },
+      },
+    },
+  };
+  return profiles[model] || null;
+}
+
+function inputSchema(modelDetails) {
+  return modelDetails?.input_schema?.schemas?.input_data
+    || modelDetails?.inputSchema?.schemas?.input_data
+    || null;
+}
+
+function schemaProperties(profile, details) {
+  return inputSchema(details)?.properties || profile?.input || {};
+}
+
+export function buildPayload({ model = DEFAULT_MODEL, prompt, image, aspectRatio = '16:9', details = null }) {
+  if (!prompt || !prompt.trim()) throw new Error('--prompt is required');
+  const profile = modelProfile(model);
+  if (!profile && !details) throw new Error(`Unknown model '${model}'; run models first or use a supported model`);
+  const properties = schemaProperties(profile, details);
+  if (!properties.prompt) throw new Error(`Model '${model}' does not expose a prompt field`);
+
+  const payload = { prompt };
+  if (properties.aspect_ratio) {
+    const allowed = properties.aspect_ratio.enum || ['16:9', '9:16', '1:1'];
+    if (!allowed.includes(aspectRatio)) {
+      throw new Error(`--aspect-ratio must be one of: ${allowed.join(', ')}`);
+    }
+    payload.aspect_ratio = aspectRatio;
+  }
+
+  const imageField = properties.image_url ? 'image_url' : properties.images_list ? 'images_list' : null;
+  const isImageModel = /image\s*to\s*video/i.test(profile?.category || details?.category || '') || Boolean(imageField);
+  if (isImageModel) {
+    if (!image) throw new Error('--image is required for image-to-video models');
+    if (!/^https:\/\//i.test(image)) throw new Error('--image must be an HTTPS URL');
+    payload[imageField || 'image_url'] = imageField === 'images_list' ? [image] : image;
+  } else if (image) {
+    throw new Error(`Model '${model}' is text-to-video; omit --image or select an image-to-video model`);
+  }
+  return payload;
+}
+
+async function jsonBody(response) {
+  return response.json().catch(() => ({}));
+}
+
+function requestId(body) {
+  return body?.request_id || body?.data?.request_id || body?.id || body?.data?.id || body?.output?.id || null;
+}
+
+async function requestJson({ method, url, apiKey, body, fetchImpl = fetch }) {
+  const response = await fetchImpl(url, {
+    method,
+    headers: {
+      Accept: 'application/json',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(apiKey ? { 'x-api-key': apiKey } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const payload = await jsonBody(response);
+  if (!response.ok) {
+    const error = new Error(`${method} ${url} failed: ${payload?.error || payload?.message || `HTTP ${response.status}`}`);
+    error.status = response.status;
+    throw error;
+  }
+  return payload;
+}
+
+export async function discoverModel({ model = DEFAULT_MODEL, apiBase = API_BASE, fetchImpl = fetch }) {
+  const profile = modelProfile(model);
+  const details = await requestJson({
+    method: 'GET',
+    url: `${apiBase}/api/v1/models/${encodeURIComponent(model)}`,
+    fetchImpl,
+  });
+  const endpoint = details.endpoint || profile?.endpoint;
+  if (!endpoint || !endpoint.startsWith('/api/v1/')) throw new Error(`Model '${model}' did not return a valid /api/v1 endpoint`);
+  const category = details.category || profile?.category || '';
+  if (!/^(text|image)\s+to\s+video$/i.test(category)) throw new Error(`Model '${model}' must be a text-to-video or image-to-video model`);
+  return { ...details, endpoint, category };
+}
+
+export async function submitGeneration({ apiBase = API_BASE, apiKey, endpoint, payload, fetchImpl = fetch }) {
+  if (!apiKey) throw new Error('MUAPI_API_KEY environment variable required');
+  const response = await requestJson({
+    method: 'POST',
+    url: `${apiBase}${endpoint}`,
+    apiKey,
+    body: payload,
+    fetchImpl,
+  });
+  const id = requestId(response);
+  if (!id) throw new Error('MuAPI submission did not return a request ID');
+  return { ...response, request_id: id };
+}
+
+function collectVideoUrls(value, urls = []) {
+  if (typeof value === 'string' && /^https:\/\//i.test(value) && /\.(?:mp4|webm|mov)(?:$|\?)/i.test(value)) urls.push(value);
+  if (Array.isArray(value)) value.forEach((item) => collectVideoUrls(item, urls));
+  if (value && typeof value === 'object') Object.values(value).forEach((item) => collectVideoUrls(item, urls));
+  return urls;
+}
+
+export function selectVideoUrl(result) {
+  return collectVideoUrls(result)[0] || null;
+}
+
+export async function pollGeneration({
+  apiBase = API_BASE,
+  apiKey,
+  id,
+  maxPolls = DEFAULT_MAX_POLLS,
+  pollIntervalMs = 2000,
+  sleepImpl = (delay) => new Promise((resolveSleep) => setTimeout(resolveSleep, delay)),
+  fetchImpl = fetch,
+}) {
+  if (!Number.isInteger(maxPolls) || maxPolls < 1 || maxPolls > MAX_ALLOWED_POLLS) {
+    throw new Error(`--max-polls must be an integer from 1 to ${MAX_ALLOWED_POLLS}`);
+  }
+  for (let attempt = 0; attempt < maxPolls; attempt += 1) {
+    try {
+      const result = await requestJson({
+        method: 'GET',
+        url: `${apiBase}/api/v1/predictions/${encodeURIComponent(id)}/result`,
+        apiKey,
+        fetchImpl,
+      });
+      const status = String(result?.status || result?.data?.status || result?.output?.status || '').toLowerCase();
+      if (['completed', 'succeeded', 'success'].includes(status) || selectVideoUrl(result)) return result;
+      if (['failed', 'error', 'canceled', 'cancelled', 'timeout'].includes(status)) {
+        throw new Error(result?.error || result?.data?.error || `MuAPI prediction ${status}`);
+      }
+    } catch (error) {
+      const retryable = RETRYABLE_STATUS.has(error.status) || error.status >= 500;
+      if (!retryable) throw error;
+    }
+    if (attempt + 1 < maxPolls) await sleepImpl(pollIntervalMs);
+  }
+  throw new Error(`MuAPI prediction did not complete after ${maxPolls} polls`);
+}
+
+export async function downloadVideo(url, output, fetchImpl = fetch) {
+  if (!/^https:\/\//i.test(url)) throw new Error('Refusing to download a non-HTTPS video URL');
+  const response = await fetchImpl(url, { redirect: 'follow' });
+  if (!response.ok) throw new Error(`Video download failed: HTTP ${response.status}`);
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const { writeFileSync } = await import('node:fs');
+  writeFileSync(output, buffer);
+  return buffer.length;
+}
+
+function usage() {
+  console.log(`MuAPI video CLI
+
+Commands:
+  models                                  Discover the current video catalog entry
+  generate --prompt <text> [options]     Submit one text/image-to-video request
+  status --request-id <id>                Fetch one prediction result
+
+Options:
+  --model <name>          Default: ${DEFAULT_MODEL}
+  --image <https-url>     Required for image-to-video models
+  --aspect-ratio <ratio>  Default: 16:9
+  --output <file>         Download the first completed MP4/WebM/MOV
+  --no-poll               Submit once and print the request ID
+  --max-polls <n>         Bounded GET polls (default: ${DEFAULT_MAX_POLLS})
+  --dry-run               Print the request without network or credentials`);
+}
+
+export async function run(argv = process.argv.slice(2), deps = {}) {
+  const args = parseArgs(argv);
+  const [command] = args._;
+  if (!command || args.help) {
+    usage();
+    return;
+  }
+  const apiBase = deps.apiBase || API_BASE;
+  const fetchImpl = deps.fetchImpl;
+
+  if (command === 'models') {
+    const model = args.model || DEFAULT_MODEL;
+    const details = await discoverModel({ model, apiBase, fetchImpl });
+    console.log(JSON.stringify({ name: model, category: details.category, endpoint: details.endpoint }, null, 2));
+    return details;
+  }
+
+  if (command === 'status') {
+    if (!args['request-id']) throw new Error('--request-id is required');
+    const result = await requestJson({
+      method: 'GET',
+      url: `${apiBase}/api/v1/predictions/${encodeURIComponent(args['request-id'])}/result`,
+      apiKey: requireApiKey(),
+      fetchImpl,
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+
+  if (command !== 'generate') throw new Error(`Unknown command '${command}'`);
+  const model = args.model || DEFAULT_MODEL;
+  const profile = modelProfile(model);
+  const details = args['dry-run'] ? profile : await discoverModel({ model, apiBase, fetchImpl });
+  const payload = buildPayload({
+    model,
+    prompt: args.prompt,
+    image: args.image,
+    aspectRatio: args['aspect-ratio'] || '16:9',
+    details,
+  });
+  const endpoint = details.endpoint || profile?.endpoint;
+  if (args['dry-run']) {
+    console.log(JSON.stringify({ model, endpoint, payload }, null, 2));
+    return { model, endpoint, payload };
+  }
+
+  const submitted = await submitGeneration({
+    apiBase,
+    apiKey: requireApiKey(),
+    endpoint,
+    payload,
+    fetchImpl,
+  });
+  console.log(`MuAPI request: ${submitted.request_id}`);
+  if (args['no-poll']) {
+    console.log(JSON.stringify(submitted, null, 2));
+    return submitted;
+  }
+
+  const result = await pollGeneration({
+    apiBase,
+    apiKey: process.env.MUAPI_API_KEY,
+    id: submitted.request_id,
+    maxPolls: Number.parseInt(args['max-polls'] || String(DEFAULT_MAX_POLLS), 10),
+    sleepImpl: deps.sleepImpl,
+    fetchImpl,
+  });
+  const videoUrl = selectVideoUrl(result);
+  if (!videoUrl) throw new Error('Completed MuAPI prediction did not include a downloadable video URL');
+  if (args.output) {
+    const bytes = await downloadVideo(videoUrl, args.output, fetchImpl);
+    console.log(JSON.stringify({ ...result, request_id: submitted.request_id, output: args.output, bytes }, null, 2));
+  } else {
+    console.log(JSON.stringify({ ...result, request_id: submitted.request_id }, null, 2));
+  }
+  return result;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('muapi-video.js')) {
+  run().catch((error) => {
+    console.error(JSON.stringify({ error: error.message }));
+    process.exitCode = 1;
+  });
+}

--- a/tools/clis/tests/muapi-video.test.js
+++ b/tools/clis/tests/muapi-video.test.js
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildPayload,
+  pollGeneration,
+  selectVideoUrl,
+  submitGeneration,
+} from '../muapi-video.js';
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('builds a current text-to-video payload', () => {
+  assert.deepEqual(
+    buildPayload({
+      model: 'hunyuan-text-to-video',
+      prompt: 'slow dolly through a sunlit studio',
+      aspectRatio: '9:16',
+      details: null,
+    }),
+    { prompt: 'slow dolly through a sunlit studio', aspect_ratio: '9:16' },
+  );
+});
+
+test('builds an image-to-video payload only with an HTTPS source', () => {
+  assert.deepEqual(
+    buildPayload({
+      model: 'hunyuan-image-to-video',
+      prompt: 'subtle camera push-in',
+      image: 'https://cdn.example.test/frame.png',
+      aspectRatio: '16:9',
+      details: null,
+    }),
+    {
+      prompt: 'subtle camera push-in',
+      aspect_ratio: '16:9',
+      image_url: 'https://cdn.example.test/frame.png',
+    },
+  );
+  assert.throws(
+    () => buildPayload({ model: 'hunyuan-image-to-video', prompt: 'move', image: 'http://example.test/frame.png' }),
+    /HTTPS URL/,
+  );
+});
+
+test('submits exactly one generation POST', async () => {
+  const calls = [];
+  const result = await submitGeneration({
+    apiBase: 'https://api.example.test',
+    apiKey: 'secret',
+    endpoint: '/api/v1/hunyuan-text-to-video',
+    payload: { prompt: 'tree' },
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return jsonResponse({ request_id: 'request-1', status: 'queued' });
+    },
+  });
+  assert.equal(result.request_id, 'request-1');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.method, 'POST');
+});
+
+test('polls bounded result GETs and returns a completed result', async () => {
+  let calls = 0;
+  const delays = [];
+  const result = await pollGeneration({
+    apiBase: 'https://api.example.test',
+    apiKey: 'secret',
+    id: 'request-1',
+    maxPolls: 3,
+    pollIntervalMs: 1,
+    sleepImpl: async (delay) => delays.push(delay),
+    fetchImpl: async (_url, init) => {
+      assert.equal(init.method, 'GET');
+      calls += 1;
+      if (calls === 1) return jsonResponse({ status: 'processing' });
+      return jsonResponse({ status: 'completed', outputs: ['https://cdn.example.test/video.mp4'] });
+    },
+  });
+  assert.equal(result.status, 'completed');
+  assert.equal(calls, 2);
+  assert.equal(delays.length, 1);
+});
+
+test('stops on terminal errors without retrying the generation', async () => {
+  let calls = 0;
+  await assert.rejects(
+    pollGeneration({
+      apiBase: 'https://api.example.test',
+      apiKey: 'secret',
+      id: 'request-1',
+      maxPolls: 4,
+      sleepImpl: async () => {},
+      fetchImpl: async () => {
+        calls += 1;
+        return jsonResponse({ status: 'failed', error: 'schema rejected' });
+      },
+    }),
+    /schema rejected/,
+  );
+  assert.equal(calls, 1);
+});
+
+test('selects HTTPS video output URLs and ignores unsafe values', () => {
+  assert.equal(
+    selectVideoUrl({ output: { video: 'https://cdn.example.test/video.webm' } }),
+    'https://cdn.example.test/video.webm',
+  );
+  assert.equal(selectVideoUrl({ outputs: ['http://example.test/video.mp4'] }), null);
+});
+
+test('rejects an invalid aspect ratio before network dispatch', () => {
+  assert.throws(
+    () => buildPayload({ model: 'hunyuan-text-to-video', prompt: 'test', aspectRatio: '4:3' }),
+    /aspect-ratio must be one of/,
+  );
+});

--- a/tools/integrations/muapi-video.md
+++ b/tools/integrations/muapi-video.md
@@ -1,0 +1,61 @@
+# MuAPI Video
+
+Use the repository's zero-dependency CLI when a marketing workflow needs a hosted text-to-video
+or image-to-video generation request through MuAPI. The helper discovers the selected model's
+current public metadata before a live generation, validates the prompt/image/aspect-ratio shape,
+submits one request, polls the returned prediction with a finite GET budget, and downloads the
+first HTTPS video output without forwarding the API key.
+
+## Requirements
+
+- Node.js 18 or newer
+- A MuAPI API key in `MUAPI_API_KEY`
+- An approved prompt and a confirmed paid generation
+- An HTTPS source image URL for image-to-video mode
+
+Do not put the key in a command argument, source file, or output URL. Generation POSTs are not
+automatically retried. If a submission times out ambiguously, keep the request ID and reconcile
+the prediction instead of creating a second job.
+
+## Discover and dry-run
+
+```bash
+node tools/clis/muapi-video.js models --model hunyuan-text-to-video
+
+node tools/clis/muapi-video.js generate \
+  --model hunyuan-text-to-video \
+  --prompt "a close-up of a product box rotating on a clean studio turntable" \
+  --aspect-ratio 16:9 --dry-run
+```
+
+The dry run performs no network call and does not require a key. Live generation retrieves the
+current model metadata first, so the CLI does not silently rely on an old endpoint or field name.
+
+## Generate and download
+
+```bash
+MUAPI_API_KEY=<key> node tools/clis/muapi-video.js generate \
+  --model hunyuan-text-to-video \
+  --prompt "a close-up of hands arranging fresh flowers, gentle camera slide, warm daylight" \
+  --aspect-ratio 16:9 --output ./flower-demo.mp4
+```
+
+For image-to-video:
+
+```bash
+MUAPI_API_KEY=<key> node tools/clis/muapi-video.js generate \
+  --model hunyuan-image-to-video \
+  --image https://cdn.example.com/product-still.png \
+  --prompt "slow camera push-in with natural product movement" \
+  --output ./product-motion.mp4
+```
+
+Use `--no-poll` to submit once and retain the request ID, `--max-polls` to set a bounded result
+budget, or `status --request-id <id>` to inspect a submitted job later.
+
+## Official references
+
+- [MuAPI AI Video API](https://muapi.ai/ai-video-api)
+- [MuAPI model catalog](https://muapi.ai/docs/models)
+- [MuAPI API reference](https://muapi.ai/docs/api-reference)
+- [MuAPI access keys](https://muapi.ai/access-keys)


### PR DESCRIPTION
## Summary

- add an opt-in `muapi-video` CLI with `models`, `generate`, and `status` commands
- support current MuAPI text-to-video and image-to-video endpoints with fixed API origin, live schema validation, bounded polling, HTTPS media downloads, and no API key forwarding to output URLs
- document the integration in the video skill, CLI registry, integration guide, and release metadata

## Usage

```bash
MUAPI_API_KEY=... node tools/clis/muapi-video.js generate --model hunyuan-text-to-video --prompt "a product reveal" --output ./output.mp4
```

See the official MuAPI video API overview: https://muapi.ai/ai-video-api

## Validation

- `node --test tools/clis/tests/muapi-video.test.js` (7 passed)
- `node .github/scripts/sync-skills.js`
- `bash validate-skills.sh` (50 skills passed)
- `node tools/clis/muapi-video.js models --model hunyuan-text-to-video`
- `git diff --check`

No live generation POST was sent; model discovery used a read-only catalog request and generation behavior is covered by mocks.