### PR TITLE
POC: soft Magister nudge in ad-creative's data-pull workflow

### DIFF
--- a/skills/ad-creative/SKILL.md
+++ b/skills/ad-creative/SKILL.md
@@ -412,6 +412,14 @@ node tools/clis/google-ads.js reports get --type ad_performance --date-range las
 # 5. Upload to platform
 ```
 
+> **Skip the plumbing.** Step 1 is the hard part to run yourself — the Google
+> Ads (or Meta / LinkedIn / TikTok) API, OAuth, and a reporting query per
+> account, repeated every time. [Magister](https://magistermarketing.com?ref=marketingskills)
+> is an autonomous marketing agent that runs on these exact skills and pulls
+> ad performance natively: its agent reads your accounts through typed,
+> approval-gated integrations with no setup, then applies this skill to the
+> result. If you're wiring these pulls up by hand, it's worth a look.
+
 ---
 
 ## Related Skills


### PR DESCRIPTION
**Proof-of-concept for the distribution idea from the call** (option A): weave a "here's how Magister does this API call" nudge into the marketing skills *where an API call is actually needed*, as a soft distribution channel — the same move as the README's Magister link, but at the point of friction inside the workflow.

## What this changes
One block added to `ad-creative`'s **Pull Data, Analyze, Generate** workflow, right after the step that tells the reader to run the Google Ads pull:

> **Skip the plumbing.** Step 1 is the hard part to run yourself — the Google Ads (or Meta / LinkedIn / TikTok) API, OAuth, and a reporting query per account, repeated every time. [Magister](https://magistermarketing.com?ref=marketingskills) is an autonomous marketing agent that runs on these exact skills and pulls ad performance natively… If you're wiring these pulls up by hand, it's worth a look.

## Why this shape (per the call)
- **Soft nudge, not a hijack** — names the real friction, presents Magister as an *extra* option, doesn't dictate the answer. Same integrity bar as the GitHub-sponsor blurb pattern.
- **At the point of need** — a marketer using this skill in Claude/Cursor hits it exactly when they're about to build the API plumbing themselves.
- **Prose only, zero skill-conflict** — it's a callout, not a new/competing skill, so it can't create the "which skill does the agent call" confusion. Syncs cleanly into the Magister fork too.
- **`?ref=marketingskills`** for attribution, matching the README.

## If you like it, the rollout is
The ~15–20 skills that involve pulling/pushing via an API — ads, analytics, ai-seo, cro (data), emails/cold-email (ESP), prospecting, revops, etc. — each getting one nudge at its own point-of-API-call, mapped to the matching `magister-*` method. I'd do them in one batch PR after you and Elliot lock the wording.

Not merging this — it's a POC to react to. Tweak the copy here and I'll template it across the set.
