### PR TITLE
feat: onboard Converly as a paying Skill Partner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Run into a problem or have a question? [Open an issue](https://github.com/coreyh
 The library is free and MIT-licensed. [Verified Partners](tools/REGISTRY.md#verified-partners) fund the work — vetted, disclosed tool integrations, listed alongside the neutral options and never influencing what the core skills recommend. The full rules and boundaries are in [tools/PARTNERS.md](tools/PARTNERS.md). [Become a partner →](https://marketing-skills.com/sponsorship)
 
 <!-- PARTNERS:START -->
-_No active partners yet. [Become a partner →](https://marketing-skills.com/sponsorship)_
+> ◆ **[Converly](https://converly.io?ref=marketingskills)** — *Conversion tracking / attribution.* Server-side conversion tracking that fires when someone submits a form, books a meeting, or starts a chat — passing click IDs and identifiers for Enhanced Conversions (Google) and high EMQ match rates (Meta), across 100+ tools. CLI + MCP so your agent sets it up in minutes. → [Integration guide](tools/integrations/converly.md)
 <!-- PARTNERS:END -->
 
 <!-- The Partners block above is generated from partners.json — run `node scripts/sync-partners.mjs` after editing it. -->

--- a/partners.json
+++ b/partners.json
@@ -12,7 +12,7 @@
       "blurb": "Server-side conversion tracking that fires when someone submits a form, books a meeting, or starts a chat — passing click IDs and identifiers for Enhanced Conversions (Google) and high EMQ match rates (Meta), across 100+ tools. CLI + MCP so your agent sets it up in minutes.",
       "logoUrl": "",
       "integration": "tools/integrations/converly.md",
-      "active": false
+      "active": true
     }
   ]
 }

--- a/partners.json
+++ b/partners.json
@@ -10,7 +10,7 @@
       "tier": "skill-partner",
       "tagline": "Server-side conversion tracking",
       "blurb": "Server-side conversion tracking that fires when someone submits a form, books a meeting, or starts a chat — passing click IDs and identifiers for Enhanced Conversions (Google) and high EMQ match rates (Meta), across 100+ tools. CLI + MCP so your agent sets it up in minutes.",
-      "logoUrl": "",
+      "logoUrl": "/logos/converly.png",
       "integration": "tools/integrations/converly.md",
       "active": true
     }

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -24,6 +24,7 @@ Anyone — including tool makers and partners — may contribute content that na
 <!-- PARTNERS:START -->
 | Partner | Category | Guide |
 |---------|----------|-------|
+| ◆ Converly | Conversion tracking / attribution | [converly.md](integrations/converly.md) |
 <!-- PARTNERS:END -->
 
 <!-- The table above is generated from partners.json — run `node scripts/sync-partners.mjs`. -->
@@ -34,6 +35,7 @@ Anyone — including tool makers and partners — may contribute content that na
 
 | Tool | Category | API | MCP | CLI | SDK | Guide |
 |------|----------|:---:|:---:|:---:|:---:|-------|
+| ◆ converly | Conversion Tracking | ✓ | ✓ | ✓ | - | [converly.md](integrations/converly.md) |
 | ga4 | Analytics | ✓ | ✓ | [✓](clis/ga4.js) | ✓ | [ga4.md](integrations/ga4.md) |
 | mixpanel | Analytics | ✓ | - | [✓](clis/mixpanel.js) | ✓ | [mixpanel.md](integrations/mixpanel.md) |
 | amplitude | Analytics | ✓ | - | [✓](clis/amplitude.js) | ✓ | [amplitude.md](integrations/amplitude.md) |

--- a/tools/integrations/converly.md
+++ b/tools/integrations/converly.md
@@ -1,0 +1,48 @@
+# Converly
+
+> **◆ Verified Partner integration.** Converly sponsors Marketing Skills. This integration is disclosed and vetted for fit; it does **not** change what any skill recommends. It's listed here alongside the neutral options for the same job — use it when it's the right fit, not because it's a partner. See [Verified Partners](../REGISTRY.md#verified-partners).
+
+Server-side conversion tracking: sends conversions to ad platforms and analytics tools when a visitor completes an action on your site — a form submit, a booked meeting, a started chat.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | REST API — [developers.converly.io](https://developers.converly.io) |
+| MCP | ✓ | Converly MCP server — [converly.io/mcp](https://converly.io/mcp) — lets an agent set up tracking end to end |
+| CLI | ✓ | Configure conversions and destinations from the terminal |
+| SDK | – | Single site snippet + drag-and-drop flow builder |
+
+## What it does
+
+Server-side delivery bypasses ad blockers and browser privacy limits that silently drop browser-pixel events — which is what recovers "missing" conversions and lifts match rates. Converly passes name, email, phone, click IDs, and IP, enabling **Enhanced Conversions** on Google Ads and high **EMQ** (Event Match Quality) scores on Meta.
+
+- **Destinations:** Google Ads, Meta Ads, LinkedIn Ads, TikTok Ads, Google Analytics.
+- **Sources (100+):** form builders (Gravity Forms, WPForms, Contact Form 7, Fluent Forms, Formidable, Ninja Forms, Typeform, Jotform, Tally, Webflow, Elementor, Wix) and CRM/scheduling/chat (HubSpot, Salesforce, Pipedrive, Calendly, HighLevel, Intercom, LiveChat).
+- **Build:** one site snippet installed once, then drag-and-drop conversion flows; add/remove destinations in one click.
+- **Reported lift (vendor-supplied — verify with your own holdout):** ~19% more conversions on Google Ads, ~23% on Meta Ads with server-side tracking.
+
+## Authentication
+
+- **Type:** API key. Store it in an environment variable / secret manager — never in the repo. `TODO: exact env var name from developers.converly.io`
+
+## Setup (agent-driven via CLI or MCP)
+
+1. **Authenticate** to Converly (CLI login or MCP). `TODO: exact auth command / MCP tool name`
+2. **Install the site snippet** once on all pages; confirm it's in the initial HTML.
+3. **Define the conversion** — pick the trigger (form submit / meeting booked / chat started) and source tool, and map the fields to capture (email, phone, name, click IDs). `TODO: create-flow command + field-mapping schema`
+4. **Connect destinations** — add the ad platforms/analytics tools to send to; one conversion can fan out to several. `TODO: destination-add command + per-platform credentials (e.g. Google Ads conversion action + customer ID; Meta dataset/pixel ID + CAPI token)`
+5. **Verify a real conversion** — fire a test action, confirm it lands in each destination with identifiers attached (Enhanced Conversions diagnostics on Google; EMQ on Meta). Don't call tracking done until a real conversion is observed downstream.
+
+> The `TODO` lines are placeholders for Converly's exact syntax; fill from [developers.converly.io](https://developers.converly.io) + [converly.io/mcp](https://converly.io/mcp) during the accuracy review, then remove this note.
+
+## How it fits the skills
+
+- Converly is one way to **implement** the server-side send described in `attribution` → `references/first-party-tracking.md`. The *strategy* (what to count, source of truth, how to read the numbers) still comes from `attribution` and `analytics`; Converly handles the browser→server→platform hop and identity fields.
+- After conversions flow, judge results with `ads` discipline: never sum conversions across attribution windows, and treat vendor lift figures as a hypothesis to verify with a holdout.
+
+## Links
+
+- Site: https://converly.io
+- Developer docs / API: https://developers.converly.io
+- MCP: https://converly.io/mcp


### PR DESCRIPTION
## What

Onboards **Converly** as a paying Skill Partner. Aaron Beashel completed the payment and the onboarding form, so this is the green light — the inverse of the #571 unpublish.

## Changes

- **`partners.json`** → `active: true`
- **README** + **REGISTRY Verified Partners table** → regenerated via `node scripts/sync-partners.mjs` (now "1 partner")
- **REGISTRY Tool Index** → restored the `◆ converly` capability-matrix row (not sync-managed, so re-added by hand — mirrors what #571 removed)
- **`tools/integrations/converly.md`** → restored from the gitignored `.partners-pending/` folder

The guide's disclosure header ("Converly sponsors Marketing Skills") is now accurate.

## Effect

Once merged to `main`, the live site shows Converly via its runtime `partners.json` fetch (Skill Partners tier on the homepage band + sponsorship page), and the README/registry list it as a Verified Partner.

## Note

Activated using the details already in `partners.json` (name, URL, category, tagline, blurb). If Aaron's onboarding form provided anything new — a logo URL, an updated blurb — that's a quick follow-up edit to `partners.json` + re-run sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
