### PR TITLE
feat: publish Ploy as a live Skill Partner (Website)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The library is free and MIT-licensed. [Verified Partners](tools/REGISTRY.md#veri
 
 <!-- PARTNERS:START -->
 > ◆ **[Converly](https://converly.io?ref=marketingskills)** — *Conversion tracking / attribution.* Server-side conversion tracking that fires when someone submits a form, books a meeting, or starts a chat — passing click IDs and identifiers for Enhanced Conversions (Google) and high EMQ match rates (Meta), across 100+ tools. CLI + MCP so your agent sets it up in minutes. → [Integration guide](tools/integrations/converly.md)
+
+> ◆ **[Ploy](https://ploy.ai?ref=marketingskills)** — *AI website & growth platform.* AI marketing platform built around a Webflow-grade website builder — site optimization, SEO/AEO, visitor identification, and ad creative in one, with WebMCP to expose site actions to AI assistants. → [Integration guide](tools/integrations/ploy.md)
 <!-- PARTNERS:END -->
 
 <!-- The Partners block above is generated from partners.json — run `node scripts/sync-partners.mjs` after editing it. -->

--- a/partners.json
+++ b/partners.json
@@ -25,7 +25,7 @@
       "blurb": "AI marketing platform built around a Webflow-grade website builder — site optimization, SEO/AEO, visitor identification, and ad creative in one, with WebMCP to expose site actions to AI assistants.",
       "logoUrl": "/logos/ploy.png",
       "integration": "tools/integrations/ploy.md",
-      "active": false
+      "active": true
     }
   ]
 }

--- a/tools/REGISTRY.md
+++ b/tools/REGISTRY.md
@@ -25,6 +25,7 @@ Anyone — including tool makers and partners — may contribute content that na
 | Partner | Category | Guide |
 |---------|----------|-------|
 | ◆ Converly | Conversion tracking / attribution | [converly.md](integrations/converly.md) |
+| ◆ Ploy | AI website & growth platform | [ploy.md](integrations/ploy.md) |
 <!-- PARTNERS:END -->
 
 <!-- The table above is generated from partners.json — run `node scripts/sync-partners.mjs`. -->
@@ -36,6 +37,7 @@ Anyone — including tool makers and partners — may contribute content that na
 | Tool | Category | API | MCP | CLI | SDK | Guide |
 |------|----------|:---:|:---:|:---:|:---:|-------|
 | ◆ converly | Conversion Tracking | ✓ | ✓ | ✓ | - | [converly.md](integrations/converly.md) |
+| ◆ ploy | Website | ✓ | ✓ | ✓ | - | [ploy.md](integrations/ploy.md) |
 | ga4 | Analytics | ✓ | ✓ | [✓](clis/ga4.js) | ✓ | [ga4.md](integrations/ga4.md) |
 | mixpanel | Analytics | ✓ | - | [✓](clis/mixpanel.js) | ✓ | [mixpanel.md](integrations/mixpanel.md) |
 | amplitude | Analytics | ✓ | - | [✓](clis/amplitude.js) | ✓ | [amplitude.md](integrations/amplitude.md) |

--- a/tools/integrations/ploy.md
+++ b/tools/integrations/ploy.md
@@ -1,0 +1,49 @@
+# Ploy
+
+> **◆ Verified Partner integration.** Ploy sponsors Marketing Skills. This integration is disclosed and vetted for fit; it does **not** change what any skill recommends. It's listed here alongside the neutral options for the same job — use it when it's the right fit, not because it's a partner. See [Verified Partners](../REGISTRY.md#verified-partners).
+
+AI marketing platform built around a website builder: one system for building the site, optimizing it (SEO/AEO, CRO), identifying and engaging visitors, and generating ad creative with attribution. An in-app agent builds pages, writes copy, analyzes performance, and manages deploys through conversation.
+
+## Capabilities
+
+| Integration | Available | Notes |
+|-------------|-----------|-------|
+| API | ✓ | Workspace-scoped API tokens for CI/headless use; inbound [webhooks](https://docs.ploy.ai/webhooks) trigger Ploybooks; OpenAPI spec published at `/.well-known/api-catalog` |
+| MCP | ✓ | **WebMCP** — exposes selected website actions to compatible AI assistants while preserving the site's existing interface, permissions, and application logic |
+| CLI | ✓ | Standalone binary (macOS/Linux) — workspaces, sites, domains, publishing, PloyDB, Ploybooks, variables/secrets, Code Sync — [docs.ploy.ai/cli](https://docs.ploy.ai/cli) |
+| SDK | – | Agent-first instead: the CLI ships [agent skills + site inspection](https://docs.ploy.ai/cli/local-development) for coding agents working in a checked-out site |
+
+## What it does
+
+- **Site builder** — pages, sections, components on a design system; publish, deploy history, rollback, custom domains. Can serve alongside an existing site via [routing rules](https://docs.ploy.ai/routing-rules).
+- **Analytics & visitors** — traffic tracking, visitor identification, GA4 and Google Search Console connections.
+- **PloyDB** — structured content database; [CMS migration](https://docs.ploy.ai/database/cms-migration) imports existing CMS content and builds pages from the imported tables.
+- **Ploybooks** — scheduled/triggered marketing playbooks; fire them from external systems via webhooks.
+- **WebMCP** — expose chosen site actions (forms, booking, etc.) to AI assistants via the Model Context Protocol without rebuilding the interface.
+- **Integrations** — GitHub, Figma, Google Analytics, Search Console, Notion, Slack, HubSpot, and more.
+
+## Authentication
+
+- **Type:** sign-in via Ploy for interactive use; **workspace-scoped API token** for CI and headless environments ([docs](https://docs.ploy.ai/cli/authentication)). Store tokens in an environment variable / secret manager — never in the repo.
+
+## Setup (agent-driven via CLI)
+
+1. **Install the CLI** — macOS/Linux binary ([install docs](https://docs.ploy.ai/cli/install)).
+2. **Authenticate** — interactive sign-in, or set a workspace API token for [remote agents & CI](https://docs.ploy.ai/cli/remote-development) (non-interactive commands, explicit IDs, safe secret handling).
+3. **Select context** — workspace and site.
+4. **Build or migrate** — create pages via the agent/builder, or import existing CMS content into PloyDB and generate pages from it.
+5. **Publish** — push production, connect a custom domain, verify the deploy; roll back if needed.
+6. **Optionally enable WebMCP** — choose which site actions to expose to AI assistants.
+
+## How it fits the skills
+
+- Ploy is one way to **implement** the site itself — an alternative to the stacks in `website-build-webflow` / `website-build-framer` / `website-build-native`. The strategy layer (what pages, what copy, what structure) still comes from `site-architecture`, `copywriting`, and `cro`.
+- Its SEO/AEO surface pairs with `seo-audit` and `ai-seo`; judge its analytics, visitor-identification, and attribution output with `analytics` / `attribution` discipline.
+- WebMCP is relevant to `ai-integration` — exposing site actions to agents.
+
+## Links
+
+- Site: https://ploy.ai
+- Docs: https://docs.ploy.ai
+- CLI reference: https://docs.ploy.ai/cli/reference
+- Support: support@ploy.ai

--- a/tools/integrations/ploy.md
+++ b/tools/integrations/ploy.md
@@ -37,9 +37,8 @@ AI marketing platform built around a website builder: one system for building th
 
 ## How it fits the skills
 
-- Ploy is one way to **implement** the site itself — an alternative to the stacks in `website-build-webflow` / `website-build-framer` / `website-build-native`. The strategy layer (what pages, what copy, what structure) still comes from `site-architecture`, `copywriting`, and `cro`.
-- Its SEO/AEO surface pairs with `seo-audit` and `ai-seo`; judge its analytics, visitor-identification, and attribution output with `analytics` / `attribution` discipline.
-- WebMCP is relevant to `ai-integration` — exposing site actions to agents.
+- Ploy is one way to **implement** the site itself — an alternative to a Webflow/Framer or hand-coded stack. The strategy layer (what pages, what copy, what structure) still comes from `site-architecture`, `copywriting`, and `cro`.
+- Its SEO/AEO surface pairs with `seo-audit`, `ai-seo`, and `schema`; judge its analytics, visitor-identification, and attribution output with `analytics` / `attribution` discipline.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Flips the staged Ploy entry (#576) live now that payment has cleared.

- `partners.json`: `active: true`
- README Partners block + REGISTRY Verified Partners table regenerated via `sync-partners.mjs` (2 partners)
- REGISTRY Tool Index: ◆ ploy row — Website · API ✓ (workspace tokens, webhooks, OpenAPI catalog) · MCP ✓ (WebMCP) · CLI ✓ · SDK –
- `tools/integrations/ploy.md`: finalized ◆ disclosed guide, written from docs.ploy.ai (CLI install/auth, remote agents & CI, PloyDB, Ploybooks, WebMCP, routing rules) — no TODOs left
- Follows the Converly precedent: no partner-only By-Category section

## Site

The logo is staged at `marketingskills-website/public/logos/ploy.png` and ships from that repo; the site reads `partners.json` from raw main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)