### PR TITLE
feat: add no-slop skill — shared anti-slop pass for prose (2.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [
     {
       "name": "marketing-skills",
-      "description": "50 marketing skills for technical marketers and founders: CRO, copywriting, cold email, prospecting, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, comprehensive AARRR-structured marketing plans, public relations and earned media, offer design, event marketing and webinars, and more",
+      "description": "51 marketing skills for technical marketers and founders: CRO, copywriting, cold email, prospecting, SEO, AI SEO, paid ads, SMS, ad creative, video production, image generation, co-marketing, churn prevention, pricing, referrals, revenue operations, sales enablement, customer research, site architecture, comprehensive AARRR-structured marketing plans, public relations and earned media, offer design, event marketing and webinars, and more",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -34,6 +34,7 @@ Current versions of all skills. Agents can compare against local versions to che
 | marketing-loops | 1.2.0 | 2026-07-10 |
 | marketing-plan | 1.1.1 | 2026-08-23 |
 | marketing-psychology | 2.0.0 | 2026-05-05 |
+| no-slop | 1.0.0 | 2026-09-01 |
 | offers | 1.0.1 | 2026-08-23 |
 | onboarding | 2.0.1 | 2026-08-23 |
 | ads | 2.3.2 | 2026-08-23 |
@@ -56,6 +57,10 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.12.0 (2026-09-01)
+
+- Added the **`no-slop`** skill (1.0.0) — a shared anti-slop pass every prose skill can run before delivery, so nothing ships reading as AI-generated. A tell doesn't just read badly; it makes the reader discount the *claim*, so this is a quality gate, not a style nit. Upgrades the common "AI-tell list" pattern with **severity tiers** (Fatal / Flag / Context), **marketing-channel-specific slop** (CTA, subject-line, hook, broetry/engagement-bait, persona-by-demographic, vanity-metric reporting) rather than a generic copy checklist, a **claims-not-slop** tie-in to copywriting's supportable-claims rule (de-slopping never invents proof), the read-aloud + bar tests, and a **register exception** so a genuinely formal brand voice isn't flattened. Exhaustive word/phrase catalogue in `references/lexical-tells.md`; six evals covering hero hype, email/subject slop, the formal-register exception, LinkedIn broetry, vanity-metric analytics slop, and demographic-vs-state targeting. New skill = repo y release; total skills: 51. Directly invocable now ("de-slop this," "does this read as AI"); wiring it into each prose skill's delivery step ships as a follow-up.
 
 ### 2.11.0 (2026-08-23)
 

--- a/skills/no-slop/SKILL.md
+++ b/skills/no-slop/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: no-slop
+description: When prose is about to ship and must not read as AI-generated. Use when the user says "de-slop this," "no slop," "does this read as AI," "make this sound human," "remove the AI tells," "this sounds like ChatGPT," "anti-slop," "kill the AI voice," or wants a pre-delivery quality gate on copy. Every prose skill (copywriting, emails, social, ad-creative, cold-email, website-copy) runs no-slop before handoff. For broad line-editing of existing copy, see copy-editing. For writing from scratch, see copywriting.
+metadata:
+  version: 1.0.0
+---
+
+# No-Slop
+
+You are the last check before prose ships. Your job is to catch the constructions, words, and shortcuts that make writing read as machine-generated, and to fix them without inventing anything.
+
+A tell is not a style nit. Readers now pattern-match AI writing in seconds, and once they do they discount the **claim**, not just the prose. One tell in a headline can lose the argument for a page that was otherwise true. That is why this runs on every prose deliverable before it leaves.
+
+**Run no-slop before delivering any prose** — copy, emails, ad text, social posts, landing pages. It is a pass, not a rewrite: preserve the argument and the brand voice, remove the machine fingerprints.
+
+Voice check first: read `.agents/product-marketing.md` (or `.claude/product-marketing.md`) if it exists. De-slopping never means flattening a real brand voice into the same clipped style everyone else uses — see **The register exception** below.
+
+---
+
+## How to run the pass
+
+1. **Scan for Fatal tells** (below) and remove every one — these are non-negotiable.
+2. **Scan for Flag tells** and fix unless the brand voice load-bears them.
+3. **Run the two tests** (read-aloud, and the bar test).
+4. **Route any unsupportable claim** you find to the copywriting rule (don't invent proof to replace slop) — see **Claims, not slop**.
+5. **Report** what you changed by tier, and end with what you couldn't fix without more input (a real number, a customer quote, a voice doc).
+
+Never swap one empty construction for another. If you can't make a line specific, flag it `[NEED: proof/number/example]` rather than dressing up the emptiness.
+
+---
+
+## Severity tiers
+
+The upgrade over a flat checklist: not every tell is equal, so fix by priority.
+
+| Tier | Meaning | Action |
+|------|---------|--------|
+| **Fatal** | Instantly reads as AI; discredits the claim | Remove every instance, always |
+| **Flag** | Reads as AI in aggregate; fine once, damning as a pattern | Fix unless the brand voice genuinely needs it |
+| **Context** | Only slop when empty (formal register, long sentences) | Judge against brand voice, not against formality |
+
+---
+
+## Fatal tells (remove on sight)
+
+1. **"Not just X — but Y."** The single most recognizable AI construction. Variants: "It's not about X, it's about Y." Rewrite as a flat statement of Y.
+   - ✗ It's not just a CRM, it's a growth engine.
+   - ✓ It closes the loop between the ad click and the signed contract.
+2. **Claims with no referent.** "Industry-leading," "best-in-class," "world-class," "cutting-edge," "next-level," "game-changing," "revolutionary." They say nothing and signal nothing specific was available. Delete or replace with the specific fact.
+3. **Emoji as structure.** 🚀 ✨ 💡 leading bullets or headers. Fine in Slack, fatal in shipped copy.
+4. **Invented proof.** A statistic, testimonial, customer name, or "up to X%" with no source. Never generate it — mark `[NEED: x]`.
+5. **The em-dash summary clause as a habit.** One deliberate em-dash is style; the reflexive "— and that's what makes the difference" close is a signature tell. (House style here also avoids the decorative em-dash entirely; prefer a period or a colon.)
+
+---
+
+## Flag tells (fix unless load-bearing)
+
+6. **Reflexive tricolon.** Three-item lists as the default rhythm ("faster, smarter, more reliable"). Fine once; a tell as a pattern. Replace with one specific claim.
+7. **Metronomic sentence length.** Every sentence 12–18 words. Human writing varies violently. Break it: a three-word sentence, then a long one.
+8. **Question-then-answer opening.** "What if there were a better way? There is." Cut the question, state the thing.
+9. **The reassuring close.** Ending on a line that restates without adding ("and that's the difference").
+10. **Symmetrical paragraphs.** Every block the same length. Vary deliberately.
+11. **Hedged claims that should be flat.** "Can help you potentially reduce costs by up to 30%." Every hedge is a small confession; stack four and the reader believes none. → "Cuts fulfillment cost 31% at [customer]."
+12. **Benefits with no mechanism.** "Save time" is a wish. "Save time by auto-matching invoices to POs" is a claim.
+13. **Discourse glue.** "Moreover," "furthermore," "additionally," "that said," "it's worth noting." Usually deletable with no loss.
+
+Exhaustive word and phrase lists (the delve/leverage/seamless/transform families) live in [references/lexical-tells.md](references/lexical-tells.md). Load it when doing a full lexical sweep.
+
+---
+
+## Marketing-channel slop
+
+Generic copy checklists stop at prose. These are the tells specific to the surfaces this library writes for.
+
+- **CTA slop.** "Get started today," "Take your X to the next level," "Unlock your potential," "Join thousands of." Replace with the specific next action and its payoff. → "See your unmatched invoices in 2 minutes."
+- **Subject-line slop** (→ **emails**). Curiosity-gap bait with no substance ("You won't believe this…"), false "Re:"/"Fwd:", one-word hype ("🔥 Big news"). The subject should survive being read as the whole message.
+- **Hook slop** (→ **ad-creative**). "POV:", "Stop scrolling," "Here's the thing nobody tells you," recycled trend audio with no relevance. A hook earns the next second by being specific to the viewer's state, not by generic pattern-interrupt.
+- **Broetry / engagement bait** (→ **social**). One-line-per-paragraph LinkedIn cadence, "Agree?" closers, manufactured vulnerability, "Let that sink in." Say the substance a person would say out loud.
+- **Persona by demographic, not state.** "For SMBs" tells the reader nothing about whether it's for them. "For teams still approving invoices in email" does.
+- **Vanity-metric reporting slop** (→ **analytics**). Declaring a winner on ten conversions, quoting a rate without its denominator or window, a dashboard screenshot as "insight." A number without its comparison is decoration.
+- **Both-sidesing.** Copy that carefully weighs pros and cons to sound balanced reads as generated. Take a position.
+
+---
+
+## The two tests
+
+Faster than any checklist, and they catch what checklists miss.
+
+1. **Read it aloud.** Every time you stumble, stall, or hear a press release, mark that sentence. This catches rhythm problems nothing else does.
+2. **The bar test.** Would a person say this substance to another person at a bar? Not the register — the *substance*. If it would embarrass someone said out loud, it's not a claim, it's filler.
+
+---
+
+## Claims, not slop
+
+Slop and unsupported claims travel together, and the fix for both is specificity, not decoration. When de-slopping surfaces a claim the source can't support, do not paper over it with a punchier empty line. Hand it to the **copywriting** rule: name the claim, offer the closest supportable version, and state the evidence that would unlock the original (a review export, a written guarantee, a citable dataset). A de-slop pass that invents a number to replace a cliché has made the copy worse, not better.
+
+---
+
+## What good sounds like
+
+Specific. Uneven in rhythm. Willing to be blunt. Contains at least one fact that could be checked and disproved.
+
+> Most invoice tools promise automation and then hand you a queue to approve manually. Ours matches the PO, checks the total, and escalates only the ones that don't reconcile. Last quarter that was 6% of them.
+
+Three sentences. One number. One admission it doesn't handle everything. Not a word from the lexical tables.
+
+---
+
+## The register exception
+
+Some brands genuinely speak in a polished, formal register — enterprise security, regulated finance, medical. **Register is not slop.** The test is never formality, it is *emptiness*: a formal sentence making a specific, falsifiable claim is fine; a casual sentence that says nothing is not. Check `.agents/product-marketing.md` for the intended voice before flattening it, and watch for the opposite failure — over-correcting every client into the same clipped, punchy style is its own tell.
+
+---
+
+## Related Skills
+
+- **copywriting**: Writing prose from scratch (run no-slop before handoff)
+- **copy-editing**: Broad line-editing and refresh of existing copy (no-slop is its AI-tell pass)
+- **emails**, **social**, **ad-creative**, **cold-email**, **website-copy**: Channel prose that runs no-slop before delivery
+- **brand-voice**: The intended voice no-slop must preserve, not flatten

--- a/skills/no-slop/SKILL.md
+++ b/skills/no-slop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-slop
-description: When prose is about to ship and must not read as AI-generated. Use when the user says "de-slop this," "no slop," "does this read as AI," "make this sound human," "remove the AI tells," "this sounds like ChatGPT," "anti-slop," "kill the AI voice," or wants a pre-delivery quality gate on copy. Every prose skill (copywriting, emails, social, ad-creative, cold-email, website-copy) runs no-slop before handoff. For broad line-editing of existing copy, see copy-editing. For writing from scratch, see copywriting.
+description: When prose is about to ship and must not read as AI-generated. Use when the user says "de-slop this," "no slop," "does this read as AI," "make this sound human," "remove the AI tells," "this sounds like ChatGPT," "anti-slop," "kill the AI voice," or wants a pre-delivery quality gate on copy. Run it before handoff on any prose deliverable — copy, emails, ad text, social posts, landing pages. For broad line-editing of existing copy, see copy-editing. For writing from scratch, see copywriting.
 metadata:
   version: 1.0.0
 ---
@@ -115,7 +115,7 @@ Some brands genuinely speak in a polished, formal register — enterprise securi
 
 ## Related Skills
 
-- **copywriting**: Writing prose from scratch (run no-slop before handoff)
+- **copywriting**: Writing prose from scratch, including website and landing-page copy (run no-slop before handoff)
 - **copy-editing**: Broad line-editing and refresh of existing copy (no-slop is its AI-tell pass)
-- **emails**, **social**, **ad-creative**, **cold-email**, **website-copy**: Channel prose that runs no-slop before delivery
-- **brand-voice**: The intended voice no-slop must preserve, not flatten
+- **emails**, **social**, **ad-creative**, **cold-email**, **sms**: Channel prose that runs no-slop before delivery
+- **product-marketing**: The product voice and positioning context (`.agents/product-marketing.md`) no-slop must preserve, not flatten

--- a/skills/no-slop/evals/evals.json
+++ b/skills/no-slop/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "no-slop",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "De-slop this homepage hero: \"In today's fast-paced world, our revolutionary, industry-leading platform empowers teams to seamlessly unlock their full potential. It's not just a tool — it's a game-changer.\"",
+      "expected_output": "Should identify the Fatal tells (the 'not just X — it's Y' construction, the referent-free claims 'revolutionary'/'industry-leading'/'game-changer', the 'in today's fast-paced world' filler, the 'seamlessly'/'unlock full potential'/'empowers' families) and rewrite as a flat, specific statement of what the product actually does. Should NOT invent a statistic or customer to replace the hype — if the source gives no specific capability, it should flag [NEED: what the product concretely does] rather than fabricate. Reports changes and ends with what it couldn't determine without product detail.",
+      "assertions": [
+        "Removes the 'not just X, it's Y' construction",
+        "Removes referent-free superlatives (revolutionary, industry-leading, game-changer) rather than swapping in different empty ones",
+        "Does not invent a statistic, percentage, or customer name to replace the hype",
+        "Flags missing specifics (e.g. [NEED: ...]) instead of fabricating them",
+        "Preserves the intent while making at least one line concrete or explicitly flags the gap"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Is this good to send? Subject: \"🔥 You won't believe this game-changer\" — Body: \"Hey! We're thrilled to share our latest, cutting-edge solution that will revolutionize how you work. Whether you're a startup or an enterprise, we've got you covered!\"",
+      "expected_output": "Should run no-slop and reject it as-is. Flags subject-line slop (curiosity-gap bait + emoji hype + referent-free 'game-changer') and body slop (the 'whether you're a X or a Y' opener, 'cutting-edge solution', 'revolutionize', 'we've got you covered', abstract 'solution'). Should rewrite the subject to survive being read as the whole message and rewrite the body around a specific action/payoff, or flag [NEED] where the actual offer is unknown. Should not declare it fixed by swapping in equivalent hype.",
+      "assertions": [
+        "Flags the subject line as curiosity-gap/emoji hype and rewrites it to carry real substance",
+        "Identifies the 'whether you're a X or a Y' opener and the 'we've got you covered' filler",
+        "Removes 'cutting-edge solution' / 'revolutionize' rather than substituting new empty phrasing",
+        "Asks for or flags the missing concrete offer instead of inventing one"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Our brand is a regulated medical-devices company with a formal, precise voice. De-slop this: \"Our device is engineered to meet ISO 13485 requirements and reduces calibration drift to within 0.2% over a 12-month interval, verified in the attached validation report.\"",
+      "expected_output": "Should apply the register exception: recognize that formal register is not slop, and that this sentence makes specific, falsifiable, sourced claims (ISO 13485, 0.2%, 12 months, a validation report). Should leave it essentially intact rather than 'punching it up' into a casual voice, and explicitly note that over-correcting a legitimate formal brand voice is itself a tell. Should check brand voice (product-marketing.md) before flattening.",
+      "assertions": [
+        "Does NOT rewrite the formal sentence into a casual/punchy voice",
+        "Explicitly invokes the register exception (formality is not slop; emptiness is)",
+        "Recognizes the claims are specific and sourced, so little or nothing needs changing",
+        "Warns against over-correcting a legitimate formal voice"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Tighten this LinkedIn post: \"I failed.\\n\\nHard.\\n\\nBut here's the thing.\\n\\nEvery setback is a setup for a comeback.\\n\\nLet that sink in.\\n\\nAgree?\"",
+      "expected_output": "Should flag broetry/engagement-bait slop: the one-line-per-paragraph cadence, 'here's the thing', the empty aphorism 'every setback is a setup for a comeback', 'let that sink in', and the 'Agree?' closer. Should rewrite around actual substance a person would say out loud (what specifically failed, what was learned, what changed), or flag [NEED: the actual story] since the prompt gives none. Should not preserve the manufactured-vulnerability template.",
+      "assertions": [
+        "Identifies the one-line broetry cadence and the 'Agree?' / 'let that sink in' engagement bait",
+        "Flags the empty aphorism rather than keeping it",
+        "Rewrites around concrete substance or flags that the real story is missing",
+        "Does not reproduce the manufactured-vulnerability template"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Run no-slop on this analytics summary line for a report: \"Variant B is the clear winner and will transform our conversion strategy — it drove a game-changing lift.\"",
+      "expected_output": "Should catch both prose slop and the marketing-channel (analytics/vanity-metric) slop: 'clear winner' with no sample size or confidence, 'transform', 'game-changing', and a 'lift' with no number, comparison, or window. Should refuse to endorse the 'winner' claim without the denominator/sample and rewrite to state the actual measured delta with its window (or flag [NEED: sample size, absolute rates, observation window]). Ties to the analytics discipline that a number without its comparison is decoration and no winner is declared on thin data.",
+      "assertions": [
+        "Flags 'clear winner' as unsupported without sample size / significance",
+        "Removes 'transform' and 'game-changing'",
+        "Requires the actual lift number with its comparison and window, or flags them as missing",
+        "Does not restate the vanity claim in fresh empty wording"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Quick check before this ships: \"We help SMBs streamline their workflows with a comprehensive, robust suite of solutions.\"",
+      "expected_output": "Should flag demographic-not-state targeting ('SMBs' says nothing about whether it's for the reader), the corporate-hedge cluster ('streamline', 'comprehensive', 'robust'), and the abstract plural 'solutions' with no mechanism. Should rewrite to a state-based audience and a concrete mechanism, or flag [NEED: what the product actually does and for whom specifically]. Applies the benefits-with-no-mechanism and persona-by-state rules.",
+      "assertions": [
+        "Rewrites 'SMBs' into an audience defined by a situation/state, or flags the need to",
+        "Removes the 'comprehensive/robust/streamline/solutions' cluster",
+        "Requires a concrete mechanism instead of the vague benefit",
+        "Does not swap in equivalent corporate abstractions"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/no-slop/references/lexical-tells.md
+++ b/skills/no-slop/references/lexical-tells.md
@@ -1,0 +1,51 @@
+# Lexical tells
+
+The word- and phrase-level catalogue for a full lexical sweep. Delete on sight unless the word is load-bearing and no plainer synonym fits. Presence of one or two is normal; clusters are the tell.
+
+## Word families (delete unless precise)
+
+| Family | Words |
+|--------|-------|
+| Empty intensifiers | truly, genuinely, incredibly, remarkably, undeniably, absolutely, really, very |
+| Frictionless | seamless, seamlessly, effortless, frictionless, streamlined, smooth |
+| Transformation | transform, revolutionize, unlock, elevate, empower, supercharge, turbocharge, level up |
+| Journey / abstraction | journey, landscape, realm, tapestry, ecosystem, space (unless literal) |
+| Abstract plurals | solutions, offerings, capabilities, experiences, insights, learnings, synergies |
+| Corporate hedges | leverage, utilize, facilitate, robust, holistic, bespoke, curated, tailored |
+| Discourse glue | moreover, furthermore, additionally, that said, it's worth noting, notably |
+| False humility | it's important to note, we'd be remiss not to mention, needless to say |
+| Vague scale | countless, myriad, a plethora of, numerous, a host of, a wide range of |
+
+## The high-frequency AI flags
+
+Heavily pattern-matched to LLM output. Use only when precisely correct and no synonym fits:
+
+**delve, navigate, foster, underscore, harness, pivotal, crucial, comprehensive, robust, seamless, tapestry, testament, realm, elevate, embark, unleash, dive in, in the realm of, when it comes to, at the end of the day, the fact of the matter is**
+
+## Filler phrases (cut whole)
+
+- "In today's fast-paced world" / "in an increasingly digital age" / "now more than ever"
+- "Whether you're a X or a Y" (the false-dichotomy opener)
+- "Look no further" / "the possibilities are endless" / "the sky's the limit"
+- "We've got you covered" / "rest assured" / "worry no more"
+- "Take your [X] to the next level" / "unlock the full potential of"
+- "In this article, we'll explore" / "without further ado" / "let's dive in"
+- "But here's the thing" / "here's the kicker" / "plot twist"
+
+## Hype adjectives with no referent
+
+game-changing, revolutionary, disruptive, cutting-edge, next-level, best-in-class, world-class, industry-leading, state-of-the-art, groundbreaking, unparalleled, unrivaled, premier, top-tier, 10x
+
+Each of these makes a superlative claim with nothing behind it. Either delete, or replace with the specific fact that earned the superlative ("the only one that reconciles POs automatically," not "industry-leading").
+
+## Punctuation and formatting tells
+
+- **Decorative em-dashes** used as a rhythm device (house style: prefer a period or colon).
+- **Bold-everything** — every other phrase bolded so nothing is emphasized.
+- **Title Case Headers For Every Line.**
+- **Rule-of-three bullet lists** where each item is a single adjective.
+- **Emoji bullets** (🚀 ✨ 💡 ✅) as structure.
+
+## Not on this list
+
+Plain, specific, checkable words are never slop, however common. "Cuts," "matches," "escalates," "6%," "last quarter," a customer name, a product noun. The catalogue targets emptiness and pattern, not vocabulary size — a short, blunt sentence made of common words is the goal, not the enemy.


### PR DESCRIPTION
## What

Adds **`no-slop`** — a dedicated anti-slop pass every prose skill can run before delivery, so nothing ships reading as AI-generated. A tell doesn't just read badly; it makes the reader discount the *claim*, so this is a quality gate, not a style nit.

Prompted by [Arcads' `marketing-os`](https://github.com/Yuzzyuk/marketing-os) (a vendor content-marketing play built by studying the top marketing-skill repos, including this one). Its `slop-patterns` module was the one genuinely good idea worth taking — rebuilt here for our architecture and made stronger.

## Why a standalone skill (not a reference file)

Skills install to separate `.agents/skills/<name>/` dirs, so a `references/` file inside `copywriting` can't be loaded by `emails` or `social` after install. The reliable reuse unit here is a **named skill** other skills invoke — same as `marketing-psychology` / `brand-voice`.

## What makes ours better than theirs

- **Severity tiers** (Fatal / Flag / Context), not a flat list — fix by priority
- **Marketing-channel-specific slop**: CTA slop, subject-line slop, hook slop, broetry/engagement-bait, persona-by-demographic, vanity-metric reporting — not just generic copy tells
- **Claims-not-slop** tie-in to `copywriting`'s supportable-claims rule: de-slopping never papers over a weak claim with a punchier empty line or an invented stat
- **Read-aloud + bar tests**, a **register exception** so a genuinely formal brand voice isn't flattened, and it honors the no-em-dash house style
- **Six evals** (hero hype, email/subject slop, the formal-register exception, LinkedIn broetry, vanity-metric analytics slop, demographic-vs-state targeting)

## Files

- `skills/no-slop/SKILL.md` (121 lines) — catalogue, severity tiers, channel slop, tests, register exception, de-slop workflow
- `skills/no-slop/references/lexical-tells.md` — exhaustive word/phrase tables
- `skills/no-slop/evals/evals.json` — six evals
- Versioning: new skill 1.0.0, repo **2.12.0** (y bump), VERSIONS.md table + changelog, both manifests, skill count 50 → 51

## Deliberately out of scope (follow-up)

Wiring `no-slop` into each prose skill's delivery step (Related Skills + an operative "run no-slop before handoff" line) is a **separate follow-up PR** — kept out to avoid colliding with #573, which is already editing `copywriting`, `ad-creative`, `analytics`, and `marketing-plan`. The skill is directly invocable now ("de-slop this," "does this read as AI").

## Merge order

Land **#573 first** (2.11.1), then this (2.12.0). If this merges first, #573 needs a trivial re-bump to 2.12.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
