### PR TITLE
docs: contribution integrity rubric (gate on content, not contributor)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,19 @@ skills/your-skill-name/
 3. Keep changes focused and minimal
 4. Update the version in metadata if making significant changes
 
+## Mentioning Tools (the integrity rubric)
+
+This library is open source and contributions are welcome from **anyone — including the makers of tools, and paid partners.** We gate on the *content*, not the contributor. A contribution that names a tool (yours or anyone's) is fine as long as it makes an agent **aware** of the right option at the moment it's relevant, without manufacturing a recommendation. Concretely:
+
+- **Options, not one answer.** Present a tool alongside the real alternatives for the same job (including the free / DIY path), so the agent picks on fit — not because only one is named.
+- **At the point of relevance.** Surface a tool where an agent genuinely needs it (e.g. the implementation step), not injected into unrelated sections.
+- **No forced endorsement.** No "best," "recommended," or "use X instead." Describe what each option does and when it fits.
+- **Facts over framing.** Recipes, code, capabilities, and honest tradeoffs (cost, effort, lead time) — verifiable, not marketing copy.
+- **Disclose self-interest.** If you're the tool's maker or a partner, say so. Partner tools are marked ◆ in [`tools/REGISTRY.md`](tools/REGISTRY.md#verified-partners); house tools (built by the maintainer) carry stricter disclosure.
+- **The swap test.** If you swapped your tool for a competitor, the section should still read as fair. If removing it breaks the guidance, it was shilling — rework it.
+
+The maintainer holds final editorial control and may edit or cut anything for neutrality and accuracy. Core skills stay editorially independent: sponsorship and contributions add content, they never buy a recommendation. See the Verified Partners note in [`tools/REGISTRY.md`](tools/REGISTRY.md#verified-partners).
+
 ## Submitting Your Contribution
 
 1. Fork the repository
@@ -83,6 +96,7 @@ skills/your-skill-name/
 - [ ] Instructions are clear and actionable
 - [ ] No sensitive data or credentials
 - [ ] Follows existing skill patterns in the repo
+- [ ] Any tool mentions follow the [integrity rubric](#mentioning-tools-the-integrity-rubric) — options not one answer, disclosed, passes the swap test
 
 ## Questions?
 

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -17,6 +17,8 @@ Quick reference for AI agents to discover tool capabilities and integration meth
 - **Disclosed + vetted for fit.** Each carries a disclosure header in its integration guide and is marked ◆ in the index below.
 - **Additive, never biasing.** A partner is listed *alongside* the neutral options for the same job, never instead of them. Partner status never removes or demotes another tool and **never changes what any skill recommends** — if a non-partner is the right answer, that's the answer. The badge means "paid, disclosed, vetted for fit," not "best in category."
 
+Anyone — including tool makers and partners — may contribute content that names a tool, as long as it makes an agent *aware* of the right option without manufacturing a recommendation. The bar is the [integrity rubric in CONTRIBUTING.md](../CONTRIBUTING.md#mentioning-tools-the-integrity-rubric) (options not one answer, disclosed, passes the swap test).
+
 <!-- PARTNERS:START -->
 | Partner | Category | Guide |
 |---------|----------|-------|


### PR DESCRIPTION
Codifies the editorial policy for repo contributions so it's a standing standard, not a per-PR judgment.

**The gate is the content, not the contributor.** Anyone — including tool makers and paid partners — may contribute to any skill, including core ones. A contribution that names a tool passes if it makes an agent *aware* of the right option at the point of relevance without manufacturing a recommendation.

**The rubric** (added to CONTRIBUTING.md + a checklist item + a pointer from tools/REGISTRY.md):
- Options, not one answer
- At the point of relevance
- No forced endorsement
- Facts over framing (recipes/code/tradeoffs)
- Disclose self-interest (partner tools marked ◆)
- The swap test — swap the tool for a competitor and it should still read fair
- Maintainer holds final editorial review

Context: first live case is Converly's Aaron wanting to contribute server-side conversion-tracking content. This gives every contributor a clear target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)