### PR TITLE
fix: ploy category → canonical grid name

### DIFF
--- a/partners.json
+++ b/partners.json
@@ -18,7 +18,7 @@
       "id": "ploy",
       "name": "Ploy",
       "url": "https://ploy.ai",
-      "category": "Website",
+      "category": "Website & landing page builders",
       "categoryShort": "AI website & growth platform",
       "tier": "skill-partner",
       "tagline": "Turns your website into a growth engine",


### PR DESCRIPTION
One-line data fix: `category: "Website"` → `"Website & landing page builders"` so Ploy matches `CATEGORIES[].name` in the site's partner-program grid (`categoryKey: p.category` on the incoming site branch). Cards are unaffected — they render `categoryShort`. `sync-partners.mjs` confirms README/REGISTRY unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)