### PR TITLE
feat: stage Ploy as pending Skill Partner (Website category)

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -13,6 +13,19 @@
       "logoUrl": "/logos/converly.png",
       "integration": "tools/integrations/converly.md",
       "active": true
+    },
+    {
+      "id": "ploy",
+      "name": "Ploy",
+      "url": "https://ploy.ai",
+      "category": "Website",
+      "categoryShort": "AI website & growth platform",
+      "tier": "skill-partner",
+      "tagline": "Turns your website into a growth engine",
+      "blurb": "AI marketing platform built around a Webflow-grade website builder — site optimization, SEO/AEO, visitor identification, and ad creative in one, with WebMCP to expose site actions to AI assistants.",
+      "logoUrl": "/logos/ploy.png",
+      "integration": "tools/integrations/ploy.md",
+      "active": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ploy (ploy.ai, checkout email from eliana@runploy.com) completed Skill Partner checkout on 2026-09-03 — $500/mo monthly, agreement version 2026-08 accepted at checkout. Per Corey, **Ploy's category is Website** (it's multi-category — Webflow-grade builder + SEO/AEO + visitor ID + ad creative — and a multi-category tool claims one category per tools/PARTNERS.md).

Payment has cleared but the onboarding packet (logo, blurb, docs) hasn't arrived yet, so this stages the partner without publishing anything:

- `partners.json`: adds the `ploy` entry with `category: Website`, `active: false` — sync verified README and REGISTRY are unchanged while inactive
- Draft integration guide staged locally in `.partners-pending/ploy.md` (gitignored) with TODOs to fill from the onboarding packet

## Go-live checklist (when the onboarding form lands)

- [ ] Finalize `.partners-pending/ploy.md` → `tools/integrations/ploy.md` (fill TODOs, accuracy review)
- [ ] Self-host their logo at `/logos/ploy.png` on the site
- [ ] Flip `active: true`, run `node scripts/sync-partners.mjs`
- [ ] Add ◆ ploy row to the REGISTRY Tool Index + a Website category section
- [ ] Launch announcement (tweet + LinkedIn + Swipe Files mention)

If no onboarding email shows up, follow up with eliana@runploy.com — payment is already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)