### PR TITLE
feat: ai-seo 2.5.0 — ChatGPT 5.6 format-volatility guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, and growth",
-    "version": "2.11.0",
+    "version": "2.11.1",
     "repository": "https://github.com/coreyhaines31/marketingskills"
   },
   "plugins": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "marketing-skills",
   "description": "Marketing skills for AI agents — conversion optimization, copywriting, SEO, paid ads, ad creative, and growth",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "author": {
     "name": "Corey Haines"
   },

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ Current versions of all skills. Agents can compare against local versions to che
 |-------|---------|--------------|
 | ab-testing | 2.0.0 | 2026-05-05 |
 | ad-creative | 2.8.2 | 2026-08-23 |
-| ai-seo | 2.4.0 | 2026-08-21 |
+| ai-seo | 2.5.0 | 2026-09-04 |
 | analytics | 2.0.1 | 2026-07-22 |
 | aso | 2.0.1 | 2026-08-19 |
 | attribution | 1.1.0 | 2026-07-23 |
@@ -56,6 +56,11 @@ Current versions of all skills. Agents can compare against local versions to che
 | video | 2.1.0 | 2026-07-14 |
 
 ## Recent Changes
+
+### 2.11.1 (2026-09-04)
+
+- **ai-seo** (2.4.0 → 2.5.0): new `references/format-volatility.md` — the citation-*format* volatility axis, companion to agent-readiness.md's citation-*source* volatility. Anchored on the **ChatGPT 5.6 format shift** (Aug 2026, Peec AI data via Tomek Rudzki and Lily Ray): fan-out queries dropped the "vs / comparison / top / best / reviews" modifiers while `site:` and "official" searches surged, and citations by page type fell −50.5% for listicles (15.77% → 7.80%) and −32.1% for comparison pages (9.08% → 6.17%) — the two formats companies scaled for GEO, demoted in one release. Covers what changes (stop justifying scaled listicle/comparison production with "wins AI citations"; owned "official" pages rising as the citable class) and what doesn't (comparisons still convert humans and still earn citations on Google AIO / Gemini / Perplexity — a per-platform format table replaces one-size-fits-all advice). Adds **LinkedIn as a citation surface** from LinkedIn's own AEO guide (via Chris Long, platform-reported: most-cited outlet for professional searches; Articles out-cite Posts ~60/40; first words of a post become the URL slug — front-load the target phrase), a **DIY ChatGPT fan-out extraction** diagnostic (DevTools → network payload → literal background queries; explicitly warned against as a mass-generation content-spam input), and a **measurement-rigor** section (AI answers are non-deterministic: 3–5 runs per query, mention *rate* with sample size, rates-over-time not run-vs-run, technical/comprehension/trust cause split; framing credited to Initial Commit's AEO audit skill, Josh Pigford). SKILL.md: Content Types section rewritten around the volatility (stale ~33%-comparison-share table retired to context), ChatGPT fan-out + extraction pointer added to the fan-out section, LinkedIn added to the Presence pillar, non-determinism rule added to DIY monitoring, new triggers ('do listicles still work for AI,' 'ChatGPT stopped citing comparison pages,' 'AI citation format shift'). New eval (id 10) covers the scaled-comparison-roadmap prompt that must get the 5.6 pushback plus the one-run-anecdote measurement correction.
+
 
 ### 2.11.0 (2026-08-23)
 

--- a/skills/ai-seo/SKILL.md
+++ b/skills/ai-seo/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ai-seo
-description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' 'optimize for Claude/Gemini,' 'llms.txt,' 'llms-full.txt,' 'OKF,' 'Open Knowledge Format,' 'knowledge bundle,' 'agent-readable site,' 'agent readiness,' 'is my site agent-ready,' or 'WebMCP.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
+description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' 'optimize for Claude/Gemini,' 'llms.txt,' 'llms-full.txt,' 'OKF,' 'Open Knowledge Format,' 'knowledge bundle,' 'agent-readable site,' 'agent readiness,' 'is my site agent-ready,' 'WebMCP,' 'do listicles still work for AI,' 'ChatGPT stopped citing comparison pages,' or 'AI citation format shift.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema."
 metadata:
-  version: 2.4.0
+  version: 2.5.0
 ---
 
 # AI SEO
@@ -104,6 +104,8 @@ Google's own example: a user asking "how to fix lawns" triggers fan-out queries 
 - A page that comprehensively answers a parent topic (with sub-questions covered) will be retrieved more often than narrow per-query pages.
 
 **Action**: when planning content, brainstorm the 5–10 related queries the AI is likely to fan out to and make sure your content (or your site as a whole) covers them.
+
+ChatGPT fans out too — and you can extract its *literal* background queries for your niche via DevTools (method in [references/format-volatility.md](references/format-volatility.md)). Post-5.6, ChatGPT's fan-outs shifted away from "best/vs/top" modifiers toward `site:` and "official" searches — use the extraction to see where your category's fan-outs stand today.
 
 ---
 
@@ -253,6 +255,7 @@ AI systems don't just cite your website — they cite where you appear.
 - Wikipedia mentions (7.8% of all ChatGPT citations)
 - Reddit discussions (volatile: ~1.8% of ChatGPT citations historically, but nearly wiped from ChatGPT by Aug 2026 retrieval changes — still retrieved elsewhere; see the volatility section in [references/agent-readiness.md](references/agent-readiness.md))
 - Industry publications and guest posts
+- LinkedIn — per LinkedIn's own AEO guide, the most-cited outlet for professional-topic searches; Articles out-cite Posts ~60/40, and a post's first words become its URL slug, so front-load the target phrase (details in [references/format-volatility.md](references/format-volatility.md))
 - Review sites (G2, Capterra, TrustRadius for B2B SaaS)
 - YouTube (frequently cited by Google AI Overviews)
 - Podcasts (episodes get transcribed, show notes published — both get crawled and cited)
@@ -366,24 +369,11 @@ For ecom and local business specifically, Google highlights:
 
 ## Content Types That Get Cited Most
 
-Not all content is equally citable. Prioritize these formats:
+Not all content is equally citable — and the format mix is **volatile**. The long-standing baseline had comparison articles (~33%) and listicles (~10%) among the top citation earners, but **ChatGPT 5.6 (Aug 2026) demoted the exploited formats: listicle citations fell −50.5% and comparison-page citations −32.1%, while `site:` and "official" retrieval surged** — a shift toward primary sources and owned pages. Format strategy is now per-platform (comparisons still work on Google AIO/Gemini/Perplexity). See [references/format-volatility.md](references/format-volatility.md) for the shift data, the per-platform format table, LinkedIn's citation numbers, and the ChatGPT fan-out extraction diagnostic.
 
-| Content Type | Citation Share | Why AI Cites It |
-|-------------|:------------:|----------------|
-| **Comparison articles** | ~33% | Structured, balanced, high-intent |
-| **Definitive guides** | ~15% | Comprehensive, authoritative |
-| **Original research/data** | ~12% | Unique, citable statistics |
-| **Best-of/listicles** | ~10% | Clear structure, entity-rich |
-| **Product pages** | ~10% | Specific details AI can extract |
-| **How-to guides** | ~8% | Step-by-step structure |
-| **Opinion/analysis** | ~10% | Expert perspective, quotable |
+**Evergreen winners across platforms:** original research and data, definitive guides, and owned "official" pages — product, docs, pricing — with extractable structure.
 
-**Underperformers for AI citation:**
-- Generic blog posts without structure
-- Thin product pages with marketing fluff
-- Gated content (AI can't access it)
-- Content without dates or author attribution
-- PDF-only content (harder for AI to parse)
+**Underperformers:** generic unstructured posts, thin or gated or PDF-only content, and anything undated without author attribution.
 
 **Citation ≠ recommendation.** Getting cited means your content was useful to consult; getting *recommended* — onto the buyer's actual shortlist — is governed by web-wide consensus (reviews, forums, analysts, press) and is largely independent of your own content. Self-promotional "best [category]" listicles can even backfire for emerging brands: in one 100-query B2B study, 69% of the AI Overview citations that self-promotional listicles earned came in answers that recommended competitors instead of the publishing brand. See [references/citations-vs-recommendations.md](references/citations-vs-recommendations.md) for the visibility ladder (retrieved → cited → mentioned → recommended), stage-dependent buyer's-guide strategy, what earns recommendations, and the attribution blind spot.
 
@@ -418,6 +408,8 @@ Monthly manual check:
 2. Run each through ChatGPT, Perplexity, and Google
 3. Record: Are you cited? Who is? What page?
 4. Log in a spreadsheet, track month-over-month
+
+AI answers are **non-deterministic** — one run is an anecdote, not a measurement. Run each query 3–5 times per platform and track the mention *rate* with its sample size ("cited 3/5, n=5"), comparing rates over time rather than single runs. Full rigor checklist in [references/format-volatility.md](references/format-volatility.md).
 
 ### Search Console expectations
 

--- a/skills/ai-seo/evals/evals.json
+++ b/skills/ai-seo/evals/evals.json
@@ -125,6 +125,11 @@
         "Does not present citation-share statistics as stable facts; recommends verifying against the user's own citation monitoring"
       ],
       "files": []
+    },
+    {
+      "id": 10,
+      "prompt": "We're a B2B SaaS planning our 2026 content roadmap. The plan is 40 comparison pages ('us vs competitor') and 20 'best tools' listicles, mainly to win ChatGPT citations. Also, how do I know if it's working — I checked ChatGPT once last week and we weren't mentioned.",
+      "expected_output": "Should load references/format-volatility.md and push back on the rationale with the ChatGPT 5.6 shift (Aug 2026, Peec AI data): listicle citations fell ~50% and comparison-page citations ~32% post-5.6, with fan-out queries dropping 'best/vs/top/comparison' modifiers in favor of site: and 'official' searches — so 'win ChatGPT citations' no longer justifies scaled comparison/listicle production. Should NOT say comparison pages are dead: they still convert humans and still earn citations on Google AI Overviews, Gemini, and Perplexity — format strategy is per-platform. Should steer investment toward owned 'official' pages (product, docs, pricing, original research), which are rising as the citable class and dominate Gemini (~60% business sites). May suggest extracting ChatGPT's real fan-out queries via the DevTools method for coverage planning (while warning against mass-generating a page per query — scaled content abuse). On measurement: one ChatGPT check is an anecdote — AI answers are non-deterministic; run each query 3–5 times per platform, track mention rate with sample size (e.g. 'cited 3/5'), and compare rates over time. Numbers should be treated as dated snapshots to verify against own monitoring."
     }
   ]
 }

--- a/skills/ai-seo/references/format-volatility.md
+++ b/skills/ai-seo/references/format-volatility.md
@@ -50,6 +50,8 @@ The interpretation (Lily Ray's, and it fits the fan-out data): these are exactly
 | Product/docs/pricing (owned, "official") | **Rising** | Strong | **Dominant** | Strong |
 | How-to / guides | Steady | Strong | OK | Strong |
 
+*(Table caveat: the demotion was measured on ChatGPT only. "OK" for Gemini/Perplexity means no demotion has been reported there — not that stability was measured. Any engine can ship its own 5.6-style shift.)*
+
 4. **Treat every number above as a dated snapshot.** Same doctrine as source volatility: these are Aug 2026 measurements of a moving system. Verify against your own citation monitoring before betting budget.
 
 ## LinkedIn as a citation surface (from LinkedIn's own AEO guide)

--- a/skills/ai-seo/references/format-volatility.md
+++ b/skills/ai-seo/references/format-volatility.md
@@ -1,0 +1,96 @@
+# Format Volatility — Which Content Formats AI Cites (and How Fast That Changes)
+
+Citation-*source* volatility (Reddit wiped overnight, Gemini favoring owned sites) is covered in [agent-readiness.md](agent-readiness.md). This reference covers the second volatility axis: citation-*format* — which page types AI engines retrieve and cite, and the August 2026 evidence that heavily-exploited formats get demoted.
+
+Read this before recommending comparison pages, listicles, or "best X" content for AI visibility. The advice changed materially with ChatGPT 5.6.
+
+## The ChatGPT 5.6 format shift (August 2026)
+
+Data from Peec AI (shared by Tomek Rudzki via Lily Ray, Aug 2026), comparing ChatGPT retrieval behavior before and after the 5.6 launch:
+
+**Fan-out queries** — the modifiers that declined most as a share of ChatGPT's background searches:
+
+- "vs"
+- "comparison"
+- "top"
+- "best"
+- "reviews"
+
+At the same time: a surge in `site:` searches and modifiers like **"official"**.
+
+**Citations by page type** — share of total ChatGPT citations:
+
+| Page type | Pre-5.6 | Post-5.6 | Change |
+|---|---:|---:|---:|
+| Listicles ("Top 10 X," "8 best Y") | 15.77% | 7.80% | **−50.5%** |
+| Comparison pages ("X vs Y," alternatives) | 9.08% | 6.17% | **−32.1%** |
+
+The interpretation (Lily Ray's, and it fits the fan-out data): these are exactly the two formats companies scaled for GEO over the prior 18 months, and ChatGPT adjusted retrieval to mitigate the spam. The `site:`/"official" surge points the same direction — **toward primary sources and owned domains, away from aggregator formats**.
+
+## What this changes (and what it doesn't)
+
+**It does NOT mean "stop making comparison pages."** Comparison and best-of content still:
+
+- Converts human buyers (its original job)
+- Gets cited by Google AI Overviews (which follow core rankings, not ChatGPT's retrieval)
+- Feeds Gemini and Perplexity, which haven't shown the same demotion
+- Answers real mid-funnel queries on your own site
+
+**It DOES mean:**
+
+1. **Stop justifying scaled listicle/comparison production with "it wins AI citations."** On ChatGPT — the largest AI answer surface — that rationale lost half its force in one release.
+2. **The "official"/primary-source shift favors your owned pages.** Product pages, docs, pricing pages, original research — the pages only you can publish — are rising as the citable class. This compounds the Gemini finding (business-owned sites ≈ 60% of citations).
+3. **Format strategy is now per-platform.** Check which engines matter for your category before choosing formats:
+
+| Format | ChatGPT (post-5.6) | Google AIO | Gemini | Perplexity |
+|---|---|---|---|---|
+| Listicles / best-of | Demoted | Rankings-dependent | OK | OK |
+| Comparison / vs pages | Demoted | Rankings-dependent | OK | OK |
+| Original research + data | Strong | Strong | Strong | Strong |
+| Product/docs/pricing (owned, "official") | **Rising** | Strong | **Dominant** | Strong |
+| How-to / guides | Steady | Strong | OK | Strong |
+
+4. **Treat every number above as a dated snapshot.** Same doctrine as source volatility: these are Aug 2026 measurements of a moving system. Verify against your own citation monitoring before betting budget.
+
+## LinkedIn as a citation surface (from LinkedIn's own AEO guide)
+
+LinkedIn quietly published its own AEO/AI-search guidance (surfaced by Chris Long, Sep 2026). The platform-reported numbers:
+
+- LinkedIn is the **most-cited outlet for professional-topic searches**
+- **~60% of LinkedIn citations come from Articles**, ~40% from Posts
+- Post URLs use the **first words of the post as the slug**
+
+**Tactics:**
+
+- For professional/B2B topics, LinkedIn Articles are a first-class Presence-pillar surface — treat long-form Articles (not just feed posts) as citable assets with the same extractable structure as blog content.
+- **Front-load the target phrase in a post's opening words** — they become the URL slug, which is retrieval surface.
+- This is platform-reported data (LinkedIn grading its own homework); weight accordingly, but the Articles > Posts split matches the general pattern that long-form structured content out-cites feed content.
+
+## DIY diagnostic: extract ChatGPT's real fan-out queries
+
+You don't need a tool to see what ChatGPT actually searches for in your niche (method circulating publicly, Aug 2026):
+
+1. Run an important query for your category in ChatGPT (with search).
+2. Open DevTools → Network tab, refresh the conversation (URL id after `/c/`).
+3. Find the conversation response payload and search it for `queries`.
+4. You'll see the literal background searches ChatGPT fanned out to.
+
+**Use it for:** building your query-test list from *real* fan-out behavior instead of guesses; checking whether your category's fan-outs still use "best/vs" modifiers or have shifted to `site:`/"official" patterns; finding sub-topics your content doesn't cover.
+
+**Do not use it for:** auto-generating and mass-publishing an article per fan-out query. That's the exact scaled-content pattern 5.6 demoted (and Google's scaled content abuse policy names). The diagnostic is for coverage planning, not content spam.
+
+## Measurement rigor: AI answers are non-deterministic
+
+A single ChatGPT answer is an anecdote, not a measurement — the same prompt returns different sources run-to-run. (The statistical-rigor framing here is popularized by Initial Commit's AEO audit skill, Josh Pigford, Aug 2026; the practice stands on its own.)
+
+When auditing or monitoring:
+
+- **Run each query 3–5 times per platform**, fresh session each time.
+- **Track mention/citation *rate*** ("cited in 3 of 5 runs"), never a yes/no from one run.
+- **Report the sample size** with every number ("40% mention rate, n=5") so future-you knows how much to trust it.
+- **Compare rates over time, not runs.** A drop from 4/5 to 3/5 is noise; a drop from 4/5 to 0/5 sustained across a month is signal.
+- Before diagnosing *why* you're not cited, split causes the way an audit should: **technical** (can't be crawled/parsed — see agent-readiness.md), **comprehension** (AI describes you inaccurately or vaguely), or **trust** (understood but not selected — see citations-vs-recommendations.md).
+
+---
+
+*Sources, all labeled and dated: Peec AI pre/post-5.6 citation data via Tomek Rudzki and Lily Ray (Aug 2026); LinkedIn's AEO guide numbers via Chris Long (Sep 2026, platform-reported); fan-out extraction method as publicly circulated (Aug 2026); measurement-rigor framing credited to Initial Commit's AEO audit skill (Josh Pigford, Aug 2026). All snapshots of a volatile system — verify against your own monitoring.*


### PR DESCRIPTION
## What

New `references/format-volatility.md` + surgical SKILL.md updates (488 lines, under cap; skill 2.4.0 → 2.5.0, repo 2.11.0 → 2.11.1).

- **ChatGPT 5.6 format shift** (Peec AI data via Lily Ray, Aug 2026): listicle citations −50.5%, comparison pages −32.1%; fan-outs dropped best/vs/top modifiers, surged site:/"official" → owned primary pages rising as the citable class. Per-platform format table replaces the stale one-size-fits-all citation-share table (~33% comparisons) which is retired into historical context.
- **LinkedIn AEO guide data** (platform-reported): most-cited outlet for professional searches, Articles > Posts 60/40, first-words-become-slug tactic. LinkedIn added to the Presence pillar.
- **DIY ChatGPT fan-out extraction** via DevTools — diagnostic for coverage planning, explicitly warned against as mass-generation input.
- **Measurement rigor**: AI answers are non-deterministic — 3–5 runs per query, mention rate with sample size, rates over time; technical/comprehension/trust cause split. Credited to Initial Commit's AEO audit skill (concepts only, nothing copied from the members-only folder).
- New eval (id 10): scaled comparison-page roadmap prompt must get the 5.6 pushback + one-run-anecdote correction.

All sources labeled and dated per house style; numbers framed as snapshots to verify against own monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkATzBmdajdqT1uU3y5v1j